### PR TITLE
Minor linting fixes to build_proton.sh

### DIFF
--- a/build_proton.sh
+++ b/build_proton.sh
@@ -29,7 +29,7 @@ function build_freetype
 {
     cd "$TOP"/freetype2
 
-    if [ ! -e "$TOOLS_DIR64"/lib/libprotonfreetype.$LIB_SUFFIX ]; then
+    if [ ! -e "$TOOLS_DIR64"/lib/libprotonfreetype."$LIB_SUFFIX" ]; then
         sed -i -e 's/^LIBRARY.*/LIBRARY=libprotonfreetype/' builds/unix/unix-cc.in
 
         bash ./autogen.sh
@@ -65,7 +65,7 @@ function build_libpng
         bash ./autogen.sh
     fi
 
-    if [ ! -e "$TOOLS_DIR64"/lib/libprotonpng16.$LIB_SUFFIX ]; then
+    if [ ! -e "$TOOLS_DIR64"/lib/libprotonpng16."$LIB_SUFFIX" ]; then
         #libpng 32-bit
         mkdir -p "$TOP"/build/libpng.win32
         cd "$TOP"/build/libpng.win32
@@ -98,7 +98,7 @@ function build_libjpeg
     #if this fails with an nasm error, install a newer nasm with
     #homebrew or the like and put it into your PATH
 
-    if [ ! -e "$TOOLS_DIR64"/lib/libprotonjpeg.$LIB_SUFFIX ]; then
+    if [ ! -e "$TOOLS_DIR64"/lib/libprotonjpeg."$LIB_SUFFIX" ]; then
         #libjpeg 32-bit
         mkdir -p "$TOP"/build/libjpeg.win32
         cd "$TOP"/build/libjpeg.win32
@@ -125,12 +125,12 @@ function build_libjpeg
 
 function build_openal
 {
-    if [ ! -e "$TOOLS_DIR64"/lib/libopenal.$LIB_SUFFIX ]; then
+    if [ ! -e "$TOOLS_DIR64"/lib/libopenal."$LIB_SUFFIX" ]; then
         #openal 32-bit
         cd "$TOP"
         mkdir -p build/openal.win32
         cd build/openal.win32
-        $I386_WRAPPER $CMAKE32 "$TOP"/openal-soft -DCMAKE_C_FLAGS="-m32" -DCMAKE_INSTALL_PREFIX="$TOOLS_DIR32"
+        $I386_WRAPPER "$CMAKE32" "$TOP"/openal-soft -DCMAKE_C_FLAGS="-m32" -DCMAKE_INSTALL_PREFIX="$TOOLS_DIR32"
         $I386_WRAPPER make $JOBS VERBOSE=1
         $I386_WRAPPER make install VERBOSE=1
 
@@ -138,15 +138,15 @@ function build_openal
         cd "$TOP"
         mkdir -p build/openal.win64
         cd build/openal.win64
-        $AMD64_WRAPPER $CMAKE64 "$TOP"/openal-soft -DCMAKE_INSTALL_PREFIX="$TOOLS_DIR64"
+        $AMD64_WRAPPER "$CMAKE64" "$TOP"/openal-soft -DCMAKE_INSTALL_PREFIX="$TOOLS_DIR64"
         $AMD64_WRAPPER make $JOBS VERBOSE=1
         $AMD64_WRAPPER make install VERBOSE=1
     fi
 
     cp -L "$TOOLS_DIR32"/lib/libopenal* "$DST_DIR"/lib/
     cp -L "$TOOLS_DIR64"/lib/libopenal* "$DST_DIR"/lib64/
-    $STRIP "$DST_DIR"/lib/libopenal.$LIB_SUFFIX
-    $STRIP "$DST_DIR"/lib64/libopenal.$LIB_SUFFIX
+    $STRIP "$DST_DIR"/lib/libopenal."$LIB_SUFFIX"
+    $STRIP "$DST_DIR"/lib64/libopenal."$LIB_SUFFIX"
 }
 
 function build_libSDL
@@ -174,10 +174,10 @@ function build_libSDL
         make install-lib
     fi
 
-    cp "$TOOLS_DIR32"/lib/libSDL2.$LIB_SUFFIX "$DST_DIR"/lib
+    cp "$TOOLS_DIR32"/lib/libSDL2."$LIB_SUFFIX" "$DST_DIR"/lib
     $STRIP "$DST_DIR"/lib/libSDL2.dylib
 
-    cp "$TOOLS_DIR64"/lib/libSDL2.$LIB_SUFFIX "$DST_DIR"/lib64
+    cp "$TOOLS_DIR64"/lib/libSDL2."$LIB_SUFFIX" "$DST_DIR"/lib64
     $STRIP "$DST_DIR"/lib64/libSDL2.dylib
 }
 
