### PR TITLE
Runtime config suggestion for specific game options

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,11 @@ Runtime Config Options
 Proton can be tuned at runtime to help certain games run. The Steam client sets
 some options for known games using the <tt>STEAM_COMPAT_CONFIG</tt> variable.
 You can override these options using the environment variables described below.
-The best way to set these environment overrides is by renaming
+The best way to set these environment overrides for all games is by renaming
 "user_settings.sample.py" to "user_settings.py" and modifying it appropriately.
+If you want to set a specific game to a different setting than the defaults, 
+use the `Set Launch Options` under the games `Properties`. You can launch the
+game as you would make it `YOUR_VARIABLE=1 %command%` [(source)](https://superuser.com/questions/954041/how-to-set-an-environment-variable-for-an-specific-game-on-steam-for-linux#980437).
 
 To enable an option, set the variable to a non-<tt>0</tt> value.  To disable an
 option, set the variable to <tt>0</tt>. To use Steam's default configuration, do

--- a/README.md
+++ b/README.md
@@ -172,9 +172,9 @@ some options for known games using the <tt>STEAM_COMPAT_CONFIG</tt> variable.
 You can override these options using the environment variables described below.
 The best way to set these environment overrides for all games is by renaming
 "user_settings.sample.py" to "user_settings.py" and modifying it appropriately.
-If you want to set a specific game to a different setting than the defaults, 
+If you want to set different `PROTON_` variables than the "user_settings.py" for a specific game, 
 use the `Set Launch Options` under the games `Properties`. You can launch the
-game as you would make it `YOUR_VARIABLE=1 %command%` [(source)](https://superuser.com/questions/954041/how-to-set-an-environment-variable-for-an-specific-game-on-steam-for-linux#980437).
+game as you would with `PROTON_VARIABLE=1 %command%` [(source)](https://superuser.com/questions/954041/how-to-set-an-environment-variable-for-an-specific-game-on-steam-for-linux#980437).
 
 To enable an option, set the variable to a non-<tt>0</tt> value.  To disable an
 option, set the variable to <tt>0</tt>. To use Steam's default configuration, do


### PR DESCRIPTION
Updated README to reflect specific-game environment variable modification alongside the existing global option available through `user_settings.py`.

I didn't see a contribution guideline and don't know whether you take PRs here.

I'm introducing this as a description of how users can set variables on a specific game as well as globally. The README does a good job of showing how proton can be modified for all games. 

An idea for `user_settings.py` in the future, and something I might look into:

Allow specific games to have their environment variables modified through this file. It could be done by providing the unique ID for the game as a separate nested dictionary. Just an idea :smile: 