### PR TITLE
Add support for dxvk d3d10 dlls to proton

### DIFF
--- a/build_proton.sh
+++ b/build_proton.sh
@@ -469,11 +469,17 @@ function build_dxvk
     mkdir -p "$DST_DIR"/lib64/wine/dxvk
     cp "$TOP/build/dxvk.win64/bin/dxgi.dll" "$DST_DIR"/lib64/wine/dxvk/
     cp "$TOP/build/dxvk.win64/bin/d3d11.dll" "$DST_DIR"/lib64/wine/dxvk/
+    cp "$TOP/build/dxvk.win64/bin/d3d10.dll" "$DST_DIR"/lib64/wine/dxvk/
+    cp "$TOP/build/dxvk.win64/bin/d3d10_1.dll" "$DST_DIR"/lib64/wine/dxvk/
+    cp "$TOP/build/dxvk.win64/bin/d3d10core.dll" "$DST_DIR"/lib64/wine/dxvk/
     git submodule status -- dxvk > "$DST_DIR"/lib64/wine/dxvk/version
 
     mkdir -p "$DST_DIR"/lib/wine/dxvk
     cp "$TOP/build/dxvk.win32/bin/dxgi.dll" "$DST_DIR"/lib/wine/dxvk/
     cp "$TOP/build/dxvk.win32/bin/d3d11.dll" "$DST_DIR"/lib/wine/dxvk/
+    cp "$TOP/build/dxvk.win32/bin/d3d10.dll" "$DST_DIR"/lib/wine/dxvk/
+    cp "$TOP/build/dxvk.win32/bin/d3d10_1.dll" "$DST_DIR"/lib/wine/dxvk/
+    cp "$TOP/build/dxvk.win32/bin/d3d10core.dll" "$DST_DIR"/lib/wine/dxvk/
     git submodule status -- dxvk > "$DST_DIR"/lib/wine/dxvk/version
 }
 

--- a/proton.in
+++ b/proton.in
@@ -300,9 +300,18 @@ with prefix_lock:
     def make_dxvk_links(dll_dir, link_dir):
         if os.path.lexists(link_dir + "/d3d11.dll"):
             os.remove(link_dir + "/d3d11.dll")
+        if os.path.lexists(link_dir + "/d3d10.dll"):
+            os.remove(link_dir + "/d3d10.dll")
+        if os.path.lexists(link_dir + "/d3d10_1.dll"):
+            os.remove(link_dir + "/d3d10_1.dll")
+        if os.path.lexists(link_dir + "/d3d10core.dll"):
+            os.remove(link_dir + "/d3d10core.dll")
         if os.path.lexists(link_dir + "/dxgi.dll"):
             os.remove(link_dir + "/dxgi.dll")
         os.symlink(dll_dir + "/d3d11.dll", link_dir + "/d3d11.dll")
+        os.symlink(dll_dir + "/d3d10.dll", link_dir + "/d3d10.dll")
+        os.symlink(dll_dir + "/d3d10_1.dll", link_dir + "/d3d10_1.dll")
+        os.symlink(dll_dir + "/d3d10core.dll", link_dir + "/d3d10core.dll")
         os.symlink(dll_dir + "/dxgi.dll", link_dir + "/dxgi.dll")
 
     if "wined3d11" in config_opts:
@@ -319,6 +328,9 @@ with prefix_lock:
             prefix + "drive_c/windows/syswow64")
         dlloverrides["dxgi"] = "n"
         dlloverrides["d3d11"] = "n"
+        dlloverrides["d3d10"] = "n"
+        dlloverrides["d3d10_1"] = "n"
+        dlloverrides["d3d10core"] = "n"
 
 if "nod3d11" in config_opts:
     dlloverrides["d3d11"] = ""


### PR DESCRIPTION
Note: Not tested yet as I am just about to setup the additional things needed to build a proton package.

But wanted to get input on why this hasn't been added yet? Suspecting that the d3d10 support isnt fully trusted yet or something? Please comment if I'm wasting my time testing this. @aeikum @doitsujin