@@ -283,7 +283,7 @@ function build_wine64
         JPEG_CFLAGS="$JPEG64_CFLAGS" JPEG_LIBS="$JPEG64_LIBS" ac_cv_lib_soname_jpeg="$ac_cv_lib_soname_jpeg64" \
         FREETYPE_CFLAGS="$FREETYPE64_CFLAGS" FREETYPE_LIBS="$FREETYPE64_LIBS" ac_cv_lib_soname_freetype="$ac_cv_lib_soname_freetype64" \
         $AMD64_WRAPPER "$TOP"/wine/configure \
-        --without-curses $WITHOUT_X \
+        --without-curses "$WITHOUT_X" \
         --enable-win64 --disable-tests --prefix="$DST_DIR"
     STRIP="$STRIP" $AMD64_WRAPPER make $JOBS
     INSTALL_PROGRAM_FLAGS="$INSTALL_PROGRAM_FLAGS" STRIP="$STRIP" $AMD64_WRAPPER make install-lib
@@ -300,7 +300,7 @@ function build_wine32
         JPEG_CFLAGS="$JPEG32_CFLAGS" JPEG_LIBS="$JPEG32_LIBS" ac_cv_lib_soname_jpeg="$ac_cv_lib_soname_jpeg32" \
         FREETYPE_CFLAGS="$FREETYPE32_CFLAGS" FREETYPE_LIBS="$FREETYPE32_LIBS" ac_cv_lib_soname_freetype="$ac_cv_lib_soname_freetype32" \
         $I386_WRAPPER "$TOP"/wine/configure \
-        --without-curses $WITHOUT_X \
+        --without-curses "$WITHOUT_X" \
         --disable-tests --prefix="$TOP/build/dist.win32/"
     STRIP="$STRIP" $I386_WRAPPER make $JOBS
     INSTALL_PROGRAM_FLAGS="$INSTALL_PROGRAM_FLAGS" STRIP="$STRIP" $I386_WRAPPER make install-lib
@@ -333,7 +333,7 @@ function build_lsteamclient64
         --dll .
     CXXFLAGS="-Wno-attributes -O2" CFLAGS="-O2 -g" PATH="$TOOLS_DIR64/bin:$PATH" $AMD64_WRAPPER make $JOBS
     if [ x"$STRIP" != x ]; then
-        $AMD64_WRAPPER $STRIP lsteamclient.dll.so
+        $AMD64_WRAPPER "$STRIP" lsteamclient.dll.so
     fi
     cp -a lsteamclient.dll.so "$DST_DIR"/lib64/wine/
 }
@@ -355,7 +355,7 @@ function build_lsteamclient32
         --dll .
     CXXFLAGS="-Wno-attributes -O2" CFLAGS="-O2 -g" PATH="$TOOLS_DIR32/bin:$PATH" $I386_WRAPPER make $JOBS
     if [ x"$STRIP" != x ]; then
-        $I386_WRAPPER $STRIP lsteamclient.dll.so
+        $I386_WRAPPER "$STRIP" lsteamclient.dll.so
     fi
     cp -a lsteamclient.dll.so "$DST_DIR"/lib/wine/
 }
