### PR TITLE
Prevent users from running build_proton.sh as root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 build/
 contrib/
+*.swp

--- a/build_proton.sh
+++ b/build_proton.sh
@@ -16,6 +16,11 @@ usage()
 
 set -e
 
+if (( EUID == 0 )); then
+    echo 'Do not run this script as root.'
+    exit 1
+fi
+
 JOBS=-j"$(( $(nproc 2>/dev/null||sysctl -n hw.ncpu 2>/dev/null||echo 4) + 1))"
 PLATFORM=$(uname)
 


### PR DESCRIPTION
Prevents users from borking their systems and wasting time wondering why schroot does not work, as per #1510 