### PR TITLE
Optimize build_proton.sh by setting jobs to available cores

### DIFF
--- a/build_proton.sh
+++ b/build_proton.sh
@@ -16,7 +16,7 @@ usage()
 
 set -e
 
-JOBS=-j$(expr `nproc 2>/dev/null||sysctl -n hw.ncpu 2>/dev/null||echo 4` + 1)
+JOBS=-j"$(( $(nproc 2>/dev/null||sysctl -n hw.ncpu 2>/dev/null||echo 4) + 1))"
 PLATFORM=$(uname)
 
 [ -z "$STEAM_RUNTIME" ] && STEAM_RUNTIME="$HOME/steam-runtime"

--- a/build_proton.sh
+++ b/build_proton.sh
@@ -16,7 +16,7 @@ usage()
 
 set -e
 
-JOBS=-j$(expr `nproc 2>/dev/null||echo 4` + 1)
+JOBS=-j$(expr `nproc 2>/dev/null||sysctl -n hw.ncpu 2>/dev/null||echo 4` + 1)
 PLATFORM=$(uname)
 
 [ -z "$STEAM_RUNTIME" ] && STEAM_RUNTIME="$HOME/steam-runtime"

--- a/build_proton.sh
+++ b/build_proton.sh
@@ -16,7 +16,7 @@ usage()
 
 set -e
 
-JOBS=-j5
+JOBS=-j$(expr `nproc 2>/dev/null||echo 4` + 1)
 PLATFORM=$(uname)
 
 [ -z "$STEAM_RUNTIME" ] && STEAM_RUNTIME="$HOME/steam-runtime"


### PR DESCRIPTION
build_proton uses available cores for job count. Defaults to 5.

This uses a combination of `nproc` (very common Linux command), and `systctl` (standard hw manager on macOS) as well a default value. 

This was tested on Ubuntu 18.04 with both `bash` and `sh`. 