### PR TITLE
Add issue templates

### DIFF
--- a/ISSUE_TEMPLATE/compatibility_template.md
+++ b/ISSUE_TEMPLATE/compatibility_template.md
@@ -1,0 +1,35 @@
+# Compatibility Report
+- Name of the game with compatibility issues:
+- Steam AppID of the game: 
+
+## System Information
+- Driver-/(LLVM-)/kernel- version/GPU: <!-- e.g. Mesa 18.2/7.0.0/4.17/RX 580 -->
+- Link to full system information report as [Gist](https://gist.github.com/):
+- Proton version:
+
+## I confirm:
+- [ ] that I haven't found an existing compatibility report for this game.
+- [ ] that I have checked whether there are updates for my system available.
+
+<!-- Please add `PROTON_LOG=1 %command%` to the game's launch options and drag
+and drop the generated `$HOME/steam-$APPID.log` into this issue report -->
+
+## Symptoms <!-- What's the problem? -->
+
+
+## Reproduction
+
+
+<!--
+1. You can find the Steam AppID in the URL of the shop page of the game.
+   e.g. for `The Witcher 3: Wild Hunt` the AppID is `292030`.
+2. You can find your driver and Linux version, as well as your graphics
+   processor's name in the system information report of Steam.
+3. You can retrieve a full system information report by clicking
+   `Help` > `System Information` in the Steam client on your machine.
+4. Please copy it to your clipboard by pressing `Ctrl+A` and then `Ctrl+C`.
+   Then paste it in a [Gist](https://gist.github.com/) and post the link in
+   this issue to prevent chaos by too much info in one place.
+5. Please search for open issues and pull requests by the name of the game and
+   find out whether they are relevant and should be referenced above.
+-->

--- a/ISSUE_TEMPLATE/feature_template.md
+++ b/ISSUE_TEMPLATE/feature_template.md
@@ -1,0 +1,14 @@
+# Feature Request
+
+## I confirm:
+- [ ] that I haven't found another request for this feature.
+- [ ] that I have checked whether there are updates for my system available that
+      contain this feature already.
+
+## Description <!-- What do you want to be added? -->
+
+## Justification [optional] <!-- Why integration in Proton instead of Wine? -->
+
+## Risks [optional]
+
+## References [optional] <!-- Which issues are related? -->

--- a/ISSUE_TEMPLATE/whitelist_template.md
+++ b/ISSUE_TEMPLATE/whitelist_template.md
@@ -1,0 +1,34 @@
+# Whitelist Request
+- Name of the game to be whitelisted:
+- Steam AppID of the game: 
+
+## System Information
+- Driver-/(LLVM-)/kernel- version/GPU: <!-- e.g. Mesa 18.2/7.0.0/4.17/RX 580 -->
+- Link to full system information report as [Gist](https://gist.github.com/):
+- Proton version:
+
+## I confirm:
+- [ ] that pressing the `Play` button in the Steam client is sufficient.
+- [ ] that [runtime config options](https://github.com/ValveSoftware/Proton#runtime-config-options)
+      are necessary to run the game.
+- [ ] that no workarounds other than the mentioned ones are necessary.
+
+## Issues
+- [ ] I haven't experienced any issues.
+- [ ] There are no issues left open for this game.
+- [ ] Although I consider the gaming experience equal to Windows there are
+      remaining issues:
+
+<!--
+1. You can find the Steam AppID in the URL of the shop page of the game.
+   e.g. for `The Witcher 3: Wild Hunt` the AppID is `292030`.
+2. You can find your driver and Linux version, as well as your graphics
+   processor's name in the system information report of Steam.
+3. You can retrieve a full system information report by clicking
+   `Help` > `System Information` in the Steam client on your machine.
+4. Please copy it to your clipboard by pressing `Ctrl+A` and then `Ctrl+C`.
+   Then paste it in a [Gist](https://gist.github.com/) and post the link in
+   this issue to prevent chaos by too much info in one place.
+5. Please search for open issues and pull requests by the name of the game and
+   find out whether they are relevant and should be referenced above.
+-->


### PR DESCRIPTION
This PR adds 3 issue templates.
Originally @mtdeguzis has opened pull request #266 to add an issue template which I consider a good and important idea. However, it was preferred to add multiple templates finally.

Since this project shows a lot of activity I have the feeling that adding templates should happen in a reasonable time. For this reason I created three of them.

However, I do not recommend to merge this PR as is, because when I got it right there will only be a menu to choose the right issue template when the [Template Builder](https://help.github.com/articles/about-issue-and-pull-request-templates/) is used. This means that otherwise people would have to enter a specific URL to use a specific template.

As a result I recommend an entitled person to feed the template builder with these templates or overwrite the template files afterwards.

When you like to share ideas for improvements regarding the templates feel free to provide me feedback.