### PR TITLE
[MacOS] Add missing build dependency mingw-w64

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,10 @@ build dxvk on your local system; refer to [the dxvk README.md](https://github.co
 Building for macOS
 ---
 To build Proton for macOS, install the latest Xcode command line tools, as
-well as cmake (for openal-soft) and a recent nasm (for libjpeg-turbo), libtool, and automake. You can
+well as cmake (for openal-soft), and mingw-w64 (for dxvk) and a recent nasm (for libjpeg-turbo), libtool, and automake. You can
 use a packager like [Homebrew](https://brew.sh/) to find these packages.
 
-        brew install cmake nasm libtool automake
+        brew install cmake nasm libtool automake mingw-w64
 
 Then run:
 


### PR DESCRIPTION
mingw-w64 is needed for compiling dxvk