### PR TITLE
Add vagrant script for build vm.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,44 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrant file for setting up a build environment for Proton.
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "generic/debian9"
+
+  # Uncomment to increase guest resources from the default
+  #config.vm.provider "virtualbox" do |v|
+  #  v.memory = 2048
+  #  v.cpus = 4
+  #end
+
+  config.vm.synced_folder ".", "/home/vagrant/Proton", type: "rsync", rsync__exclude: [".git/", "/output/"], rsync__args: ["--verbose", "--archive", "-z", "--links", "--update"]
+
+  config.vm.provision "shell", privileged: "true", inline: <<-SHELL
+    dpkg --add-architecture i386
+    apt-get update
+    apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common
+    #add winehq repo
+    curl -fsSL https://dl.winehq.org/wine-builds/Release.key | apt-key add -
+    echo 'deb http://dl.winehq.org/wine-builds/debian stretch main' > /etc/apt/sources.list.d/winehq.list
+    #add backports
+    echo 'deb http://ftp.debian.org/debian stretch-backports main' > /etc/apt/sources.list.d/backports.list
+    #add docker repo
+    curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian stretch stable"
+    apt-get update
+	apt-get install -y gpgv2 gnupg2 g++ g++-6-multilib mingw-w64 git docker-ce winehq-devel fontforge-nox
+    apt-get remove -y winehq-devel
+    apt-get -y -t stretch-backports install meson
+    update-alternatives --set x86_64-w64-mingw32-gcc `which x86_64-w64-mingw32-gcc-posix`
+    update-alternatives --set x86_64-w64-mingw32-g++ `which x86_64-w64-mingw32-g++-posix`
+    update-alternatives --set i686-w64-mingw32-gcc `which i686-w64-mingw32-gcc-posix`
+    update-alternatives --set i686-w64-mingw32-g++ `which i686-w64-mingw32-g++-posix`
+    adduser vagrant docker
+  SHELL
+
+  config.vm.provision "shell", privileged: "true", inline: <<-SHELL
+    # unprivileged shell still runs as root for some reason
+    sudo -u vagrant /home/vagrant/Proton/vagrant-user-setup.sh
+  SHELL
+end

--- a/build/makefile_base.mak
+++ b/build/makefile_base.mak
@@ -919,7 +919,7 @@ dxvk64: $(DXVK_CONFIGURE_FILES64)
 	cp "$(DXVK_OBJ64)"/bin/d3d10.dll "$(DST_DIR)"/lib64/wine/dxvk
 	cp "$(DXVK_OBJ64)"/bin/d3d10_1.dll "$(DST_DIR)"/lib64/wine/dxvk
 	cp "$(DXVK_OBJ64)"/bin/d3d10core.dll "$(DST_DIR)"/lib64/wine/dxvk
-	( cd $(SRCDIR) && git submodule status -- dxvk ) > "$(DST_DIR)"/lib64/wine/dxvk/version
+	if test -e $(SRCDIR)/.git; then ( cd $(SRCDIR) && git submodule status -- dxvk ) > "$(DST_DIR)"/lib64/wine/dxvk/version; fi
 
 
 dxvk32: $(DXVK_CONFIGURE_FILES32)
@@ -930,7 +930,7 @@ dxvk32: $(DXVK_CONFIGURE_FILES32)
 	cp "$(DXVK_OBJ32)"/bin/d3d10.dll "$(DST_DIR)"/lib/wine/dxvk/
 	cp "$(DXVK_OBJ32)"/bin/d3d10_1.dll "$(DST_DIR)"/lib/wine/dxvk/
 	cp "$(DXVK_OBJ32)"/bin/d3d10core.dll "$(DST_DIR)"/lib/wine/dxvk/
-	( cd $(SRCDIR) && git submodule status -- dxvk ) > "$(DST_DIR)"/lib/wine/dxvk/version
+	if test -e $(SRCDIR)/.git; then ( cd $(SRCDIR) && git submodule status -- dxvk ) > "$(DST_DIR)"/lib/wine/dxvk/version; fi
 
 endif # NO_DXVK
 

--- a/vagrant-user-setup.sh
+++ b/vagrant-user-setup.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+git clone https://github.com/ValveSoftware/steam-runtime.git -b wip-docker
+./steam-runtime/setup_docker.sh --beta amd64 --extra-bootstrap=/home/vagrant/Proton/steamrt-bootstrap.sh steam-proton-dev
+./steam-runtime/setup_docker.sh --beta i386 --extra-bootstrap=/home/vagrant/Proton/steamrt-bootstrap.sh steam-proton-dev32
+mkdir build
+cd build
+../Proton/configure.sh --steam-runtime64=docker:steam-proton-dev --steam-runtime32=docker:steam-proton-dev32


### PR DESCRIPTION
I have limited time, so I wanted to at least get this sent while I have some time and now that I know the build succeeds. This adds a Vagrantfile which automates the process of making a build vm and streamlines its use. There are unfortunately some important tasks remaining that I'm not able to finish at the moment:

- I had to remove the dxvk version marker for this case because it requires .git folders which I decided not to sync into the vm. This may need more thought if it's important.
- The readme should really have documentation of how to create and use the vm.
- I should test that the build created by the vm actually works.