@@ -378,7 +378,7 @@ function build_vrclient64
     CXXFLAGS="-Wno-attributes -std=c++0x -O2 -g" CFLAGS="-O2 -g" PATH="$TOOLS_DIR64/bin:$PATH" $AMD64_WRAPPER make $JOBS -C vrclient_x64
     PATH="$TOOLS_DIR64/bin:$PATH" $AMD64_WRAPPER winebuild --dll --fake-module -E vrclient_x64/vrclient_x64.spec -o vrclient_x64.dll.fake
     if [ x"$STRIP" != x ]; then
-        $AMD64_WRAPPER $STRIP vrclient_x64/vrclient_x64.dll.so
+        $AMD64_WRAPPER "$STRIP" vrclient_x64/vrclient_x64.dll.so
     fi
     cp -a vrclient_x64/vrclient_x64.dll.so "$DST_DIR"/lib64/wine/
     cp -a vrclient_x64.dll.fake "$DST_DIR"/lib64/wine/fakedlls/vrclient_x64.dll
@@ -421,7 +421,7 @@ function build_vrclient32
     CXXFLAGS="-Wno-attributes -std=c++0x -O2 -g" CFLAGS="-O2 -g" PATH="$TOOLS_DIR32/bin:$PATH" $I386_WRAPPER make $JOBS -C vrclient
     PATH="$TOOLS_DIR32/bin:$PATH" $I386_WRAPPER winebuild --dll --fake-module -E vrclient/vrclient.spec -o vrclient.dll.fake
     if [ x"$STRIP" != x ]; then
-        $I386_WRAPPER $STRIP vrclient/vrclient.dll.so
+        $I386_WRAPPER "$STRIP" vrclient/vrclient.dll.so
     fi
     cp -a vrclient/vrclient.dll.so "$DST_DIR"/lib/wine/
     cp -a vrclient.dll.fake "$DST_DIR"/lib/wine/fakedlls/vrclient.dll
@@ -492,14 +492,14 @@ for (( i=1; i <= $#; i++)); do
     elif [ "$param" == "--build" ]; then
         i=$((i+1))
         if [ "$i" -gt "$#" ]; then
-            usage `basename $0`
+            usage "$(basename "$0")"
             exit 1
         fi
         BUILD_COMPONENTS="${!i}"
     elif [ "$param" == "--with-ffmpeg" ]; then
         WITH_FFMPEG=1
     else
-        usage `basename $0`
+        usage "$(basename "$0")"
         exit 1
     fi
 done
@@ -518,7 +518,7 @@ mkdir -p "$DST_DIR"/{bin,lib,lib64}
 mkdir -p "$TOOLS_DIR64"/lib{,64}
 
 if [ x"$RELEASE_BUILD" == x ]; then
-    set +e; CCACHE=`which ccache`; set -e
+    set +e; CCACHE="$(command -v ccache)"; set -e
 fi
 
 if [ "$PLATFORM" == "Darwin" ]; then
@@ -556,9 +556,9 @@ else
     fi
 
     gcc_ver=$($AMD64_WRAPPER gcc -v 2>&1 | grep 'gcc version' | cut -d' ' -f3)
-    gcc_maj=$(echo $gcc_ver | cut -d'.' -f1)
-    gcc_min=$(echo $gcc_ver | cut -d'.' -f2)
-    if [ $gcc_maj -lt 5 -o '(' $gcc_maj -eq 5 -a $gcc_min -lt 3 ')' ]; then
+    gcc_maj=$(echo "$gcc_ver" | cut -d'.' -f1)
+    gcc_min=$(echo "$gcc_ver" | cut -d'.' -f2)
+    if [ "$gcc_maj" -lt 5 ] || { [ "$gcc_maj" -eq 5 ] && [ "$gcc_min" -lt 3 ];}; then
         echo "need gcc >= 5.3"
         exit 1
     fi


### PR DESCRIPTION
  --Added double quotes around various variables to avoid globbing and word splitting.
  --Removed use of legacy basetick and replaced with $()
  --Avoid use of -a and -o and replaced with || and && which are more preferred.

Suggestions and fixes were recommended by shellcheck.

The only error still suggested by shellcheck is:

Line 541:
    MAKE="make"
    ^-- SC2034: MAKE appears unused. Verify use (or export if used externally).
 