### PR TITLE
Force wined3d if there's no Vulkan support

### DIFF
--- a/build/makefile_base.mak
+++ b/build/makefile_base.mak
@@ -272,8 +272,12 @@ $(PROTON37_TRACKED_FILES_TARGET): $(addprefix $(SRCDIR)/,proton_3.7_tracked_file
 USER_SETTINGS_PY_TARGET := $(addprefix $(DST_BASE)/,user_settings.sample.py)
 $(USER_SETTINGS_PY_TARGET): $(addprefix $(SRCDIR)/,user_settings.sample.py)
 
+VKQUERY_TARGET := $(addprefix $(DST_BASE)/,vkquery.py)
+$(VKQUERY_TARGET): $(addprefix $(SRCDIR)/,vkquery.py)
+
 DIST_COPY_TARGETS := $(TOOLMANIFEST_TARGET) $(FILELOCK_TARGET) $(PROTON_PY_TARGET) \
-                     $(PROTON37_TRACKED_FILES_TARGET) $(USER_SETTINGS_PY_TARGET)
+                     $(PROTON37_TRACKED_FILES_TARGET) $(USER_SETTINGS_PY_TARGET) \
+                     $(VKQUERY_TARGET)
 
 DIST_VERSION := $(DST_DIR)/version
 DIST_OVR32 := $(DST_DIR)/lib/wine/dxvk/openvr_api_dxvk.dll

--- a/proton
+++ b/proton
@@ -15,6 +15,7 @@ import sys
 import tarfile
 
 from filelock import FileLock
+from vkquery import is_vulkan_supported
 
 #To enable debug logging, copy "user_settings.sample.py" to "user_settings.py"
 #and edit it if needed.
@@ -263,6 +264,11 @@ if "wined3d11" in config_opts:
 
 if not check_environment("PROTON_USE_WINED3D", "wined3d"):
     check_environment("PROTON_USE_WINED3D11", "wined3d")
+
+if not 'PROTON_USE_WINED3D' in env and not is_vulkan_supported():
+    log('No Vulkan support detected, falling back to wined3d')
+    config_opts.add('wined3d')
+
 check_environment("PROTON_NO_D3D11", "nod3d11")
 check_environment("PROTON_NO_D3D10", "nod3d10")
 check_environment("PROTON_NO_ESYNC", "noesync")

--- a/proton
+++ b/proton
@@ -15,7 +15,7 @@ import sys
 import tarfile
 
 from filelock import FileLock
-from vkquery import is_vulkan_supported
+from vkquery import VkQuery
 
 #To enable debug logging, copy "user_settings.sample.py" to "user_settings.py"
 #and edit it if needed.
@@ -265,7 +265,8 @@ if "wined3d11" in config_opts:
 if not check_environment("PROTON_USE_WINED3D", "wined3d"):
     check_environment("PROTON_USE_WINED3D11", "wined3d")
 
-if not 'PROTON_USE_WINED3D' in env and not is_vulkan_supported():
+vk = VkQuery()
+if not 'PROTON_USE_WINED3D' in env and vk.lib_found() and not vk.device_available():
     log('No Vulkan support detected, falling back to wined3d')
     config_opts.add('wined3d')
 
@@ -302,6 +303,8 @@ if "SteamGameId" in env:
             lfile.write("Proton: " + f.readline().strip() + "\n")
         lfile.write("SteamGameId: " + env["SteamGameId"] + "\n")
         lfile.write("Command: " + str(sys.argv[2:]) + "\n")
+        lfile.write("Vulkan library found: " + str(vk.lib_found()) + "\n")
+        lfile.write("Vulkan hardware support: " + str(vk.device_available()) + "\n")
         lfile.write("======================\n")
         lfile.flush()
 else:

--- a/vkquery.py
+++ b/vkquery.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+# pylint: disable=wildcard-import, unused-wildcard-import, invalid-name
+
+"""Query Vulkan capabilities"""
+
+from ctypes import *
+
+VkResult = c_int32  # enum (size == 4)
+VK_SUCCESS = 0
+VK_ERROR_INITIALIZATION_FAILED = -3
+
+VkStructureType = c_int32  # enum (size == 4)
+VK_STRUCTURE_TYPE_APPLICATION_INFO = 0
+VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO = 1
+
+VkInstanceCreateFlags = c_int32  # enum (size == 4)
+
+VkInstance = c_void_p  # handle (struct ptr)
+
+
+def vk_make_version(major, minor, patch):
+    """
+    VK_MAKE_VERSION macro logic for Python
+
+    https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#fundamentals-versionnum
+    """
+    return c_uint32((major << 22) | (minor << 12) | patch)
+
+
+class VkApplicationInfo(Structure):
+
+    """Python shim for struct VkApplicationInfo
+
+    https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkApplicationInfo.html
+    """
+
+    # pylint: disable=too-few-public-methods
+
+    _fields_ = [('sType', VkStructureType),
+                ('pNext', c_void_p),
+                ('pApplicationName', c_char_p),
+                ('applicationVersion', c_uint32),
+                ('pEngineName', c_char_p),
+                ('engineVersion', c_uint32),
+                ('apiVersion', c_uint32)]
+
+    def __init__(self, name, version):
+        super().__init__()
+        self.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO
+        self.pApplicationName = name.encode()
+        self.applicationVersion = vk_make_version(*version)
+        self.apiVersion = vk_make_version(1, 0, 0)
+
+
+class VkInstanceCreateInfo(Structure):
+
+    """Python shim for struct VkInstanceCreateInfo
+
+    https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkInstanceCreateInfo.html
+    """
+
+    # pylint: disable=too-few-public-methods
+
+    _fields_ = [('sType', VkStructureType),
+                ('pNext', c_void_p),
+                ('flags', VkInstanceCreateFlags),
+                ('pApplicationInfo', POINTER(VkApplicationInfo)),
+                ('enabledLayerCount', c_uint32),
+                ('ppEnabledLayerNames', c_char_p),
+                ('enabledExtensionCount', c_uint32),
+                ('ppEnabledExtensionNames', c_char_p)]
+
+    def __init__(self, app_info):
+        super().__init__()
+        self.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO
+        self.pApplicationInfo = pointer(app_info)
+
+
+def is_vulkan_supported():
+    """
+    Returns True iff vulkan library can be loaded, initialized,
+    and reports at least one physical device available.
+    """
+    vulkan = None
+    try:
+        vulkan = CDLL('libvulkan.so.1')
+    except OSError:
+        return False
+    app_info = VkApplicationInfo('vkinfo', version=(0, 1, 0))
+    create_info = VkInstanceCreateInfo(app_info)
+    instance = VkInstance()
+    result = vulkan.vkCreateInstance(byref(create_info), 0, byref(instance))
+    if result != VK_SUCCESS:
+        return False
+    dev_count = c_uint32(0)
+    result = vulkan.vkEnumeratePhysicalDevices(instance, byref(dev_count), 0)
+    vulkan.vkDestroyInstance(instance, 0)
+    return result == VK_SUCCESS and dev_count.value > 0


### PR DESCRIPTION
*Because I got annoyed by pasting PROTON_USE_WINED3D11=1 for every game on my old Thinkpad X220...*

Implementation queries if system supports any Vulkan physical devices. If vulkan library can be loaded and there is at least one physical device available, then proceed as normal - otherwise inject PROTON_USE_WINED3D11 variable to prevent dxvk from reporting no DirectX11 support at all.

According to https://store.steampowered.com/hwsurvey?platform=linux ~13-15% of Linux Steam users still do not have hardware support for Vulkan API (Intel Sandy Bridge or older, NVIDIA GTX 5xx series or older and AMD Radeon HD 76xx or older). Those systems are quite old, but often capable of running e.g. most Unity games.

Fixes e.g. Gorogoa (557600) #1711, Tesla Effect: A Tex Murphy Adventure (261510), and probably any other Unity title using only D3D11 renderer.

In future it could be expanded to filter devices providing incomplete or broken Vulkan support (and e.g. either report warnings in log or forcing wine3d311) to mitigate issues like broken fonts in #791.