### PR TITLE
build_proton: Fix build wine32 typo

### DIFF
--- a/build_proton.sh
+++ b/build_proton.sh
@@ -620,7 +620,7 @@ case "$BUILD_COMPONENTS" in
         build_vrclient32
         ;;
     "wine") build_wine64; build_wine32 ;;
-    "wine32") build_wine64 ;;
+    "wine32") build_wine32 ;;
     "wine64") build_wine64 ;;
     "vrclient") build_vrclient32; build_vrclient64 ;;
     "vrclient32") build_vrclient32 ;;


### PR DESCRIPTION
`./build_proton.sh --build wine32` builds wine64 instead of wine32, looks like a typo.