### PR TITLE
Add PROTON_NO_D3D10

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ the Wine prefix. Removing the option will revert to the previous behavior.
 |                       | <tt>PROTON_DUMP_DEBUG_COMMANDS</tt> | When running a game, Proton will write some useful debug scripts for that game into `$PROTON_DEBUG_DIR/proton_$USER/`. |
 |                       | <tt>PROTON_DEBUG_DIR<tt>       | Root directory for the Proton debug scripts, `/tmp` by default. |
 | <tt>wined3d</tt>      | <tt>PROTON_USE_WINED3D</tt>    | Use OpenGL-based wined3d instead of Vulkan-based DXVK for d3d11 and d3d10. This used to be called `PROTON_USE_WINED3D11`, which is now an alias for this same option. |
-| <tt>nod3d11</tt>      | <tt>PROTON_NO_D3D11</tt>       | Disable <tt>d3d11.dll</tt>, for games which can fall back to and run better with d3d9. |
+| <tt>nod3d11</tt>      | <tt>PROTON_NO_D3D11</tt>       | Disable <tt>d3d11.dll</tt>, for d3d11 games which can fall back to and run better with d3d9. |
+| <tt>nod3d10</tt>      | <tt>PROTON_NO_D3D10</tt>       | Disable <tt>d3d10.dll</tt> and <tt>dxgi.dll</tt>, for d3d10 games which can fall back to and run better with d3d9. |
 | <tt>noesync</tt>      | <tt>PROTON_NO_ESYNC</tt>       | Do not use eventfd-based in-process synchronization primitives. |
 
 <!-- Target:  GitHub Flavor Markdown.  To test locally:  pandoc -f markdown_github -t html README.md  -->

--- a/proton
+++ b/proton
@@ -404,6 +404,7 @@ if "nod3d11" in config_opts:
         del dlloverrides["dxgi"]
 
 if "nod3d10" in config_opts:
+    dlloverrides["d3d10_1"] = ""
     dlloverrides["d3d10"] = ""
     dlloverrides["dxgi"] = ""
 

--- a/proton
+++ b/proton
@@ -219,6 +219,7 @@ if "wined3d11" in config_opts:
 if not check_environment("PROTON_USE_WINED3D", "wined3d"):
     check_environment("PROTON_USE_WINED3D11", "wined3d")
 check_environment("PROTON_NO_D3D11", "nod3d11")
+check_environment("PROTON_NO_D3D10", "nod3d10")
 check_environment("PROTON_NO_ESYNC", "noesync")
 
 if not "noesync" in config_opts:
@@ -401,6 +402,10 @@ if "nod3d11" in config_opts:
     dlloverrides["d3d11"] = ""
     if "dxgi" in dlloverrides:
         del dlloverrides["dxgi"]
+
+if "nod3d10" in config_opts:
+    dlloverrides["d3d10"] = ""
+    dlloverrides["dxgi"] = ""
 
 s = ""
 for dll in dlloverrides:


### PR DESCRIPTION
This acts almost like NO_D3D11, but in this case we disable not only d3d10, but also dxgi. This allows games like #2058 to work, since disabling d3d10 alone just makes the application confused when it can load dxgi but not d3d10.