### PR TITLE
Allow override of dlls with WINEDLLOVERRIDES environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,5 +194,6 @@ the Wine prefix. Removing the option will revert to the previous behavior.
 | <tt>wined3d11</tt>    | <tt>PROTON_USE_WINED3D11</tt>  | Use OpenGL-based wined3d instead of Vulkan-based DXVK for d3d11. |
 | <tt>nod3d11</tt>      | <tt>PROTON_NO_D3D11</tt>       | Disable <tt>d3d11.dll</tt>, for games which can fall back to and run better with d3d9. |
 | <tt>noesync</tt>      | <tt>PROTON_NO_ESYNC</tt>       | Do not use eventfd-based in-process synchronization primitives. |
+|                       | <tt>PROTON_WINEDLLOVERRIDES</tt> | Override which DLLs should be loaded ([see Wine User Guide](https://wiki.winehq.org/Wine_User%27s_Guide#WINEDLLOVERRIDES.3DDLL_Overrides)) |
 
 <!-- Target:  GitHub Flavor Markdown.  To test locally:  pandoc -f markdown_github -t html README.md  -->

--- a/proton.in
+++ b/proton.in
@@ -332,7 +332,10 @@ for dll in dlloverrides:
         s = s + ";" + dll + "=" + setting
     else:
         s = dll + "=" + setting
-env["WINEDLLOVERRIDES"] = s
+if len(env["WINEDLLOVERRIDES"]) > 0:
+    env["WINEDLLOVERRIDES"] = env["WINEDLLOVERRIDES"] + ';' + s
+else:
+    env["WINEDLLOVERRIDES"] = s
 
 ARCH_UNKNOWN=0
 ARCH_I386=1

--- a/proton.in
+++ b/proton.in
@@ -332,8 +332,8 @@ for dll in dlloverrides:
         s = s + ";" + dll + "=" + setting
     else:
         s = dll + "=" + setting
-if "WINEDLLOVERRIDES" in os.environ:
-    env["WINEDLLOVERRIDES"] = os.environ["WINEDLLOVERRIDES"] + ";" + s
+if "PROTON_WINEDLLOVERRIDES" in os.environ:
+    env["WINEDLLOVERRIDES"] = os.environ["PROTON_WINEDLLOVERRIDES"] + ";" + s
 else:
     env["WINEDLLOVERRIDES"] = s
 

--- a/proton.in
+++ b/proton.in
@@ -332,8 +332,8 @@ for dll in dlloverrides:
         s = s + ";" + dll + "=" + setting
     else:
         s = dll + "=" + setting
-if 'WINEDLLOVERRIDES' in os.environ:
-    env["WINEDLLOVERRIDES"] = os.environ["WINEDLLOVERRIDES"] + ';' + s
+if "WINEDLLOVERRIDES" in os.environ:
+    env["WINEDLLOVERRIDES"] = os.environ["WINEDLLOVERRIDES"] + ";" + s
 else:
     env["WINEDLLOVERRIDES"] = s
 

--- a/proton.in
+++ b/proton.in
@@ -332,8 +332,8 @@ for dll in dlloverrides:
         s = s + ";" + dll + "=" + setting
     else:
         s = dll + "=" + setting
-if len(env["WINEDLLOVERRIDES"]) > 0:
-    env["WINEDLLOVERRIDES"] = env["WINEDLLOVERRIDES"] + ';' + s
+if 'WINEDLLOVERRIDES' in os.environ:
+    env["WINEDLLOVERRIDES"] = os.environ["WINEDLLOVERRIDES"] + ';' + s
 else:
     env["WINEDLLOVERRIDES"] = s
 


### PR DESCRIPTION
Proton overrides the environment variable WINEDLLOVERRIDES entirely, this change allows to add own dll overrides.