### PR TITLE
Create directories before copying dxvk dlls

### DIFF
--- a/proton
+++ b/proton
@@ -204,6 +204,8 @@ with prefix_lock:
     shutil.copy(basedir + "/dist/lib/wine/fakedlls/vrclient.dll", dst)
     shutil.copy(basedir + "/dist/lib64/wine/fakedlls/vrclient_x64.dll", dst)
 
+    makedirs(prefix + "drive_c/windows/syswow64/")
+    makedirs(prefix + "drive_c/windows/system32/")
     shutil.copy(basedir + "/dist/lib/wine/dxvk/openvr_api_dxvk.dll", prefix + "/drive_c/windows/syswow64/")
     shutil.copy(basedir + "/dist/lib64/wine/dxvk/openvr_api_dxvk.dll", prefix + "/drive_c/windows/system32/")
 


### PR DESCRIPTION
Avoids this error:
```Traceback (most recent call last):
  File "/spinner/levi/steamapps/common/Proton 3.7/proton", line 207, in <module>
    shutil.copy(basedir + "/dist/lib/wine/dxvk/openvr_api_dxvk.dll", prefix + "drive_c/windows/syswow64/")
  File "/usr/lib/python2.7/shutil.py", line 138, in copy
    copyfile(src, dst)
  File "/usr/lib/python2.7/shutil.py", line 97, in copyfile
    with open(dst, 'wb') as fdst:
IOError: [Errno 21] Is a directory: '/spinner/levi/steamapps/compatdata/22110/pfx/drive_c/windows/syswow64/'```