### PR TITLE
Hashbang sanitizing

### DIFF
--- a/lsteamclient/gen_wrapper.py
+++ b/lsteamclient/gen_wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 #NOTE: If you make modifications here, consider whether they should
 #be duplicated in ../vrclient/gen_wrapper.py

--- a/proton
+++ b/proton
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/env python2.7
 
 #script to launch Wine with the correct environment
 

--- a/user_settings.sample.py
+++ b/user_settings.sample.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/env python2.7
 
 #to enable these settings, name this file "user_settings.py"
 

--- a/vrclient_x64/gen_wrapper.py
+++ b/vrclient_x64/gen_wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 #NOTE: If you make modifications here, consider whether they should
 #be duplicated in ../lsteamclient/gen_wrapper.py


### PR DESCRIPTION
Use /usr/bin/env in hashbangs to allow different prefixes to be used