### PR TITLE
Fix stdcall parameter size computation

### DIFF
--- a/lsteamclient/gen_wrapper.py
+++ b/lsteamclient/gen_wrapper.py
@@ -10,6 +10,7 @@ import sys
 import clang.cindex
 import os
 import re
+import math
 
 sdk_versions = [
     "142",
@@ -416,7 +417,7 @@ def handle_method(cfile, classname, winclassname, cppname, method, cpp, cpp_h, e
         parambytes = 4 #_this
     for param in list(method.get_children()):
         if param.kind == clang.cindex.CursorKind.PARM_DECL:
-            parambytes += param.type.get_size()
+            parambytes += int(math.ceil(param.type.get_size()/4.0) * 4)
     cfile.write("DEFINE_THISCALL_WRAPPER(%s_%s, %s)\n" % (winclassname, used_name, parambytes))
     cpp_h.write("extern ")
     if method.result_type.spelling.startswith("ISteam"):

--- a/lsteamclient/winISteamApps.c
+++ b/lsteamclient/winISteamApps.c
@@ -132,7 +132,7 @@ bool __thiscall winISteamApps_STEAMAPPS_INTERFACE_VERSION008_GetCurrentBetaName(
     return cppISteamApps_STEAMAPPS_INTERFACE_VERSION008_GetCurrentBetaName(_this->linux_side, pchName, cchNameBufferSize);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamApps_STEAMAPPS_INTERFACE_VERSION008_MarkContentCorrupt, 5)
+DEFINE_THISCALL_WRAPPER(winISteamApps_STEAMAPPS_INTERFACE_VERSION008_MarkContentCorrupt, 8)
 bool __thiscall winISteamApps_STEAMAPPS_INTERFACE_VERSION008_MarkContentCorrupt(winISteamApps_STEAMAPPS_INTERFACE_VERSION008 *_this, bool bMissingFilesOnly)
 {
     TRACE("%p\n", _this);
@@ -374,7 +374,7 @@ bool __thiscall winISteamApps_STEAMAPPS_INTERFACE_VERSION007_GetCurrentBetaName(
     return cppISteamApps_STEAMAPPS_INTERFACE_VERSION007_GetCurrentBetaName(_this->linux_side, pchName, cchNameBufferSize);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamApps_STEAMAPPS_INTERFACE_VERSION007_MarkContentCorrupt, 5)
+DEFINE_THISCALL_WRAPPER(winISteamApps_STEAMAPPS_INTERFACE_VERSION007_MarkContentCorrupt, 8)
 bool __thiscall winISteamApps_STEAMAPPS_INTERFACE_VERSION007_MarkContentCorrupt(winISteamApps_STEAMAPPS_INTERFACE_VERSION007 *_this, bool bMissingFilesOnly)
 {
     TRACE("%p\n", _this);
@@ -597,7 +597,7 @@ bool __thiscall winISteamApps_STEAMAPPS_INTERFACE_VERSION006_GetCurrentBetaName(
     return cppISteamApps_STEAMAPPS_INTERFACE_VERSION006_GetCurrentBetaName(_this->linux_side, pchName, cchNameBufferSize);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamApps_STEAMAPPS_INTERFACE_VERSION006_MarkContentCorrupt, 5)
+DEFINE_THISCALL_WRAPPER(winISteamApps_STEAMAPPS_INTERFACE_VERSION006_MarkContentCorrupt, 8)
 bool __thiscall winISteamApps_STEAMAPPS_INTERFACE_VERSION006_MarkContentCorrupt(winISteamApps_STEAMAPPS_INTERFACE_VERSION006 *_this, bool bMissingFilesOnly)
 {
     TRACE("%p\n", _this);
@@ -804,7 +804,7 @@ bool __thiscall winISteamApps_STEAMAPPS_INTERFACE_VERSION005_GetCurrentBetaName(
     return cppISteamApps_STEAMAPPS_INTERFACE_VERSION005_GetCurrentBetaName(_this->linux_side, pchName, cchNameBufferSize);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamApps_STEAMAPPS_INTERFACE_VERSION005_MarkContentCorrupt, 5)
+DEFINE_THISCALL_WRAPPER(winISteamApps_STEAMAPPS_INTERFACE_VERSION005_MarkContentCorrupt, 8)
 bool __thiscall winISteamApps_STEAMAPPS_INTERFACE_VERSION005_MarkContentCorrupt(winISteamApps_STEAMAPPS_INTERFACE_VERSION005 *_this, bool bMissingFilesOnly)
 {
     TRACE("%p\n", _this);

--- a/lsteamclient/winISteamClient.c
+++ b/lsteamclient/winISteamClient.c
@@ -71,7 +71,7 @@ winISteamGameServer * __thiscall winISteamClient_SteamClient017_GetISteamGameSer
         cppISteamClient_SteamClient017_GetISteamGameServer(_this->linux_side, hSteamUser, hSteamPipe, pchVersion));
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamClient_SteamClient017_SetLocalIPBinding, 10)
+DEFINE_THISCALL_WRAPPER(winISteamClient_SteamClient017_SetLocalIPBinding, 12)
 void __thiscall winISteamClient_SteamClient017_SetLocalIPBinding(winISteamClient_SteamClient017 *_this, uint32 unIP, uint16 usPort)
 {
     TRACE("%p\n", _this);
@@ -417,7 +417,7 @@ winISteamGameServer * __thiscall winISteamClient_SteamClient016_GetISteamGameSer
         cppISteamClient_SteamClient016_GetISteamGameServer(_this->linux_side, hSteamUser, hSteamPipe, pchVersion));
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamClient_SteamClient016_SetLocalIPBinding, 10)
+DEFINE_THISCALL_WRAPPER(winISteamClient_SteamClient016_SetLocalIPBinding, 12)
 void __thiscall winISteamClient_SteamClient016_SetLocalIPBinding(winISteamClient_SteamClient016 *_this, uint32 unIP, uint16 usPort)
 {
     TRACE("%p\n", _this);
@@ -737,7 +737,7 @@ winISteamGameServer * __thiscall winISteamClient_SteamClient015_GetISteamGameSer
         cppISteamClient_SteamClient015_GetISteamGameServer(_this->linux_side, hSteamUser, hSteamPipe, pchVersion));
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamClient_SteamClient015_SetLocalIPBinding, 10)
+DEFINE_THISCALL_WRAPPER(winISteamClient_SteamClient015_SetLocalIPBinding, 12)
 void __thiscall winISteamClient_SteamClient015_SetLocalIPBinding(winISteamClient_SteamClient015 *_this, uint32 unIP, uint16 usPort)
 {
     TRACE("%p\n", _this);
@@ -1024,7 +1024,7 @@ winISteamGameServer * __thiscall winISteamClient_SteamClient014_GetISteamGameSer
         cppISteamClient_SteamClient014_GetISteamGameServer(_this->linux_side, hSteamUser, hSteamPipe, pchVersion));
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamClient_SteamClient014_SetLocalIPBinding, 10)
+DEFINE_THISCALL_WRAPPER(winISteamClient_SteamClient014_SetLocalIPBinding, 12)
 void __thiscall winISteamClient_SteamClient014_SetLocalIPBinding(winISteamClient_SteamClient014 *_this, uint32 unIP, uint16 usPort)
 {
     TRACE("%p\n", _this);
@@ -1302,7 +1302,7 @@ winISteamGameServer * __thiscall winISteamClient_SteamClient012_GetISteamGameSer
         cppISteamClient_SteamClient012_GetISteamGameServer(_this->linux_side, hSteamUser, hSteamPipe, pchVersion));
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamClient_SteamClient012_SetLocalIPBinding, 10)
+DEFINE_THISCALL_WRAPPER(winISteamClient_SteamClient012_SetLocalIPBinding, 12)
 void __thiscall winISteamClient_SteamClient012_SetLocalIPBinding(winISteamClient_SteamClient012 *_this, uint32 unIP, uint16 usPort)
 {
     TRACE("%p\n", _this);
@@ -1562,7 +1562,7 @@ winISteamGameServer * __thiscall winISteamClient_SteamClient011_GetISteamGameSer
         cppISteamClient_SteamClient011_GetISteamGameServer(_this->linux_side, hSteamUser, hSteamPipe, pchVersion));
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamClient_SteamClient011_SetLocalIPBinding, 10)
+DEFINE_THISCALL_WRAPPER(winISteamClient_SteamClient011_SetLocalIPBinding, 12)
 void __thiscall winISteamClient_SteamClient011_SetLocalIPBinding(winISteamClient_SteamClient011 *_this, uint32 unIP, uint16 usPort)
 {
     TRACE("%p\n", _this);
@@ -1804,7 +1804,7 @@ winISteamGameServer * __thiscall winISteamClient_SteamClient010_GetISteamGameSer
         cppISteamClient_SteamClient010_GetISteamGameServer(_this->linux_side, hSteamUser, hSteamPipe, pchVersion));
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamClient_SteamClient010_SetLocalIPBinding, 10)
+DEFINE_THISCALL_WRAPPER(winISteamClient_SteamClient010_SetLocalIPBinding, 12)
 void __thiscall winISteamClient_SteamClient010_SetLocalIPBinding(winISteamClient_SteamClient010 *_this, uint32 unIP, uint16 usPort)
 {
     TRACE("%p\n", _this);
@@ -2037,7 +2037,7 @@ winISteamGameServer * __thiscall winISteamClient_SteamClient009_GetISteamGameSer
         cppISteamClient_SteamClient009_GetISteamGameServer(_this->linux_side, hSteamUser, hSteamPipe, pchVersion));
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamClient_SteamClient009_SetLocalIPBinding, 10)
+DEFINE_THISCALL_WRAPPER(winISteamClient_SteamClient009_SetLocalIPBinding, 12)
 void __thiscall winISteamClient_SteamClient009_SetLocalIPBinding(winISteamClient_SteamClient009 *_this, uint32 unIP, uint16 usPort)
 {
     TRACE("%p\n", _this);
@@ -2253,7 +2253,7 @@ winISteamGameServer * __thiscall winISteamClient_SteamClient008_GetISteamGameSer
         cppISteamClient_SteamClient008_GetISteamGameServer(_this->linux_side, hSteamUser, hSteamPipe, pchVersion));
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamClient_SteamClient008_SetLocalIPBinding, 10)
+DEFINE_THISCALL_WRAPPER(winISteamClient_SteamClient008_SetLocalIPBinding, 12)
 void __thiscall winISteamClient_SteamClient008_SetLocalIPBinding(winISteamClient_SteamClient008 *_this, uint32 unIP, uint16 usPort)
 {
     TRACE("%p\n", _this);
@@ -2460,7 +2460,7 @@ winISteamGameServer * __thiscall winISteamClient_SteamClient007_GetISteamGameSer
         cppISteamClient_SteamClient007_GetISteamGameServer(_this->linux_side, hSteamUser, hSteamPipe, pchVersion));
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamClient_SteamClient007_SetLocalIPBinding, 10)
+DEFINE_THISCALL_WRAPPER(winISteamClient_SteamClient007_SetLocalIPBinding, 12)
 void __thiscall winISteamClient_SteamClient007_SetLocalIPBinding(winISteamClient_SteamClient007 *_this, uint32 unIP, uint16 usPort)
 {
     TRACE("%p\n", _this);

--- a/lsteamclient/winISteamController.c
+++ b/lsteamclient/winISteamController.c
@@ -155,28 +155,28 @@ void __thiscall winISteamController_SteamController006_StopAnalogActionMomentum(
     cppISteamController_SteamController006_StopAnalogActionMomentum(_this->linux_side, controllerHandle, eAction);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamController_SteamController006_TriggerHapticPulse, 18)
+DEFINE_THISCALL_WRAPPER(winISteamController_SteamController006_TriggerHapticPulse, 20)
 void __thiscall winISteamController_SteamController006_TriggerHapticPulse(winISteamController_SteamController006 *_this, ControllerHandle_t controllerHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec)
 {
     TRACE("%p\n", _this);
     cppISteamController_SteamController006_TriggerHapticPulse(_this->linux_side, controllerHandle, eTargetPad, usDurationMicroSec);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamController_SteamController006_TriggerRepeatedHapticPulse, 26)
+DEFINE_THISCALL_WRAPPER(winISteamController_SteamController006_TriggerRepeatedHapticPulse, 32)
 void __thiscall winISteamController_SteamController006_TriggerRepeatedHapticPulse(winISteamController_SteamController006 *_this, ControllerHandle_t controllerHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec, unsigned short usOffMicroSec, unsigned short unRepeat, unsigned int nFlags)
 {
     TRACE("%p\n", _this);
     cppISteamController_SteamController006_TriggerRepeatedHapticPulse(_this->linux_side, controllerHandle, eTargetPad, usDurationMicroSec, usOffMicroSec, unRepeat, nFlags);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamController_SteamController006_TriggerVibration, 16)
+DEFINE_THISCALL_WRAPPER(winISteamController_SteamController006_TriggerVibration, 20)
 void __thiscall winISteamController_SteamController006_TriggerVibration(winISteamController_SteamController006 *_this, ControllerHandle_t controllerHandle, unsigned short usLeftSpeed, unsigned short usRightSpeed)
 {
     TRACE("%p\n", _this);
     cppISteamController_SteamController006_TriggerVibration(_this->linux_side, controllerHandle, usLeftSpeed, usRightSpeed);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamController_SteamController006_SetLEDColor, 19)
+DEFINE_THISCALL_WRAPPER(winISteamController_SteamController006_SetLEDColor, 28)
 void __thiscall winISteamController_SteamController006_SetLEDColor(winISteamController_SteamController006 *_this, ControllerHandle_t controllerHandle, uint8 nColorR, uint8 nColorG, uint8 nColorB, unsigned int nFlags)
 {
     TRACE("%p\n", _this);
@@ -408,28 +408,28 @@ void __thiscall winISteamController_SteamController005_StopAnalogActionMomentum(
     cppISteamController_SteamController005_StopAnalogActionMomentum(_this->linux_side, controllerHandle, eAction);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamController_SteamController005_TriggerHapticPulse, 18)
+DEFINE_THISCALL_WRAPPER(winISteamController_SteamController005_TriggerHapticPulse, 20)
 void __thiscall winISteamController_SteamController005_TriggerHapticPulse(winISteamController_SteamController005 *_this, ControllerHandle_t controllerHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec)
 {
     TRACE("%p\n", _this);
     cppISteamController_SteamController005_TriggerHapticPulse(_this->linux_side, controllerHandle, eTargetPad, usDurationMicroSec);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamController_SteamController005_TriggerRepeatedHapticPulse, 26)
+DEFINE_THISCALL_WRAPPER(winISteamController_SteamController005_TriggerRepeatedHapticPulse, 32)
 void __thiscall winISteamController_SteamController005_TriggerRepeatedHapticPulse(winISteamController_SteamController005 *_this, ControllerHandle_t controllerHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec, unsigned short usOffMicroSec, unsigned short unRepeat, unsigned int nFlags)
 {
     TRACE("%p\n", _this);
     cppISteamController_SteamController005_TriggerRepeatedHapticPulse(_this->linux_side, controllerHandle, eTargetPad, usDurationMicroSec, usOffMicroSec, unRepeat, nFlags);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamController_SteamController005_TriggerVibration, 16)
+DEFINE_THISCALL_WRAPPER(winISteamController_SteamController005_TriggerVibration, 20)
 void __thiscall winISteamController_SteamController005_TriggerVibration(winISteamController_SteamController005 *_this, ControllerHandle_t controllerHandle, unsigned short usLeftSpeed, unsigned short usRightSpeed)
 {
     TRACE("%p\n", _this);
     cppISteamController_SteamController005_TriggerVibration(_this->linux_side, controllerHandle, usLeftSpeed, usRightSpeed);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamController_SteamController005_SetLEDColor, 19)
+DEFINE_THISCALL_WRAPPER(winISteamController_SteamController005_SetLEDColor, 28)
 void __thiscall winISteamController_SteamController005_SetLEDColor(winISteamController_SteamController005 *_this, ControllerHandle_t controllerHandle, uint8 nColorR, uint8 nColorG, uint8 nColorB, unsigned int nFlags)
 {
     TRACE("%p\n", _this);
@@ -649,14 +649,14 @@ void __thiscall winISteamController_SteamController004_StopAnalogActionMomentum(
     cppISteamController_SteamController004_StopAnalogActionMomentum(_this->linux_side, controllerHandle, eAction);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamController_SteamController004_TriggerHapticPulse, 18)
+DEFINE_THISCALL_WRAPPER(winISteamController_SteamController004_TriggerHapticPulse, 20)
 void __thiscall winISteamController_SteamController004_TriggerHapticPulse(winISteamController_SteamController004 *_this, ControllerHandle_t controllerHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec)
 {
     TRACE("%p\n", _this);
     cppISteamController_SteamController004_TriggerHapticPulse(_this->linux_side, controllerHandle, eTargetPad, usDurationMicroSec);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamController_SteamController004_TriggerRepeatedHapticPulse, 26)
+DEFINE_THISCALL_WRAPPER(winISteamController_SteamController004_TriggerRepeatedHapticPulse, 32)
 void __thiscall winISteamController_SteamController004_TriggerRepeatedHapticPulse(winISteamController_SteamController004 *_this, ControllerHandle_t controllerHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec, unsigned short usOffMicroSec, unsigned short unRepeat, unsigned int nFlags)
 {
     TRACE("%p\n", _this);
@@ -855,14 +855,14 @@ void __thiscall winISteamController_SteamController003_StopAnalogActionMomentum(
     cppISteamController_SteamController003_StopAnalogActionMomentum(_this->linux_side, controllerHandle, eAction);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamController_SteamController003_TriggerHapticPulse, 18)
+DEFINE_THISCALL_WRAPPER(winISteamController_SteamController003_TriggerHapticPulse, 20)
 void __thiscall winISteamController_SteamController003_TriggerHapticPulse(winISteamController_SteamController003 *_this, ControllerHandle_t controllerHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec)
 {
     TRACE("%p\n", _this);
     cppISteamController_SteamController003_TriggerHapticPulse(_this->linux_side, controllerHandle, eTargetPad, usDurationMicroSec);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamController_SteamController003_TriggerRepeatedHapticPulse, 26)
+DEFINE_THISCALL_WRAPPER(winISteamController_SteamController003_TriggerRepeatedHapticPulse, 32)
 void __thiscall winISteamController_SteamController003_TriggerRepeatedHapticPulse(winISteamController_SteamController003 *_this, ControllerHandle_t controllerHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec, unsigned short usOffMicroSec, unsigned short unRepeat, unsigned int nFlags)
 {
     TRACE("%p\n", _this);
@@ -943,7 +943,7 @@ bool __thiscall winISteamController_STEAMCONTROLLER_INTERFACE_VERSION_GetControl
     return cppISteamController_STEAMCONTROLLER_INTERFACE_VERSION_GetControllerState(_this->linux_side, unControllerIndex, pState);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamController_STEAMCONTROLLER_INTERFACE_VERSION_TriggerHapticPulse, 14)
+DEFINE_THISCALL_WRAPPER(winISteamController_STEAMCONTROLLER_INTERFACE_VERSION_TriggerHapticPulse, 16)
 void __thiscall winISteamController_STEAMCONTROLLER_INTERFACE_VERSION_TriggerHapticPulse(winISteamController_STEAMCONTROLLER_INTERFACE_VERSION *_this, uint32 unControllerIndex, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec)
 {
     TRACE("%p\n", _this);

--- a/lsteamclient/winISteamFriends.c
+++ b/lsteamclient/winISteamFriends.c
@@ -119,21 +119,21 @@ FriendsGroupID_t __thiscall winISteamFriends_SteamFriends015_GetFriendsGroupIDBy
     return cppISteamFriends_SteamFriends015_GetFriendsGroupIDByIndex(_this->linux_side, iFG);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends015_GetFriendsGroupName, 6)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends015_GetFriendsGroupName, 8)
 const char * __thiscall winISteamFriends_SteamFriends015_GetFriendsGroupName(winISteamFriends_SteamFriends015 *_this, FriendsGroupID_t friendsGroupID)
 {
     TRACE("%p\n", _this);
     return cppISteamFriends_SteamFriends015_GetFriendsGroupName(_this->linux_side, friendsGroupID);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends015_GetFriendsGroupMembersCount, 6)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends015_GetFriendsGroupMembersCount, 8)
 int __thiscall winISteamFriends_SteamFriends015_GetFriendsGroupMembersCount(winISteamFriends_SteamFriends015 *_this, FriendsGroupID_t friendsGroupID)
 {
     TRACE("%p\n", _this);
     return cppISteamFriends_SteamFriends015_GetFriendsGroupMembersCount(_this->linux_side, friendsGroupID);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends015_GetFriendsGroupMembersList, 14)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends015_GetFriendsGroupMembersList, 16)
 void __thiscall winISteamFriends_SteamFriends015_GetFriendsGroupMembersList(winISteamFriends_SteamFriends015 *_this, FriendsGroupID_t friendsGroupID, CSteamID * pOutSteamIDMembers, int nMembersCount)
 {
     TRACE("%p\n", _this);
@@ -212,7 +212,7 @@ bool __thiscall winISteamFriends_SteamFriends015_IsUserInSource(winISteamFriends
     return cppISteamFriends_SteamFriends015_IsUserInSource(_this->linux_side, steamIDUser, steamIDSource);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends015_SetInGameVoiceSpeaking, 13)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends015_SetInGameVoiceSpeaking, 16)
 void __thiscall winISteamFriends_SteamFriends015_SetInGameVoiceSpeaking(winISteamFriends_SteamFriends015 *_this, CSteamID steamIDUser, bool bSpeaking)
 {
     TRACE("%p\n", _this);
@@ -282,7 +282,7 @@ int __thiscall winISteamFriends_SteamFriends015_GetLargeFriendAvatar(winISteamFr
     return cppISteamFriends_SteamFriends015_GetLargeFriendAvatar(_this->linux_side, steamIDFriend);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends015_RequestUserInformation, 13)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends015_RequestUserInformation, 16)
 bool __thiscall winISteamFriends_SteamFriends015_RequestUserInformation(winISteamFriends_SteamFriends015 *_this, CSteamID steamIDUser, bool bRequireNameOnly)
 {
     TRACE("%p\n", _this);
@@ -475,7 +475,7 @@ bool __thiscall winISteamFriends_SteamFriends015_CloseClanChatWindowInSteam(winI
     return cppISteamFriends_SteamFriends015_CloseClanChatWindowInSteam(_this->linux_side, steamIDClanChat);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends015_SetListenForFriendsMessages, 5)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends015_SetListenForFriendsMessages, 8)
 bool __thiscall winISteamFriends_SteamFriends015_SetListenForFriendsMessages(winISteamFriends_SteamFriends015 *_this, bool bInterceptEnabled)
 {
     TRACE("%p\n", _this);
@@ -780,7 +780,7 @@ bool __thiscall winISteamFriends_SteamFriends014_IsUserInSource(winISteamFriends
     return cppISteamFriends_SteamFriends014_IsUserInSource(_this->linux_side, steamIDUser, steamIDSource);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends014_SetInGameVoiceSpeaking, 13)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends014_SetInGameVoiceSpeaking, 16)
 void __thiscall winISteamFriends_SteamFriends014_SetInGameVoiceSpeaking(winISteamFriends_SteamFriends014 *_this, CSteamID steamIDUser, bool bSpeaking)
 {
     TRACE("%p\n", _this);
@@ -850,7 +850,7 @@ int __thiscall winISteamFriends_SteamFriends014_GetLargeFriendAvatar(winISteamFr
     return cppISteamFriends_SteamFriends014_GetLargeFriendAvatar(_this->linux_side, steamIDFriend);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends014_RequestUserInformation, 13)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends014_RequestUserInformation, 16)
 bool __thiscall winISteamFriends_SteamFriends014_RequestUserInformation(winISteamFriends_SteamFriends014 *_this, CSteamID steamIDUser, bool bRequireNameOnly)
 {
     TRACE("%p\n", _this);
@@ -1043,7 +1043,7 @@ bool __thiscall winISteamFriends_SteamFriends014_CloseClanChatWindowInSteam(winI
     return cppISteamFriends_SteamFriends014_CloseClanChatWindowInSteam(_this->linux_side, steamIDClanChat);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends014_SetListenForFriendsMessages, 5)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends014_SetListenForFriendsMessages, 8)
 bool __thiscall winISteamFriends_SteamFriends014_SetListenForFriendsMessages(winISteamFriends_SteamFriends014 *_this, bool bInterceptEnabled)
 {
     TRACE("%p\n", _this);
@@ -1319,7 +1319,7 @@ bool __thiscall winISteamFriends_SteamFriends013_IsUserInSource(winISteamFriends
     return cppISteamFriends_SteamFriends013_IsUserInSource(_this->linux_side, steamIDUser, steamIDSource);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends013_SetInGameVoiceSpeaking, 13)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends013_SetInGameVoiceSpeaking, 16)
 void __thiscall winISteamFriends_SteamFriends013_SetInGameVoiceSpeaking(winISteamFriends_SteamFriends013 *_this, CSteamID steamIDUser, bool bSpeaking)
 {
     TRACE("%p\n", _this);
@@ -1389,7 +1389,7 @@ int __thiscall winISteamFriends_SteamFriends013_GetLargeFriendAvatar(winISteamFr
     return cppISteamFriends_SteamFriends013_GetLargeFriendAvatar(_this->linux_side, steamIDFriend);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends013_RequestUserInformation, 13)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends013_RequestUserInformation, 16)
 bool __thiscall winISteamFriends_SteamFriends013_RequestUserInformation(winISteamFriends_SteamFriends013 *_this, CSteamID steamIDUser, bool bRequireNameOnly)
 {
     TRACE("%p\n", _this);
@@ -1582,7 +1582,7 @@ bool __thiscall winISteamFriends_SteamFriends013_CloseClanChatWindowInSteam(winI
     return cppISteamFriends_SteamFriends013_CloseClanChatWindowInSteam(_this->linux_side, steamIDClanChat);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends013_SetListenForFriendsMessages, 5)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends013_SetListenForFriendsMessages, 8)
 bool __thiscall winISteamFriends_SteamFriends013_SetListenForFriendsMessages(winISteamFriends_SteamFriends013 *_this, bool bInterceptEnabled)
 {
     TRACE("%p\n", _this);
@@ -1857,7 +1857,7 @@ bool __thiscall winISteamFriends_SteamFriends011_IsUserInSource(winISteamFriends
     return cppISteamFriends_SteamFriends011_IsUserInSource(_this->linux_side, steamIDUser, steamIDSource);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends011_SetInGameVoiceSpeaking, 13)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends011_SetInGameVoiceSpeaking, 16)
 void __thiscall winISteamFriends_SteamFriends011_SetInGameVoiceSpeaking(winISteamFriends_SteamFriends011 *_this, CSteamID steamIDUser, bool bSpeaking)
 {
     TRACE("%p\n", _this);
@@ -1927,7 +1927,7 @@ int __thiscall winISteamFriends_SteamFriends011_GetLargeFriendAvatar(winISteamFr
     return cppISteamFriends_SteamFriends011_GetLargeFriendAvatar(_this->linux_side, steamIDFriend);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends011_RequestUserInformation, 13)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends011_RequestUserInformation, 16)
 bool __thiscall winISteamFriends_SteamFriends011_RequestUserInformation(winISteamFriends_SteamFriends011 *_this, CSteamID steamIDUser, bool bRequireNameOnly)
 {
     TRACE("%p\n", _this);
@@ -2120,7 +2120,7 @@ bool __thiscall winISteamFriends_SteamFriends011_CloseClanChatWindowInSteam(winI
     return cppISteamFriends_SteamFriends011_CloseClanChatWindowInSteam(_this->linux_side, steamIDClanChat);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends011_SetListenForFriendsMessages, 5)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends011_SetListenForFriendsMessages, 8)
 bool __thiscall winISteamFriends_SteamFriends011_SetListenForFriendsMessages(winISteamFriends_SteamFriends011 *_this, bool bInterceptEnabled)
 {
     TRACE("%p\n", _this);
@@ -2381,7 +2381,7 @@ bool __thiscall winISteamFriends_SteamFriends009_IsUserInSource(winISteamFriends
     return cppISteamFriends_SteamFriends009_IsUserInSource(_this->linux_side, steamIDUser, steamIDSource);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends009_SetInGameVoiceSpeaking, 13)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends009_SetInGameVoiceSpeaking, 16)
 void __thiscall winISteamFriends_SteamFriends009_SetInGameVoiceSpeaking(winISteamFriends_SteamFriends009 *_this, CSteamID steamIDUser, bool bSpeaking)
 {
     TRACE("%p\n", _this);
@@ -2451,7 +2451,7 @@ int __thiscall winISteamFriends_SteamFriends009_GetLargeFriendAvatar(winISteamFr
     return cppISteamFriends_SteamFriends009_GetLargeFriendAvatar(_this->linux_side, steamIDFriend);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends009_RequestUserInformation, 13)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends009_RequestUserInformation, 16)
 bool __thiscall winISteamFriends_SteamFriends009_RequestUserInformation(winISteamFriends_SteamFriends009 *_this, CSteamID steamIDUser, bool bRequireNameOnly)
 {
     TRACE("%p\n", _this);
@@ -2766,7 +2766,7 @@ bool __thiscall winISteamFriends_SteamFriends008_IsUserInSource(winISteamFriends
     return cppISteamFriends_SteamFriends008_IsUserInSource(_this->linux_side, steamIDUser, steamIDSource);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends008_SetInGameVoiceSpeaking, 13)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends008_SetInGameVoiceSpeaking, 16)
 void __thiscall winISteamFriends_SteamFriends008_SetInGameVoiceSpeaking(winISteamFriends_SteamFriends008 *_this, CSteamID steamIDUser, bool bSpeaking)
 {
     TRACE("%p\n", _this);
@@ -2836,7 +2836,7 @@ int __thiscall winISteamFriends_SteamFriends008_GetLargeFriendAvatar(winISteamFr
     return cppISteamFriends_SteamFriends008_GetLargeFriendAvatar(_this->linux_side, steamIDFriend);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends008_RequestUserInformation, 13)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends008_RequestUserInformation, 16)
 bool __thiscall winISteamFriends_SteamFriends008_RequestUserInformation(winISteamFriends_SteamFriends008 *_this, CSteamID steamIDUser, bool bRequireNameOnly)
 {
     TRACE("%p\n", _this);
@@ -3070,7 +3070,7 @@ bool __thiscall winISteamFriends_SteamFriends007_IsUserInSource(winISteamFriends
     return cppISteamFriends_SteamFriends007_IsUserInSource(_this->linux_side, steamIDUser, steamIDSource);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends007_SetInGameVoiceSpeaking, 13)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends007_SetInGameVoiceSpeaking, 16)
 void __thiscall winISteamFriends_SteamFriends007_SetInGameVoiceSpeaking(winISteamFriends_SteamFriends007 *_this, CSteamID steamIDUser, bool bSpeaking)
 {
     TRACE("%p\n", _this);
@@ -3331,7 +3331,7 @@ bool __thiscall winISteamFriends_SteamFriends006_IsUserInSource(winISteamFriends
     return cppISteamFriends_SteamFriends006_IsUserInSource(_this->linux_side, steamIDUser, steamIDSource);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends006_SetInGameVoiceSpeaking, 13)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends006_SetInGameVoiceSpeaking, 16)
 void __thiscall winISteamFriends_SteamFriends006_SetInGameVoiceSpeaking(winISteamFriends_SteamFriends006 *_this, CSteamID steamIDUser, bool bSpeaking)
 {
     TRACE("%p\n", _this);
@@ -3562,7 +3562,7 @@ bool __thiscall winISteamFriends_SteamFriends005_IsUserInSource(winISteamFriends
     return cppISteamFriends_SteamFriends005_IsUserInSource(_this->linux_side, steamIDUser, steamIDSource);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends005_SetInGameVoiceSpeaking, 13)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends005_SetInGameVoiceSpeaking, 16)
 void __thiscall winISteamFriends_SteamFriends005_SetInGameVoiceSpeaking(winISteamFriends_SteamFriends005 *_this, CSteamID steamIDUser, bool bSpeaking)
 {
     TRACE("%p\n", _this);
@@ -3784,7 +3784,7 @@ bool __thiscall winISteamFriends_SteamFriends004_IsUserInSource(winISteamFriends
     return cppISteamFriends_SteamFriends004_IsUserInSource(_this->linux_side, steamIDUser, steamIDSource);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends004_SetInGameVoiceSpeaking, 13)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends004_SetInGameVoiceSpeaking, 16)
 void __thiscall winISteamFriends_SteamFriends004_SetInGameVoiceSpeaking(winISteamFriends_SteamFriends004 *_this, CSteamID steamIDUser, bool bSpeaking)
 {
     TRACE("%p\n", _this);
@@ -3974,7 +3974,7 @@ bool __thiscall winISteamFriends_SteamFriends003_IsUserInSource(winISteamFriends
     return cppISteamFriends_SteamFriends003_IsUserInSource(_this->linux_side, steamIDUser, steamIDSource);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends003_SetInGameVoiceSpeaking, 13)
+DEFINE_THISCALL_WRAPPER(winISteamFriends_SteamFriends003_SetInGameVoiceSpeaking, 16)
 void __thiscall winISteamFriends_SteamFriends003_SetInGameVoiceSpeaking(winISteamFriends_SteamFriends003 *_this, CSteamID steamIDUser, bool bSpeaking)
 {
     TRACE("%p\n", _this);

--- a/lsteamclient/winISteamGameServer.c
+++ b/lsteamclient/winISteamGameServer.c
@@ -20,7 +20,7 @@ typedef struct __winISteamGameServer_SteamGameServer012 {
     void *linux_side;
 } winISteamGameServer_SteamGameServer012;
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer012_InitGameServer, 24)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer012_InitGameServer, 28)
 bool __thiscall winISteamGameServer_SteamGameServer012_InitGameServer(winISteamGameServer_SteamGameServer012 *_this, uint32 unIP, uint16 usGamePort, uint16 usQueryPort, uint32 unFlags, AppId_t nGameAppId, const char * pchVersionString)
 {
     TRACE("%p\n", _this);
@@ -48,7 +48,7 @@ void __thiscall winISteamGameServer_SteamGameServer012_SetModDir(winISteamGameSe
     cppISteamGameServer_SteamGameServer012_SetModDir(_this->linux_side, pszModDir);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer012_SetDedicatedServer, 5)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer012_SetDedicatedServer, 8)
 void __thiscall winISteamGameServer_SteamGameServer012_SetDedicatedServer(winISteamGameServer_SteamGameServer012 *_this, bool bDedicated)
 {
     TRACE("%p\n", _this);
@@ -133,14 +133,14 @@ void __thiscall winISteamGameServer_SteamGameServer012_SetMapName(winISteamGameS
     cppISteamGameServer_SteamGameServer012_SetMapName(_this->linux_side, pszMapName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer012_SetPasswordProtected, 5)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer012_SetPasswordProtected, 8)
 void __thiscall winISteamGameServer_SteamGameServer012_SetPasswordProtected(winISteamGameServer_SteamGameServer012 *_this, bool bPasswordProtected)
 {
     TRACE("%p\n", _this);
     cppISteamGameServer_SteamGameServer012_SetPasswordProtected(_this->linux_side, bPasswordProtected);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer012_SetSpectatorPort, 6)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer012_SetSpectatorPort, 8)
 void __thiscall winISteamGameServer_SteamGameServer012_SetSpectatorPort(winISteamGameServer_SteamGameServer012 *_this, uint16 unSpectatorPort)
 {
     TRACE("%p\n", _this);
@@ -281,7 +281,7 @@ uint32 __thiscall winISteamGameServer_SteamGameServer012_GetPublicIP(winISteamGa
     return cppISteamGameServer_SteamGameServer012_GetPublicIP(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer012_HandleIncomingPacket, 18)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer012_HandleIncomingPacket, 20)
 bool __thiscall winISteamGameServer_SteamGameServer012_HandleIncomingPacket(winISteamGameServer_SteamGameServer012 *_this, const void * pData, int cbData, uint32 srcIP, uint16 srcPort)
 {
     TRACE("%p\n", _this);
@@ -295,7 +295,7 @@ int __thiscall winISteamGameServer_SteamGameServer012_GetNextOutgoingPacket(winI
     return cppISteamGameServer_SteamGameServer012_GetNextOutgoingPacket(_this->linux_side, pOut, cbMaxOut, pNetAdr, pPort);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer012_EnableHeartbeats, 5)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer012_EnableHeartbeats, 8)
 void __thiscall winISteamGameServer_SteamGameServer012_EnableHeartbeats(winISteamGameServer_SteamGameServer012 *_this, bool bActive)
 {
     TRACE("%p\n", _this);
@@ -401,7 +401,7 @@ typedef struct __winISteamGameServer_SteamGameServer011 {
     void *linux_side;
 } winISteamGameServer_SteamGameServer011;
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer011_InitGameServer, 24)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer011_InitGameServer, 28)
 bool __thiscall winISteamGameServer_SteamGameServer011_InitGameServer(winISteamGameServer_SteamGameServer011 *_this, uint32 unIP, uint16 usGamePort, uint16 usQueryPort, uint32 unFlags, AppId_t nGameAppId, const char * pchVersionString)
 {
     TRACE("%p\n", _this);
@@ -429,7 +429,7 @@ void __thiscall winISteamGameServer_SteamGameServer011_SetModDir(winISteamGameSe
     cppISteamGameServer_SteamGameServer011_SetModDir(_this->linux_side, pszModDir);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer011_SetDedicatedServer, 5)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer011_SetDedicatedServer, 8)
 void __thiscall winISteamGameServer_SteamGameServer011_SetDedicatedServer(winISteamGameServer_SteamGameServer011 *_this, bool bDedicated)
 {
     TRACE("%p\n", _this);
@@ -514,14 +514,14 @@ void __thiscall winISteamGameServer_SteamGameServer011_SetMapName(winISteamGameS
     cppISteamGameServer_SteamGameServer011_SetMapName(_this->linux_side, pszMapName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer011_SetPasswordProtected, 5)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer011_SetPasswordProtected, 8)
 void __thiscall winISteamGameServer_SteamGameServer011_SetPasswordProtected(winISteamGameServer_SteamGameServer011 *_this, bool bPasswordProtected)
 {
     TRACE("%p\n", _this);
     cppISteamGameServer_SteamGameServer011_SetPasswordProtected(_this->linux_side, bPasswordProtected);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer011_SetSpectatorPort, 6)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer011_SetSpectatorPort, 8)
 void __thiscall winISteamGameServer_SteamGameServer011_SetSpectatorPort(winISteamGameServer_SteamGameServer011 *_this, uint16 unSpectatorPort)
 {
     TRACE("%p\n", _this);
@@ -662,7 +662,7 @@ uint32 __thiscall winISteamGameServer_SteamGameServer011_GetPublicIP(winISteamGa
     return cppISteamGameServer_SteamGameServer011_GetPublicIP(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer011_HandleIncomingPacket, 18)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer011_HandleIncomingPacket, 20)
 bool __thiscall winISteamGameServer_SteamGameServer011_HandleIncomingPacket(winISteamGameServer_SteamGameServer011 *_this, const void * pData, int cbData, uint32 srcIP, uint16 srcPort)
 {
     TRACE("%p\n", _this);
@@ -676,7 +676,7 @@ int __thiscall winISteamGameServer_SteamGameServer011_GetNextOutgoingPacket(winI
     return cppISteamGameServer_SteamGameServer011_GetNextOutgoingPacket(_this->linux_side, pOut, cbMaxOut, pNetAdr, pPort);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer011_EnableHeartbeats, 5)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer011_EnableHeartbeats, 8)
 void __thiscall winISteamGameServer_SteamGameServer011_EnableHeartbeats(winISteamGameServer_SteamGameServer011 *_this, bool bActive)
 {
     TRACE("%p\n", _this);
@@ -847,7 +847,7 @@ bool __thiscall winISteamGameServer_SteamGameServer010_BUpdateUserData(winISteam
     return cppISteamGameServer_SteamGameServer010_BUpdateUserData(_this->linux_side, steamIDUser, pchPlayerName, uScore);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer010_BSetServerType, 27)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer010_BSetServerType, 36)
 bool __thiscall winISteamGameServer_SteamGameServer010_BSetServerType(winISteamGameServer_SteamGameServer010 *_this, uint32 unServerFlags, uint32 unGameIP, uint16 unGamePort, uint16 unSpectatorPort, uint16 usQueryPort, const char * pchGameDir, const char * pchVersion, bool bLANMode)
 {
     TRACE("%p\n", _this);
@@ -861,7 +861,7 @@ void __thiscall winISteamGameServer_SteamGameServer010_UpdateServerStatus(winISt
     cppISteamGameServer_SteamGameServer010_UpdateServerStatus(_this->linux_side, cPlayers, cPlayersMax, cBotPlayers, pchServerName, pSpectatorServerName, pchMapName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer010_UpdateSpectatorPort, 6)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer010_UpdateSpectatorPort, 8)
 void __thiscall winISteamGameServer_SteamGameServer010_UpdateSpectatorPort(winISteamGameServer_SteamGameServer010 *_this, uint16 unSpectatorPort)
 {
     TRACE("%p\n", _this);
@@ -1060,7 +1060,7 @@ bool __thiscall winISteamGameServer_SteamGameServer009_BUpdateUserData(winISteam
     return cppISteamGameServer_SteamGameServer009_BUpdateUserData(_this->linux_side, steamIDUser, pchPlayerName, uScore);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer009_BSetServerType, 27)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer009_BSetServerType, 36)
 bool __thiscall winISteamGameServer_SteamGameServer009_BSetServerType(winISteamGameServer_SteamGameServer009 *_this, uint32 unServerFlags, uint32 unGameIP, uint16 unGamePort, uint16 unSpectatorPort, uint16 usQueryPort, const char * pchGameDir, const char * pchVersion, bool bLANMode)
 {
     TRACE("%p\n", _this);
@@ -1074,7 +1074,7 @@ void __thiscall winISteamGameServer_SteamGameServer009_UpdateServerStatus(winISt
     cppISteamGameServer_SteamGameServer009_UpdateServerStatus(_this->linux_side, cPlayers, cPlayersMax, cBotPlayers, pchServerName, pSpectatorServerName, pchMapName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer009_UpdateSpectatorPort, 6)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer009_UpdateSpectatorPort, 8)
 void __thiscall winISteamGameServer_SteamGameServer009_UpdateSpectatorPort(winISteamGameServer_SteamGameServer009 *_this, uint16 unSpectatorPort)
 {
     TRACE("%p\n", _this);
@@ -1241,7 +1241,7 @@ bool __thiscall winISteamGameServer_SteamGameServer008_BUpdateUserData(winISteam
     return cppISteamGameServer_SteamGameServer008_BUpdateUserData(_this->linux_side, steamIDUser, pchPlayerName, uScore);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer008_BSetServerType, 27)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer008_BSetServerType, 36)
 bool __thiscall winISteamGameServer_SteamGameServer008_BSetServerType(winISteamGameServer_SteamGameServer008 *_this, uint32 unServerFlags, uint32 unGameIP, uint16 unGamePort, uint16 unSpectatorPort, uint16 usQueryPort, const char * pchGameDir, const char * pchVersion, bool bLANMode)
 {
     TRACE("%p\n", _this);
@@ -1255,7 +1255,7 @@ void __thiscall winISteamGameServer_SteamGameServer008_UpdateServerStatus(winISt
     cppISteamGameServer_SteamGameServer008_UpdateServerStatus(_this->linux_side, cPlayers, cPlayersMax, cBotPlayers, pchServerName, pSpectatorServerName, pchMapName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer008_UpdateSpectatorPort, 6)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer008_UpdateSpectatorPort, 8)
 void __thiscall winISteamGameServer_SteamGameServer008_UpdateSpectatorPort(winISteamGameServer_SteamGameServer008 *_this, uint16 unSpectatorPort)
 {
     TRACE("%p\n", _this);
@@ -1406,7 +1406,7 @@ bool __thiscall winISteamGameServer_SteamGameServer005_BUpdateUserData(winISteam
     return cppISteamGameServer_SteamGameServer005_BUpdateUserData(_this->linux_side, steamIDUser, pchPlayerName, uScore);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer005_BSetServerType, 27)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer005_BSetServerType, 36)
 bool __thiscall winISteamGameServer_SteamGameServer005_BSetServerType(winISteamGameServer_SteamGameServer005 *_this, uint32 unServerFlags, uint32 unGameIP, uint16 unGamePort, uint16 unSpectatorPort, uint16 usQueryPort, const char * pchGameDir, const char * pchVersion, bool bLANMode)
 {
     TRACE("%p\n", _this);
@@ -1420,7 +1420,7 @@ void __thiscall winISteamGameServer_SteamGameServer005_UpdateServerStatus(winISt
     cppISteamGameServer_SteamGameServer005_UpdateServerStatus(_this->linux_side, cPlayers, cPlayersMax, cBotPlayers, pchServerName, pSpectatorServerName, pchMapName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer005_UpdateSpectatorPort, 6)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer005_UpdateSpectatorPort, 8)
 void __thiscall winISteamGameServer_SteamGameServer005_UpdateSpectatorPort(winISteamGameServer_SteamGameServer005 *_this, uint16 unSpectatorPort)
 {
     TRACE("%p\n", _this);
@@ -1547,7 +1547,7 @@ bool __thiscall winISteamGameServer_SteamGameServer004_BUpdateUserData(winISteam
     return cppISteamGameServer_SteamGameServer004_BUpdateUserData(_this->linux_side, steamIDUser, pchPlayerName, uScore);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer004_BSetServerType, 31)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer004_BSetServerType, 40)
 bool __thiscall winISteamGameServer_SteamGameServer004_BSetServerType(winISteamGameServer_SteamGameServer004 *_this, int32 nGameAppId, uint32 unServerFlags, uint32 unGameIP, uint16 unGamePort, uint16 unSpectatorPort, uint16 usQueryPort, const char * pchGameDir, const char * pchVersion, bool bLANMode)
 {
     TRACE("%p\n", _this);
@@ -1561,7 +1561,7 @@ void __thiscall winISteamGameServer_SteamGameServer004_UpdateServerStatus(winISt
     cppISteamGameServer_SteamGameServer004_UpdateServerStatus(_this->linux_side, cPlayers, cPlayersMax, cBotPlayers, pchServerName, pSpectatorServerName, pchMapName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer004_UpdateSpectatorPort, 6)
+DEFINE_THISCALL_WRAPPER(winISteamGameServer_SteamGameServer004_UpdateSpectatorPort, 8)
 void __thiscall winISteamGameServer_SteamGameServer004_UpdateSpectatorPort(winISteamGameServer_SteamGameServer004 *_this, uint16 unSpectatorPort)
 {
     TRACE("%p\n", _this);

--- a/lsteamclient/winISteamHTMLSurface.c
+++ b/lsteamclient/winISteamHTMLSurface.c
@@ -178,7 +178,7 @@ void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_SetV
     cppISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_SetVerticalScroll(_this->linux_side, unBrowserHandle, nAbsolutePixelScroll);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_SetKeyFocus, 9)
+DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_SetKeyFocus, 12)
 void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_SetKeyFocus(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004 *_this, HHTMLBrowser unBrowserHandle, bool bHasKeyFocus)
 {
     TRACE("%p\n", _this);
@@ -206,7 +206,7 @@ void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_Past
     cppISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_PasteFromClipboard(_this->linux_side, unBrowserHandle);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_Find, 14)
+DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_Find, 20)
 void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_Find(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004 *_this, HHTMLBrowser unBrowserHandle, const char * pchSearchStr, bool bCurrentlyInFind, bool bReverse)
 {
     TRACE("%p\n", _this);
@@ -227,7 +227,7 @@ void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_GetL
     cppISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_GetLinkAtPosition(_this->linux_side, unBrowserHandle, x, y);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_SetCookie, 26)
+DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_SetCookie, 32)
 void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_SetCookie(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004 *_this, const char * pchHostname, const char * pchKey, const char * pchValue, const char * pchPath, RTime32 nExpires, bool bSecure, bool bHTTPOnly)
 {
     TRACE("%p\n", _this);
@@ -241,7 +241,7 @@ void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_SetP
     cppISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_SetPageScaleFactor(_this->linux_side, unBrowserHandle, flZoom, nPointX, nPointY);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_SetBackgroundMode, 9)
+DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_SetBackgroundMode, 12)
 void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_SetBackgroundMode(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004 *_this, HHTMLBrowser unBrowserHandle, bool bBackgroundMode)
 {
     TRACE("%p\n", _this);
@@ -255,14 +255,14 @@ void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_SetD
     cppISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_SetDPIScalingFactor(_this->linux_side, unBrowserHandle, flDPIScaling);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_AllowStartRequest, 9)
+DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_AllowStartRequest, 12)
 void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_AllowStartRequest(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004 *_this, HHTMLBrowser unBrowserHandle, bool bAllowed)
 {
     TRACE("%p\n", _this);
     cppISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_AllowStartRequest(_this->linux_side, unBrowserHandle, bAllowed);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_JSDialogResponse, 9)
+DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_JSDialogResponse, 12)
 void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_JSDialogResponse(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004 *_this, HHTMLBrowser unBrowserHandle, bool bResult)
 {
     TRACE("%p\n", _this);
@@ -500,7 +500,7 @@ void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_SetV
     cppISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_SetVerticalScroll(_this->linux_side, unBrowserHandle, nAbsolutePixelScroll);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_SetKeyFocus, 9)
+DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_SetKeyFocus, 12)
 void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_SetKeyFocus(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003 *_this, HHTMLBrowser unBrowserHandle, bool bHasKeyFocus)
 {
     TRACE("%p\n", _this);
@@ -528,7 +528,7 @@ void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_Past
     cppISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_PasteFromClipboard(_this->linux_side, unBrowserHandle);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_Find, 14)
+DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_Find, 20)
 void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_Find(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003 *_this, HHTMLBrowser unBrowserHandle, const char * pchSearchStr, bool bCurrentlyInFind, bool bReverse)
 {
     TRACE("%p\n", _this);
@@ -549,7 +549,7 @@ void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_GetL
     cppISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_GetLinkAtPosition(_this->linux_side, unBrowserHandle, x, y);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_SetCookie, 26)
+DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_SetCookie, 32)
 void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_SetCookie(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003 *_this, const char * pchHostname, const char * pchKey, const char * pchValue, const char * pchPath, RTime32 nExpires, bool bSecure, bool bHTTPOnly)
 {
     TRACE("%p\n", _this);
@@ -563,21 +563,21 @@ void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_SetP
     cppISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_SetPageScaleFactor(_this->linux_side, unBrowserHandle, flZoom, nPointX, nPointY);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_SetBackgroundMode, 9)
+DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_SetBackgroundMode, 12)
 void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_SetBackgroundMode(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003 *_this, HHTMLBrowser unBrowserHandle, bool bBackgroundMode)
 {
     TRACE("%p\n", _this);
     cppISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_SetBackgroundMode(_this->linux_side, unBrowserHandle, bBackgroundMode);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_AllowStartRequest, 9)
+DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_AllowStartRequest, 12)
 void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_AllowStartRequest(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003 *_this, HHTMLBrowser unBrowserHandle, bool bAllowed)
 {
     TRACE("%p\n", _this);
     cppISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_AllowStartRequest(_this->linux_side, unBrowserHandle, bAllowed);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_JSDialogResponse, 9)
+DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_JSDialogResponse, 12)
 void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_JSDialogResponse(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003 *_this, HHTMLBrowser unBrowserHandle, bool bResult)
 {
     TRACE("%p\n", _this);
@@ -814,7 +814,7 @@ void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_SetV
     cppISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_SetVerticalScroll(_this->linux_side, unBrowserHandle, nAbsolutePixelScroll);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_SetKeyFocus, 9)
+DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_SetKeyFocus, 12)
 void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_SetKeyFocus(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002 *_this, HHTMLBrowser unBrowserHandle, bool bHasKeyFocus)
 {
     TRACE("%p\n", _this);
@@ -842,7 +842,7 @@ void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_Past
     cppISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_PasteFromClipboard(_this->linux_side, unBrowserHandle);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_Find, 14)
+DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_Find, 20)
 void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_Find(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002 *_this, HHTMLBrowser unBrowserHandle, const char * pchSearchStr, bool bCurrentlyInFind, bool bReverse)
 {
     TRACE("%p\n", _this);
@@ -863,7 +863,7 @@ void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_GetL
     cppISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_GetLinkAtPosition(_this->linux_side, unBrowserHandle, x, y);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_SetCookie, 26)
+DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_SetCookie, 32)
 void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_SetCookie(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002 *_this, const char * pchHostname, const char * pchKey, const char * pchValue, const char * pchPath, RTime32 nExpires, bool bSecure, bool bHTTPOnly)
 {
     TRACE("%p\n", _this);
@@ -877,14 +877,14 @@ void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_SetP
     cppISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_SetPageScaleFactor(_this->linux_side, unBrowserHandle, flZoom, nPointX, nPointY);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_AllowStartRequest, 9)
+DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_AllowStartRequest, 12)
 void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_AllowStartRequest(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002 *_this, HHTMLBrowser unBrowserHandle, bool bAllowed)
 {
     TRACE("%p\n", _this);
     cppISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_AllowStartRequest(_this->linux_side, unBrowserHandle, bAllowed);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_JSDialogResponse, 9)
+DEFINE_THISCALL_WRAPPER(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_JSDialogResponse, 12)
 void __thiscall winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_JSDialogResponse(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002 *_this, HHTMLBrowser unBrowserHandle, bool bResult)
 {
     TRACE("%p\n", _this);

--- a/lsteamclient/winISteamHTTP.c
+++ b/lsteamclient/winISteamHTTP.c
@@ -139,7 +139,7 @@ bool __thiscall winISteamHTTP_STEAMHTTP_INTERFACE_VERSION002_SetHTTPRequestRawPo
     return cppISteamHTTP_STEAMHTTP_INTERFACE_VERSION002_SetHTTPRequestRawPostBody(_this->linux_side, hRequest, pchContentType, pubBody, unBodyLen);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamHTTP_STEAMHTTP_INTERFACE_VERSION002_CreateCookieContainer, 5)
+DEFINE_THISCALL_WRAPPER(winISteamHTTP_STEAMHTTP_INTERFACE_VERSION002_CreateCookieContainer, 8)
 HTTPCookieContainerHandle __thiscall winISteamHTTP_STEAMHTTP_INTERFACE_VERSION002_CreateCookieContainer(winISteamHTTP_STEAMHTTP_INTERFACE_VERSION002 *_this, bool bAllowResponsesToModify)
 {
     TRACE("%p\n", _this);
@@ -174,7 +174,7 @@ bool __thiscall winISteamHTTP_STEAMHTTP_INTERFACE_VERSION002_SetHTTPRequestUserA
     return cppISteamHTTP_STEAMHTTP_INTERFACE_VERSION002_SetHTTPRequestUserAgentInfo(_this->linux_side, hRequest, pchUserAgentInfo);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamHTTP_STEAMHTTP_INTERFACE_VERSION002_SetHTTPRequestRequiresVerifiedCertificate, 9)
+DEFINE_THISCALL_WRAPPER(winISteamHTTP_STEAMHTTP_INTERFACE_VERSION002_SetHTTPRequestRequiresVerifiedCertificate, 12)
 bool __thiscall winISteamHTTP_STEAMHTTP_INTERFACE_VERSION002_SetHTTPRequestRequiresVerifiedCertificate(winISteamHTTP_STEAMHTTP_INTERFACE_VERSION002 *_this, HTTPRequestHandle hRequest, bool bRequireVerifiedCertificate)
 {
     TRACE("%p\n", _this);

--- a/lsteamclient/winISteamInventory.c
+++ b/lsteamclient/winISteamInventory.c
@@ -83,7 +83,7 @@ bool __thiscall winISteamInventory_STEAMINVENTORY_INTERFACE_V002_SerializeResult
     return cppISteamInventory_STEAMINVENTORY_INTERFACE_V002_SerializeResult(_this->linux_side, resultHandle, pOutBuffer, punOutBufferSize);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamInventory_STEAMINVENTORY_INTERFACE_V002_DeserializeResult, 17)
+DEFINE_THISCALL_WRAPPER(winISteamInventory_STEAMINVENTORY_INTERFACE_V002_DeserializeResult, 20)
 bool __thiscall winISteamInventory_STEAMINVENTORY_INTERFACE_V002_DeserializeResult(winISteamInventory_STEAMINVENTORY_INTERFACE_V002 *_this, SteamInventoryResult_t * pOutResultHandle, const void * pBuffer, uint32 unBufferSize, bool bRESERVED_MUST_BE_FALSE)
 {
     TRACE("%p\n", _this);
@@ -251,7 +251,7 @@ bool __thiscall winISteamInventory_STEAMINVENTORY_INTERFACE_V002_SetProperty(win
     return cppISteamInventory_STEAMINVENTORY_INTERFACE_V002_SetProperty(_this->linux_side, handle, nItemID, pchPropertyName, pchPropertyValue);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamInventory_STEAMINVENTORY_INTERFACE_V002_SetProperty_2, 25)
+DEFINE_THISCALL_WRAPPER(winISteamInventory_STEAMINVENTORY_INTERFACE_V002_SetProperty_2, 28)
 bool __thiscall winISteamInventory_STEAMINVENTORY_INTERFACE_V002_SetProperty_2(winISteamInventory_STEAMINVENTORY_INTERFACE_V002 *_this, SteamInventoryUpdateHandle_t handle, SteamItemInstanceID_t nItemID, const char * pchPropertyName, bool bValue)
 {
     TRACE("%p\n", _this);
@@ -399,7 +399,7 @@ bool __thiscall winISteamInventory_STEAMINVENTORY_INTERFACE_V001_SerializeResult
     return cppISteamInventory_STEAMINVENTORY_INTERFACE_V001_SerializeResult(_this->linux_side, resultHandle, pOutBuffer, punOutBufferSize);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamInventory_STEAMINVENTORY_INTERFACE_V001_DeserializeResult, 17)
+DEFINE_THISCALL_WRAPPER(winISteamInventory_STEAMINVENTORY_INTERFACE_V001_DeserializeResult, 20)
 bool __thiscall winISteamInventory_STEAMINVENTORY_INTERFACE_V001_DeserializeResult(winISteamInventory_STEAMINVENTORY_INTERFACE_V001 *_this, SteamInventoryResult_t * pOutResultHandle, const void * pBuffer, uint32 unBufferSize, bool bRESERVED_MUST_BE_FALSE)
 {
     TRACE("%p\n", _this);

--- a/lsteamclient/winISteamMasterServerUpdater.c
+++ b/lsteamclient/winISteamMasterServerUpdater.c
@@ -20,7 +20,7 @@ typedef struct __winISteamMasterServerUpdater_SteamMasterServerUpdater001 {
     void *linux_side;
 } winISteamMasterServerUpdater_SteamMasterServerUpdater001;
 
-DEFINE_THISCALL_WRAPPER(winISteamMasterServerUpdater_SteamMasterServerUpdater001_SetActive, 5)
+DEFINE_THISCALL_WRAPPER(winISteamMasterServerUpdater_SteamMasterServerUpdater001_SetActive, 8)
 void __thiscall winISteamMasterServerUpdater_SteamMasterServerUpdater001_SetActive(winISteamMasterServerUpdater_SteamMasterServerUpdater001 *_this, bool bActive)
 {
     TRACE("%p\n", _this);
@@ -34,7 +34,7 @@ void __thiscall winISteamMasterServerUpdater_SteamMasterServerUpdater001_SetHear
     cppISteamMasterServerUpdater_SteamMasterServerUpdater001_SetHeartbeatInterval(_this->linux_side, iHeartbeatInterval);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMasterServerUpdater_SteamMasterServerUpdater001_HandleIncomingPacket, 18)
+DEFINE_THISCALL_WRAPPER(winISteamMasterServerUpdater_SteamMasterServerUpdater001_HandleIncomingPacket, 20)
 bool __thiscall winISteamMasterServerUpdater_SteamMasterServerUpdater001_HandleIncomingPacket(winISteamMasterServerUpdater_SteamMasterServerUpdater001 *_this, const void * pData, int cbData, uint32 srcIP, uint16 srcPort)
 {
     TRACE("%p\n", _this);
@@ -48,7 +48,7 @@ int __thiscall winISteamMasterServerUpdater_SteamMasterServerUpdater001_GetNextO
     return cppISteamMasterServerUpdater_SteamMasterServerUpdater001_GetNextOutgoingPacket(_this->linux_side, pOut, cbMaxOut, pNetAdr, pPort);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMasterServerUpdater_SteamMasterServerUpdater001_SetBasicServerData, 22)
+DEFINE_THISCALL_WRAPPER(winISteamMasterServerUpdater_SteamMasterServerUpdater001_SetBasicServerData, 32)
 void __thiscall winISteamMasterServerUpdater_SteamMasterServerUpdater001_SetBasicServerData(winISteamMasterServerUpdater_SteamMasterServerUpdater001 *_this, unsigned short nProtocolVersion, bool bDedicatedServer, const char * pRegionName, const char * pProductName, unsigned short nMaxReportedClients, bool bPasswordProtected, const char * pGameDescription)
 {
     TRACE("%p\n", _this);

--- a/lsteamclient/winISteamMatchmaking.c
+++ b/lsteamclient/winISteamMatchmaking.c
@@ -34,14 +34,14 @@ bool __thiscall winISteamMatchmaking_SteamMatchMaking009_GetFavoriteGame(winISte
     return cppISteamMatchmaking_SteamMatchMaking009_GetFavoriteGame(_this->linux_side, iGame, pnAppID, pnIP, pnConnPort, pnQueryPort, punFlags, pRTime32LastPlayedOnServer);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking009_AddFavoriteGame, 24)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking009_AddFavoriteGame, 28)
 int __thiscall winISteamMatchmaking_SteamMatchMaking009_AddFavoriteGame(winISteamMatchmaking_SteamMatchMaking009 *_this, AppId_t nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags, uint32 rTime32LastPlayedOnServer)
 {
     TRACE("%p\n", _this);
     return cppISteamMatchmaking_SteamMatchMaking009_AddFavoriteGame(_this->linux_side, nAppID, nIP, nConnPort, nQueryPort, unFlags, rTime32LastPlayedOnServer);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking009_RemoveFavoriteGame, 20)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking009_RemoveFavoriteGame, 24)
 bool __thiscall winISteamMatchmaking_SteamMatchMaking009_RemoveFavoriteGame(winISteamMatchmaking_SteamMatchMaking009 *_this, AppId_t nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags)
 {
     TRACE("%p\n", _this);
@@ -225,7 +225,7 @@ bool __thiscall winISteamMatchmaking_SteamMatchMaking009_RequestLobbyData(winISt
     return cppISteamMatchmaking_SteamMatchMaking009_RequestLobbyData(_this->linux_side, steamIDLobby);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking009_SetLobbyGameServer, 26)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking009_SetLobbyGameServer, 28)
 void __thiscall winISteamMatchmaking_SteamMatchMaking009_SetLobbyGameServer(winISteamMatchmaking_SteamMatchMaking009 *_this, CSteamID steamIDLobby, uint32 unGameServerIP, uint16 unGameServerPort, CSteamID steamIDGameServer)
 {
     TRACE("%p\n", _this);
@@ -260,7 +260,7 @@ bool __thiscall winISteamMatchmaking_SteamMatchMaking009_SetLobbyType(winISteamM
     return cppISteamMatchmaking_SteamMatchMaking009_SetLobbyType(_this->linux_side, steamIDLobby, eLobbyType);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking009_SetLobbyJoinable, 13)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking009_SetLobbyJoinable, 16)
 bool __thiscall winISteamMatchmaking_SteamMatchMaking009_SetLobbyJoinable(winISteamMatchmaking_SteamMatchMaking009 *_this, CSteamID steamIDLobby, bool bLobbyJoinable)
 {
     TRACE("%p\n", _this);
@@ -368,14 +368,14 @@ bool __thiscall winISteamMatchmaking_SteamMatchMaking008_GetFavoriteGame(winISte
     return cppISteamMatchmaking_SteamMatchMaking008_GetFavoriteGame(_this->linux_side, iGame, pnAppID, pnIP, pnConnPort, pnQueryPort, punFlags, pRTime32LastPlayedOnServer);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking008_AddFavoriteGame, 24)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking008_AddFavoriteGame, 28)
 int __thiscall winISteamMatchmaking_SteamMatchMaking008_AddFavoriteGame(winISteamMatchmaking_SteamMatchMaking008 *_this, AppId_t nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags, uint32 rTime32LastPlayedOnServer)
 {
     TRACE("%p\n", _this);
     return cppISteamMatchmaking_SteamMatchMaking008_AddFavoriteGame(_this->linux_side, nAppID, nIP, nConnPort, nQueryPort, unFlags, rTime32LastPlayedOnServer);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking008_RemoveFavoriteGame, 20)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking008_RemoveFavoriteGame, 24)
 bool __thiscall winISteamMatchmaking_SteamMatchMaking008_RemoveFavoriteGame(winISteamMatchmaking_SteamMatchMaking008 *_this, AppId_t nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags)
 {
     TRACE("%p\n", _this);
@@ -552,7 +552,7 @@ bool __thiscall winISteamMatchmaking_SteamMatchMaking008_RequestLobbyData(winISt
     return cppISteamMatchmaking_SteamMatchMaking008_RequestLobbyData(_this->linux_side, steamIDLobby);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking008_SetLobbyGameServer, 26)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking008_SetLobbyGameServer, 28)
 void __thiscall winISteamMatchmaking_SteamMatchMaking008_SetLobbyGameServer(winISteamMatchmaking_SteamMatchMaking008 *_this, CSteamID steamIDLobby, uint32 unGameServerIP, uint16 unGameServerPort, CSteamID steamIDGameServer)
 {
     TRACE("%p\n", _this);
@@ -587,7 +587,7 @@ bool __thiscall winISteamMatchmaking_SteamMatchMaking008_SetLobbyType(winISteamM
     return cppISteamMatchmaking_SteamMatchMaking008_SetLobbyType(_this->linux_side, steamIDLobby, eLobbyType);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking008_SetLobbyJoinable, 13)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking008_SetLobbyJoinable, 16)
 bool __thiscall winISteamMatchmaking_SteamMatchMaking008_SetLobbyJoinable(winISteamMatchmaking_SteamMatchMaking008 *_this, CSteamID steamIDLobby, bool bLobbyJoinable)
 {
     TRACE("%p\n", _this);
@@ -686,14 +686,14 @@ bool __thiscall winISteamMatchmaking_SteamMatchMaking007_GetFavoriteGame(winISte
     return cppISteamMatchmaking_SteamMatchMaking007_GetFavoriteGame(_this->linux_side, iGame, pnAppID, pnIP, pnConnPort, pnQueryPort, punFlags, pRTime32LastPlayedOnServer);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking007_AddFavoriteGame, 24)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking007_AddFavoriteGame, 28)
 int __thiscall winISteamMatchmaking_SteamMatchMaking007_AddFavoriteGame(winISteamMatchmaking_SteamMatchMaking007 *_this, AppId_t nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags, uint32 rTime32LastPlayedOnServer)
 {
     TRACE("%p\n", _this);
     return cppISteamMatchmaking_SteamMatchMaking007_AddFavoriteGame(_this->linux_side, nAppID, nIP, nConnPort, nQueryPort, unFlags, rTime32LastPlayedOnServer);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking007_RemoveFavoriteGame, 20)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking007_RemoveFavoriteGame, 24)
 bool __thiscall winISteamMatchmaking_SteamMatchMaking007_RemoveFavoriteGame(winISteamMatchmaking_SteamMatchMaking007 *_this, AppId_t nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags)
 {
     TRACE("%p\n", _this);
@@ -856,7 +856,7 @@ bool __thiscall winISteamMatchmaking_SteamMatchMaking007_RequestLobbyData(winISt
     return cppISteamMatchmaking_SteamMatchMaking007_RequestLobbyData(_this->linux_side, steamIDLobby);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking007_SetLobbyGameServer, 26)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking007_SetLobbyGameServer, 28)
 void __thiscall winISteamMatchmaking_SteamMatchMaking007_SetLobbyGameServer(winISteamMatchmaking_SteamMatchMaking007 *_this, CSteamID steamIDLobby, uint32 unGameServerIP, uint16 unGameServerPort, CSteamID steamIDGameServer)
 {
     TRACE("%p\n", _this);
@@ -891,7 +891,7 @@ bool __thiscall winISteamMatchmaking_SteamMatchMaking007_SetLobbyType(winISteamM
     return cppISteamMatchmaking_SteamMatchMaking007_SetLobbyType(_this->linux_side, steamIDLobby, eLobbyType);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking007_SetLobbyJoinable, 13)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking007_SetLobbyJoinable, 16)
 bool __thiscall winISteamMatchmaking_SteamMatchMaking007_SetLobbyJoinable(winISteamMatchmaking_SteamMatchMaking007 *_this, CSteamID steamIDLobby, bool bLobbyJoinable)
 {
     TRACE("%p\n", _this);
@@ -988,14 +988,14 @@ bool __thiscall winISteamMatchmaking_SteamMatchMaking006_GetFavoriteGame(winISte
     return cppISteamMatchmaking_SteamMatchMaking006_GetFavoriteGame(_this->linux_side, iGame, pnAppID, pnIP, pnConnPort, pnQueryPort, punFlags, pRTime32LastPlayedOnServer);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking006_AddFavoriteGame, 24)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking006_AddFavoriteGame, 28)
 int __thiscall winISteamMatchmaking_SteamMatchMaking006_AddFavoriteGame(winISteamMatchmaking_SteamMatchMaking006 *_this, AppId_t nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags, uint32 rTime32LastPlayedOnServer)
 {
     TRACE("%p\n", _this);
     return cppISteamMatchmaking_SteamMatchMaking006_AddFavoriteGame(_this->linux_side, nAppID, nIP, nConnPort, nQueryPort, unFlags, rTime32LastPlayedOnServer);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking006_RemoveFavoriteGame, 20)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking006_RemoveFavoriteGame, 24)
 bool __thiscall winISteamMatchmaking_SteamMatchMaking006_RemoveFavoriteGame(winISteamMatchmaking_SteamMatchMaking006 *_this, AppId_t nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags)
 {
     TRACE("%p\n", _this);
@@ -1130,7 +1130,7 @@ bool __thiscall winISteamMatchmaking_SteamMatchMaking006_RequestLobbyData(winISt
     return cppISteamMatchmaking_SteamMatchMaking006_RequestLobbyData(_this->linux_side, steamIDLobby);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking006_SetLobbyGameServer, 26)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking006_SetLobbyGameServer, 28)
 void __thiscall winISteamMatchmaking_SteamMatchMaking006_SetLobbyGameServer(winISteamMatchmaking_SteamMatchMaking006 *_this, CSteamID steamIDLobby, uint32 unGameServerIP, uint16 unGameServerPort, CSteamID steamIDGameServer)
 {
     TRACE("%p\n", _this);
@@ -1242,14 +1242,14 @@ bool __thiscall winISteamMatchmaking_SteamMatchMaking004_GetFavoriteGame(winISte
     return cppISteamMatchmaking_SteamMatchMaking004_GetFavoriteGame(_this->linux_side, iGame, pnAppID, pnIP, pnConnPort, pnQueryPort, punFlags, pRTime32LastPlayedOnServer);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking004_AddFavoriteGame, 24)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking004_AddFavoriteGame, 28)
 int __thiscall winISteamMatchmaking_SteamMatchMaking004_AddFavoriteGame(winISteamMatchmaking_SteamMatchMaking004 *_this, AppId_t nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags, uint32 rTime32LastPlayedOnServer)
 {
     TRACE("%p\n", _this);
     return cppISteamMatchmaking_SteamMatchMaking004_AddFavoriteGame(_this->linux_side, nAppID, nIP, nConnPort, nQueryPort, unFlags, rTime32LastPlayedOnServer);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking004_RemoveFavoriteGame, 20)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking004_RemoveFavoriteGame, 24)
 bool __thiscall winISteamMatchmaking_SteamMatchMaking004_RemoveFavoriteGame(winISteamMatchmaking_SteamMatchMaking004 *_this, AppId_t nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags)
 {
     TRACE("%p\n", _this);
@@ -1292,7 +1292,7 @@ CSteamID *__thiscall winISteamMatchmaking_SteamMatchMaking004_GetLobbyByIndex(wi
     return _r;
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking004_CreateLobby, 5)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking004_CreateLobby, 8)
 void __thiscall winISteamMatchmaking_SteamMatchMaking004_CreateLobby(winISteamMatchmaking_SteamMatchMaking004 *_this, bool bPrivate)
 {
     TRACE("%p\n", _this);
@@ -1384,7 +1384,7 @@ bool __thiscall winISteamMatchmaking_SteamMatchMaking004_RequestLobbyData(winISt
     return cppISteamMatchmaking_SteamMatchMaking004_RequestLobbyData(_this->linux_side, steamIDLobby);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking004_SetLobbyGameServer, 26)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking004_SetLobbyGameServer, 28)
 void __thiscall winISteamMatchmaking_SteamMatchMaking004_SetLobbyGameServer(winISteamMatchmaking_SteamMatchMaking004 *_this, CSteamID steamIDLobby, uint32 unGameServerIP, uint16 unGameServerPort, CSteamID steamIDGameServer)
 {
     TRACE("%p\n", _this);
@@ -1487,14 +1487,14 @@ bool __thiscall winISteamMatchmaking_SteamMatchMaking002_GetFavoriteGame(winISte
     return cppISteamMatchmaking_SteamMatchMaking002_GetFavoriteGame(_this->linux_side, iGame, pnAppID, pnIP, pnConnPort, pnQueryPort, punFlags, pRTime32LastPlayedOnServer);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking002_AddFavoriteGame, 24)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking002_AddFavoriteGame, 28)
 int __thiscall winISteamMatchmaking_SteamMatchMaking002_AddFavoriteGame(winISteamMatchmaking_SteamMatchMaking002 *_this, AppId_t nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags, uint32 rTime32LastPlayedOnServer)
 {
     TRACE("%p\n", _this);
     return cppISteamMatchmaking_SteamMatchMaking002_AddFavoriteGame(_this->linux_side, nAppID, nIP, nConnPort, nQueryPort, unFlags, rTime32LastPlayedOnServer);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking002_RemoveFavoriteGame, 20)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking002_RemoveFavoriteGame, 24)
 bool __thiscall winISteamMatchmaking_SteamMatchMaking002_RemoveFavoriteGame(winISteamMatchmaking_SteamMatchMaking002 *_this, AppId_t nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags)
 {
     TRACE("%p\n", _this);
@@ -1516,7 +1516,7 @@ CSteamID *__thiscall winISteamMatchmaking_SteamMatchMaking002_GetLobbyByIndex(wi
     return _r;
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking002_CreateLobby, 5)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking002_CreateLobby, 8)
 void __thiscall winISteamMatchmaking_SteamMatchMaking002_CreateLobby(winISteamMatchmaking_SteamMatchMaking002 *_this, bool bPrivate)
 {
     TRACE("%p\n", _this);
@@ -1608,7 +1608,7 @@ bool __thiscall winISteamMatchmaking_SteamMatchMaking002_RequestLobbyData(winISt
     return cppISteamMatchmaking_SteamMatchMaking002_RequestLobbyData(_this->linux_side, steamIDLobby);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking002_SetLobbyGameServer, 26)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmaking_SteamMatchMaking002_SetLobbyGameServer, 28)
 void __thiscall winISteamMatchmaking_SteamMatchMaking002_SetLobbyGameServer(winISteamMatchmaking_SteamMatchMaking002 *_this, CSteamID steamIDLobby, uint32 unGameServerIP, uint16 unGameServerPort, CSteamID steamIDGameServer)
 {
     TRACE("%p\n", _this);

--- a/lsteamclient/winISteamMatchmakingServers.c
+++ b/lsteamclient/winISteamMatchmakingServers.c
@@ -111,21 +111,21 @@ void __thiscall winISteamMatchmakingServers_SteamMatchMakingServers002_RefreshSe
     cppISteamMatchmakingServers_SteamMatchMakingServers002_RefreshServer(_this->linux_side, hRequest, iServer);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmakingServers_SteamMatchMakingServers002_PingServer, 14)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmakingServers_SteamMatchMakingServers002_PingServer, 16)
 HServerQuery __thiscall winISteamMatchmakingServers_SteamMatchMakingServers002_PingServer(winISteamMatchmakingServers_SteamMatchMakingServers002 *_this, uint32 unIP, uint16 usPort, ISteamMatchmakingPingResponse * pRequestServersResponse)
 {
     TRACE("%p\n", _this);
     return cppISteamMatchmakingServers_SteamMatchMakingServers002_PingServer(_this->linux_side, unIP, usPort, create_LinuxISteamMatchmakingPingResponse(pRequestServersResponse));
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmakingServers_SteamMatchMakingServers002_PlayerDetails, 14)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmakingServers_SteamMatchMakingServers002_PlayerDetails, 16)
 HServerQuery __thiscall winISteamMatchmakingServers_SteamMatchMakingServers002_PlayerDetails(winISteamMatchmakingServers_SteamMatchMakingServers002 *_this, uint32 unIP, uint16 usPort, ISteamMatchmakingPlayersResponse * pRequestServersResponse)
 {
     TRACE("%p\n", _this);
     return cppISteamMatchmakingServers_SteamMatchMakingServers002_PlayerDetails(_this->linux_side, unIP, usPort, create_LinuxISteamMatchmakingPlayersResponse(pRequestServersResponse));
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmakingServers_SteamMatchMakingServers002_ServerRules, 14)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmakingServers_SteamMatchMakingServers002_ServerRules, 16)
 HServerQuery __thiscall winISteamMatchmakingServers_SteamMatchMakingServers002_ServerRules(winISteamMatchmakingServers_SteamMatchMakingServers002 *_this, uint32 unIP, uint16 usPort, ISteamMatchmakingRulesResponse * pRequestServersResponse)
 {
     TRACE("%p\n", _this);
@@ -267,21 +267,21 @@ void __thiscall winISteamMatchmakingServers_SteamMatchMakingServers001_RefreshSe
     cppISteamMatchmakingServers_SteamMatchMakingServers001_RefreshServer(_this->linux_side, eType, iServer);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmakingServers_SteamMatchMakingServers001_PingServer, 14)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmakingServers_SteamMatchMakingServers001_PingServer, 16)
 HServerQuery __thiscall winISteamMatchmakingServers_SteamMatchMakingServers001_PingServer(winISteamMatchmakingServers_SteamMatchMakingServers001 *_this, uint32 unIP, uint16 usPort, ISteamMatchmakingPingResponse * pRequestServersResponse)
 {
     TRACE("%p\n", _this);
     return cppISteamMatchmakingServers_SteamMatchMakingServers001_PingServer(_this->linux_side, unIP, usPort, create_LinuxISteamMatchmakingPingResponse(pRequestServersResponse));
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmakingServers_SteamMatchMakingServers001_PlayerDetails, 14)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmakingServers_SteamMatchMakingServers001_PlayerDetails, 16)
 HServerQuery __thiscall winISteamMatchmakingServers_SteamMatchMakingServers001_PlayerDetails(winISteamMatchmakingServers_SteamMatchMakingServers001 *_this, uint32 unIP, uint16 usPort, ISteamMatchmakingPlayersResponse * pRequestServersResponse)
 {
     TRACE("%p\n", _this);
     return cppISteamMatchmakingServers_SteamMatchMakingServers001_PlayerDetails(_this->linux_side, unIP, usPort, create_LinuxISteamMatchmakingPlayersResponse(pRequestServersResponse));
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMatchmakingServers_SteamMatchMakingServers001_ServerRules, 14)
+DEFINE_THISCALL_WRAPPER(winISteamMatchmakingServers_SteamMatchMakingServers001_ServerRules, 16)
 HServerQuery __thiscall winISteamMatchmakingServers_SteamMatchMakingServers001_ServerRules(winISteamMatchmakingServers_SteamMatchMakingServers001 *_this, uint32 unIP, uint16 usPort, ISteamMatchmakingRulesResponse * pRequestServersResponse)
 {
     TRACE("%p\n", _this);

--- a/lsteamclient/winISteamMusicRemote.c
+++ b/lsteamclient/winISteamMusicRemote.c
@@ -41,7 +41,7 @@ bool __thiscall winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_BIsCu
     return cppISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_BIsCurrentMusicRemote(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_BActivationSuccess, 5)
+DEFINE_THISCALL_WRAPPER(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_BActivationSuccess, 8)
 bool __thiscall winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_BActivationSuccess(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001 *_this, bool bValue)
 {
     TRACE("%p\n", _this);
@@ -62,42 +62,42 @@ bool __thiscall winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_SetPN
     return cppISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_SetPNGIcon_64x64(_this->linux_side, pvBuffer, cbBufferLength);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnablePlayPrevious, 5)
+DEFINE_THISCALL_WRAPPER(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnablePlayPrevious, 8)
 bool __thiscall winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnablePlayPrevious(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001 *_this, bool bValue)
 {
     TRACE("%p\n", _this);
     return cppISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnablePlayPrevious(_this->linux_side, bValue);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnablePlayNext, 5)
+DEFINE_THISCALL_WRAPPER(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnablePlayNext, 8)
 bool __thiscall winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnablePlayNext(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001 *_this, bool bValue)
 {
     TRACE("%p\n", _this);
     return cppISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnablePlayNext(_this->linux_side, bValue);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnableShuffled, 5)
+DEFINE_THISCALL_WRAPPER(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnableShuffled, 8)
 bool __thiscall winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnableShuffled(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001 *_this, bool bValue)
 {
     TRACE("%p\n", _this);
     return cppISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnableShuffled(_this->linux_side, bValue);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnableLooped, 5)
+DEFINE_THISCALL_WRAPPER(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnableLooped, 8)
 bool __thiscall winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnableLooped(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001 *_this, bool bValue)
 {
     TRACE("%p\n", _this);
     return cppISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnableLooped(_this->linux_side, bValue);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnableQueue, 5)
+DEFINE_THISCALL_WRAPPER(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnableQueue, 8)
 bool __thiscall winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnableQueue(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001 *_this, bool bValue)
 {
     TRACE("%p\n", _this);
     return cppISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnableQueue(_this->linux_side, bValue);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnablePlaylists, 5)
+DEFINE_THISCALL_WRAPPER(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnablePlaylists, 8)
 bool __thiscall winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_EnablePlaylists(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001 *_this, bool bValue)
 {
     TRACE("%p\n", _this);
@@ -111,14 +111,14 @@ bool __thiscall winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_Updat
     return cppISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_UpdatePlaybackStatus(_this->linux_side, nStatus);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_UpdateShuffled, 5)
+DEFINE_THISCALL_WRAPPER(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_UpdateShuffled, 8)
 bool __thiscall winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_UpdateShuffled(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001 *_this, bool bValue)
 {
     TRACE("%p\n", _this);
     return cppISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_UpdateShuffled(_this->linux_side, bValue);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_UpdateLooped, 5)
+DEFINE_THISCALL_WRAPPER(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_UpdateLooped, 8)
 bool __thiscall winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_UpdateLooped(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001 *_this, bool bValue)
 {
     TRACE("%p\n", _this);
@@ -139,7 +139,7 @@ bool __thiscall winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_Curre
     return cppISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_CurrentEntryWillChange(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_CurrentEntryIsAvailable, 5)
+DEFINE_THISCALL_WRAPPER(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_CurrentEntryIsAvailable, 8)
 bool __thiscall winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_CurrentEntryIsAvailable(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001 *_this, bool bAvailable)
 {
     TRACE("%p\n", _this);

--- a/lsteamclient/winISteamNetworking.c
+++ b/lsteamclient/winISteamNetworking.c
@@ -69,49 +69,49 @@ bool __thiscall winISteamNetworking_SteamNetworking005_GetP2PSessionState(winISt
     return cppISteamNetworking_SteamNetworking005_GetP2PSessionState(_this->linux_side, steamIDRemote, pConnectionState);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking005_AllowP2PPacketRelay, 5)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking005_AllowP2PPacketRelay, 8)
 bool __thiscall winISteamNetworking_SteamNetworking005_AllowP2PPacketRelay(winISteamNetworking_SteamNetworking005 *_this, bool bAllow)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking005_AllowP2PPacketRelay(_this->linux_side, bAllow);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking005_CreateListenSocket, 15)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking005_CreateListenSocket, 20)
 SNetListenSocket_t __thiscall winISteamNetworking_SteamNetworking005_CreateListenSocket(winISteamNetworking_SteamNetworking005 *_this, int nVirtualP2PPort, uint32 nIP, uint16 nPort, bool bAllowUseOfPacketRelay)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking005_CreateListenSocket(_this->linux_side, nVirtualP2PPort, nIP, nPort, bAllowUseOfPacketRelay);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking005_CreateP2PConnectionSocket, 21)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking005_CreateP2PConnectionSocket, 24)
 SNetSocket_t __thiscall winISteamNetworking_SteamNetworking005_CreateP2PConnectionSocket(winISteamNetworking_SteamNetworking005 *_this, CSteamID steamIDTarget, int nVirtualPort, int nTimeoutSec, bool bAllowUseOfPacketRelay)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking005_CreateP2PConnectionSocket(_this->linux_side, steamIDTarget, nVirtualPort, nTimeoutSec, bAllowUseOfPacketRelay);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking005_CreateConnectionSocket, 14)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking005_CreateConnectionSocket, 16)
 SNetSocket_t __thiscall winISteamNetworking_SteamNetworking005_CreateConnectionSocket(winISteamNetworking_SteamNetworking005 *_this, uint32 nIP, uint16 nPort, int nTimeoutSec)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking005_CreateConnectionSocket(_this->linux_side, nIP, nPort, nTimeoutSec);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking005_DestroySocket, 9)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking005_DestroySocket, 12)
 bool __thiscall winISteamNetworking_SteamNetworking005_DestroySocket(winISteamNetworking_SteamNetworking005 *_this, SNetSocket_t hSocket, bool bNotifyRemoteEnd)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking005_DestroySocket(_this->linux_side, hSocket, bNotifyRemoteEnd);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking005_DestroyListenSocket, 9)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking005_DestroyListenSocket, 12)
 bool __thiscall winISteamNetworking_SteamNetworking005_DestroyListenSocket(winISteamNetworking_SteamNetworking005 *_this, SNetListenSocket_t hSocket, bool bNotifyRemoteEnd)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking005_DestroyListenSocket(_this->linux_side, hSocket, bNotifyRemoteEnd);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking005_SendDataOnSocket, 17)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking005_SendDataOnSocket, 20)
 bool __thiscall winISteamNetworking_SteamNetworking005_SendDataOnSocket(winISteamNetworking_SteamNetworking005 *_this, SNetSocket_t hSocket, void * pubData, uint32 cubData, bool bReliable)
 {
     TRACE("%p\n", _this);
@@ -265,42 +265,42 @@ bool __thiscall winISteamNetworking_SteamNetworking004_GetP2PSessionState(winISt
     return cppISteamNetworking_SteamNetworking004_GetP2PSessionState(_this->linux_side, steamIDRemote, pConnectionState);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking004_CreateListenSocket, 15)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking004_CreateListenSocket, 20)
 SNetListenSocket_t __thiscall winISteamNetworking_SteamNetworking004_CreateListenSocket(winISteamNetworking_SteamNetworking004 *_this, int nVirtualP2PPort, uint32 nIP, uint16 nPort, bool bAllowUseOfPacketRelay)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking004_CreateListenSocket(_this->linux_side, nVirtualP2PPort, nIP, nPort, bAllowUseOfPacketRelay);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking004_CreateP2PConnectionSocket, 21)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking004_CreateP2PConnectionSocket, 24)
 SNetSocket_t __thiscall winISteamNetworking_SteamNetworking004_CreateP2PConnectionSocket(winISteamNetworking_SteamNetworking004 *_this, CSteamID steamIDTarget, int nVirtualPort, int nTimeoutSec, bool bAllowUseOfPacketRelay)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking004_CreateP2PConnectionSocket(_this->linux_side, steamIDTarget, nVirtualPort, nTimeoutSec, bAllowUseOfPacketRelay);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking004_CreateConnectionSocket, 14)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking004_CreateConnectionSocket, 16)
 SNetSocket_t __thiscall winISteamNetworking_SteamNetworking004_CreateConnectionSocket(winISteamNetworking_SteamNetworking004 *_this, uint32 nIP, uint16 nPort, int nTimeoutSec)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking004_CreateConnectionSocket(_this->linux_side, nIP, nPort, nTimeoutSec);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking004_DestroySocket, 9)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking004_DestroySocket, 12)
 bool __thiscall winISteamNetworking_SteamNetworking004_DestroySocket(winISteamNetworking_SteamNetworking004 *_this, SNetSocket_t hSocket, bool bNotifyRemoteEnd)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking004_DestroySocket(_this->linux_side, hSocket, bNotifyRemoteEnd);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking004_DestroyListenSocket, 9)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking004_DestroyListenSocket, 12)
 bool __thiscall winISteamNetworking_SteamNetworking004_DestroyListenSocket(winISteamNetworking_SteamNetworking004 *_this, SNetListenSocket_t hSocket, bool bNotifyRemoteEnd)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking004_DestroyListenSocket(_this->linux_side, hSocket, bNotifyRemoteEnd);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking004_SendDataOnSocket, 17)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking004_SendDataOnSocket, 20)
 bool __thiscall winISteamNetworking_SteamNetworking004_SendDataOnSocket(winISteamNetworking_SteamNetworking004 *_this, SNetSocket_t hSocket, void * pubData, uint32 cubData, bool bReliable)
 {
     TRACE("%p\n", _this);
@@ -452,42 +452,42 @@ bool __thiscall winISteamNetworking_SteamNetworking003_GetP2PSessionState(winISt
     return cppISteamNetworking_SteamNetworking003_GetP2PSessionState(_this->linux_side, steamIDRemote, pConnectionState);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking003_CreateListenSocket, 15)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking003_CreateListenSocket, 20)
 SNetListenSocket_t __thiscall winISteamNetworking_SteamNetworking003_CreateListenSocket(winISteamNetworking_SteamNetworking003 *_this, int nVirtualP2PPort, uint32 nIP, uint16 nPort, bool bAllowUseOfPacketRelay)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking003_CreateListenSocket(_this->linux_side, nVirtualP2PPort, nIP, nPort, bAllowUseOfPacketRelay);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking003_CreateP2PConnectionSocket, 21)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking003_CreateP2PConnectionSocket, 24)
 SNetSocket_t __thiscall winISteamNetworking_SteamNetworking003_CreateP2PConnectionSocket(winISteamNetworking_SteamNetworking003 *_this, CSteamID steamIDTarget, int nVirtualPort, int nTimeoutSec, bool bAllowUseOfPacketRelay)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking003_CreateP2PConnectionSocket(_this->linux_side, steamIDTarget, nVirtualPort, nTimeoutSec, bAllowUseOfPacketRelay);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking003_CreateConnectionSocket, 14)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking003_CreateConnectionSocket, 16)
 SNetSocket_t __thiscall winISteamNetworking_SteamNetworking003_CreateConnectionSocket(winISteamNetworking_SteamNetworking003 *_this, uint32 nIP, uint16 nPort, int nTimeoutSec)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking003_CreateConnectionSocket(_this->linux_side, nIP, nPort, nTimeoutSec);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking003_DestroySocket, 9)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking003_DestroySocket, 12)
 bool __thiscall winISteamNetworking_SteamNetworking003_DestroySocket(winISteamNetworking_SteamNetworking003 *_this, SNetSocket_t hSocket, bool bNotifyRemoteEnd)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking003_DestroySocket(_this->linux_side, hSocket, bNotifyRemoteEnd);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking003_DestroyListenSocket, 9)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking003_DestroyListenSocket, 12)
 bool __thiscall winISteamNetworking_SteamNetworking003_DestroyListenSocket(winISteamNetworking_SteamNetworking003 *_this, SNetListenSocket_t hSocket, bool bNotifyRemoteEnd)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking003_DestroyListenSocket(_this->linux_side, hSocket, bNotifyRemoteEnd);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking003_SendDataOnSocket, 17)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking003_SendDataOnSocket, 20)
 bool __thiscall winISteamNetworking_SteamNetworking003_SendDataOnSocket(winISteamNetworking_SteamNetworking003 *_this, SNetSocket_t hSocket, void * pubData, uint32 cubData, bool bReliable)
 {
     TRACE("%p\n", _this);
@@ -597,42 +597,42 @@ typedef struct __winISteamNetworking_SteamNetworking002 {
     void *linux_side;
 } winISteamNetworking_SteamNetworking002;
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking002_CreateListenSocket, 15)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking002_CreateListenSocket, 20)
 SNetListenSocket_t __thiscall winISteamNetworking_SteamNetworking002_CreateListenSocket(winISteamNetworking_SteamNetworking002 *_this, int nVirtualP2PPort, uint32 nIP, uint16 nPort, bool bAllowUseOfPacketRelay)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking002_CreateListenSocket(_this->linux_side, nVirtualP2PPort, nIP, nPort, bAllowUseOfPacketRelay);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking002_CreateP2PConnectionSocket, 21)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking002_CreateP2PConnectionSocket, 24)
 SNetSocket_t __thiscall winISteamNetworking_SteamNetworking002_CreateP2PConnectionSocket(winISteamNetworking_SteamNetworking002 *_this, CSteamID steamIDTarget, int nVirtualPort, int nTimeoutSec, bool bAllowUseOfPacketRelay)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking002_CreateP2PConnectionSocket(_this->linux_side, steamIDTarget, nVirtualPort, nTimeoutSec, bAllowUseOfPacketRelay);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking002_CreateConnectionSocket, 14)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking002_CreateConnectionSocket, 16)
 SNetSocket_t __thiscall winISteamNetworking_SteamNetworking002_CreateConnectionSocket(winISteamNetworking_SteamNetworking002 *_this, uint32 nIP, uint16 nPort, int nTimeoutSec)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking002_CreateConnectionSocket(_this->linux_side, nIP, nPort, nTimeoutSec);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking002_DestroySocket, 9)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking002_DestroySocket, 12)
 bool __thiscall winISteamNetworking_SteamNetworking002_DestroySocket(winISteamNetworking_SteamNetworking002 *_this, SNetSocket_t hSocket, bool bNotifyRemoteEnd)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking002_DestroySocket(_this->linux_side, hSocket, bNotifyRemoteEnd);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking002_DestroyListenSocket, 9)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking002_DestroyListenSocket, 12)
 bool __thiscall winISteamNetworking_SteamNetworking002_DestroyListenSocket(winISteamNetworking_SteamNetworking002 *_this, SNetListenSocket_t hSocket, bool bNotifyRemoteEnd)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking002_DestroyListenSocket(_this->linux_side, hSocket, bNotifyRemoteEnd);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking002_SendDataOnSocket, 17)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking002_SendDataOnSocket, 20)
 bool __thiscall winISteamNetworking_SteamNetworking002_SendDataOnSocket(winISteamNetworking_SteamNetworking002 *_this, SNetSocket_t hSocket, void * pubData, uint32 cubData, bool bReliable)
 {
     TRACE("%p\n", _this);
@@ -736,7 +736,7 @@ typedef struct __winISteamNetworking_SteamNetworking001 {
     void *linux_side;
 } winISteamNetworking_SteamNetworking001;
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking001_CreateListenSocket, 14)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking001_CreateListenSocket, 16)
 SNetListenSocket_t __thiscall winISteamNetworking_SteamNetworking001_CreateListenSocket(winISteamNetworking_SteamNetworking001 *_this, int nVirtualP2PPort, uint32 nIP, uint16 nPort)
 {
     TRACE("%p\n", _this);
@@ -750,28 +750,28 @@ SNetSocket_t __thiscall winISteamNetworking_SteamNetworking001_CreateP2PConnecti
     return cppISteamNetworking_SteamNetworking001_CreateP2PConnectionSocket(_this->linux_side, steamIDTarget, nVirtualPort, nTimeoutSec);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking001_CreateConnectionSocket, 14)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking001_CreateConnectionSocket, 16)
 SNetSocket_t __thiscall winISteamNetworking_SteamNetworking001_CreateConnectionSocket(winISteamNetworking_SteamNetworking001 *_this, uint32 nIP, uint16 nPort, int nTimeoutSec)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking001_CreateConnectionSocket(_this->linux_side, nIP, nPort, nTimeoutSec);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking001_DestroySocket, 9)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking001_DestroySocket, 12)
 bool __thiscall winISteamNetworking_SteamNetworking001_DestroySocket(winISteamNetworking_SteamNetworking001 *_this, SNetSocket_t hSocket, bool bNotifyRemoteEnd)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking001_DestroySocket(_this->linux_side, hSocket, bNotifyRemoteEnd);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking001_DestroyListenSocket, 9)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking001_DestroyListenSocket, 12)
 bool __thiscall winISteamNetworking_SteamNetworking001_DestroyListenSocket(winISteamNetworking_SteamNetworking001 *_this, SNetListenSocket_t hSocket, bool bNotifyRemoteEnd)
 {
     TRACE("%p\n", _this);
     return cppISteamNetworking_SteamNetworking001_DestroyListenSocket(_this->linux_side, hSocket, bNotifyRemoteEnd);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking001_SendDataOnSocket, 17)
+DEFINE_THISCALL_WRAPPER(winISteamNetworking_SteamNetworking001_SendDataOnSocket, 20)
 bool __thiscall winISteamNetworking_SteamNetworking001_SendDataOnSocket(winISteamNetworking_SteamNetworking001 *_this, SNetSocket_t hSocket, void * pubData, uint32 cubData, bool bReliable)
 {
     TRACE("%p\n", _this);

--- a/lsteamclient/winISteamRemoteStorage.c
+++ b/lsteamclient/winISteamRemoteStorage.c
@@ -181,7 +181,7 @@ bool __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION014_I
     return cppISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION014_IsCloudEnabledForApp(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION014_SetCloudEnabledForApp, 5)
+DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION014_SetCloudEnabledForApp, 8)
 void __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION014_SetCloudEnabledForApp(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION014 *_this, bool bEnabled)
 {
     TRACE("%p\n", _this);
@@ -357,7 +357,7 @@ SteamAPICall_t __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VE
     return cppISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION014_GetPublishedItemVoteDetails(_this->linux_side, unPublishedFileId);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION014_UpdateUserPublishedItemVote, 13)
+DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION014_UpdateUserPublishedItemVote, 16)
 SteamAPICall_t __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION014_UpdateUserPublishedItemVote(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION014 *_this, PublishedFileId_t unPublishedFileId, bool bVoteUp)
 {
     TRACE("%p\n", _this);
@@ -660,7 +660,7 @@ bool __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION013_I
     return cppISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION013_IsCloudEnabledForApp(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION013_SetCloudEnabledForApp, 5)
+DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION013_SetCloudEnabledForApp, 8)
 void __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION013_SetCloudEnabledForApp(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION013 *_this, bool bEnabled)
 {
     TRACE("%p\n", _this);
@@ -836,7 +836,7 @@ SteamAPICall_t __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VE
     return cppISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION013_GetPublishedItemVoteDetails(_this->linux_side, unPublishedFileId);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION013_UpdateUserPublishedItemVote, 13)
+DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION013_UpdateUserPublishedItemVote, 16)
 SteamAPICall_t __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION013_UpdateUserPublishedItemVote(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION013 *_this, PublishedFileId_t unPublishedFileId, bool bVoteUp)
 {
     TRACE("%p\n", _this);
@@ -1118,7 +1118,7 @@ bool __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION012_I
     return cppISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION012_IsCloudEnabledForApp(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION012_SetCloudEnabledForApp, 5)
+DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION012_SetCloudEnabledForApp, 8)
 void __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION012_SetCloudEnabledForApp(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION012 *_this, bool bEnabled)
 {
     TRACE("%p\n", _this);
@@ -1294,7 +1294,7 @@ SteamAPICall_t __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VE
     return cppISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION012_GetPublishedItemVoteDetails(_this->linux_side, unPublishedFileId);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION012_UpdateUserPublishedItemVote, 13)
+DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION012_UpdateUserPublishedItemVote, 16)
 SteamAPICall_t __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION012_UpdateUserPublishedItemVote(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION012 *_this, PublishedFileId_t unPublishedFileId, bool bVoteUp)
 {
     TRACE("%p\n", _this);
@@ -1573,7 +1573,7 @@ bool __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION011_I
     return cppISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION011_IsCloudEnabledForApp(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION011_SetCloudEnabledForApp, 5)
+DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION011_SetCloudEnabledForApp, 8)
 void __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION011_SetCloudEnabledForApp(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION011 *_this, bool bEnabled)
 {
     TRACE("%p\n", _this);
@@ -1749,7 +1749,7 @@ SteamAPICall_t __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VE
     return cppISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION011_GetPublishedItemVoteDetails(_this->linux_side, unPublishedFileId);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION011_UpdateUserPublishedItemVote, 13)
+DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION011_UpdateUserPublishedItemVote, 16)
 SteamAPICall_t __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION011_UpdateUserPublishedItemVote(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION011 *_this, PublishedFileId_t unPublishedFileId, bool bVoteUp)
 {
     TRACE("%p\n", _this);
@@ -2028,7 +2028,7 @@ bool __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION010_I
     return cppISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION010_IsCloudEnabledForApp(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION010_SetCloudEnabledForApp, 5)
+DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION010_SetCloudEnabledForApp, 8)
 void __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION010_SetCloudEnabledForApp(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION010 *_this, bool bEnabled)
 {
     TRACE("%p\n", _this);
@@ -2204,7 +2204,7 @@ SteamAPICall_t __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VE
     return cppISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION010_GetPublishedItemVoteDetails(_this->linux_side, unPublishedFileId);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION010_UpdateUserPublishedItemVote, 13)
+DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION010_UpdateUserPublishedItemVote, 16)
 SteamAPICall_t __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION010_UpdateUserPublishedItemVote(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION010 *_this, PublishedFileId_t unPublishedFileId, bool bVoteUp)
 {
     TRACE("%p\n", _this);
@@ -2483,7 +2483,7 @@ bool __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION008_I
     return cppISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION008_IsCloudEnabledForApp(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION008_SetCloudEnabledForApp, 5)
+DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION008_SetCloudEnabledForApp, 8)
 void __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION008_SetCloudEnabledForApp(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION008 *_this, bool bEnabled)
 {
     TRACE("%p\n", _this);
@@ -2659,7 +2659,7 @@ SteamAPICall_t __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VE
     return cppISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION008_GetPublishedItemVoteDetails(_this->linux_side, unPublishedFileId);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION008_UpdateUserPublishedItemVote, 13)
+DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION008_UpdateUserPublishedItemVote, 16)
 SteamAPICall_t __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION008_UpdateUserPublishedItemVote(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION008 *_this, PublishedFileId_t unPublishedFileId, bool bVoteUp)
 {
     TRACE("%p\n", _this);
@@ -2900,7 +2900,7 @@ bool __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION006_I
     return cppISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION006_IsCloudEnabledForApp(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION006_SetCloudEnabledForApp, 5)
+DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION006_SetCloudEnabledForApp, 8)
 void __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION006_SetCloudEnabledForApp(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION006 *_this, bool bEnabled)
 {
     TRACE("%p\n", _this);
@@ -3076,7 +3076,7 @@ SteamAPICall_t __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VE
     return cppISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION006_GetPublishedItemVoteDetails(_this->linux_side, unPublishedFileId);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION006_UpdateUserPublishedItemVote, 13)
+DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION006_UpdateUserPublishedItemVote, 16)
 SteamAPICall_t __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION006_UpdateUserPublishedItemVote(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION006 *_this, PublishedFileId_t unPublishedFileId, bool bVoteUp)
 {
     TRACE("%p\n", _this);
@@ -3313,7 +3313,7 @@ bool __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION005_I
     return cppISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION005_IsCloudEnabledForApp(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION005_SetCloudEnabledForApp, 5)
+DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION005_SetCloudEnabledForApp, 8)
 void __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION005_SetCloudEnabledForApp(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION005 *_this, bool bEnabled)
 {
     TRACE("%p\n", _this);
@@ -3592,7 +3592,7 @@ bool __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION004_I
     return cppISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION004_IsCloudEnabledForApp(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION004_SetCloudEnabledForApp, 5)
+DEFINE_THISCALL_WRAPPER(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION004_SetCloudEnabledForApp, 8)
 void __thiscall winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION004_SetCloudEnabledForApp(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION004 *_this, bool bEnabled)
 {
     TRACE("%p\n", _this);

--- a/lsteamclient/winISteamScreenshots.c
+++ b/lsteamclient/winISteamScreenshots.c
@@ -45,7 +45,7 @@ void __thiscall winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION003_Trigg
     cppISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION003_TriggerScreenshot(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION003_HookScreenshots, 5)
+DEFINE_THISCALL_WRAPPER(winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION003_HookScreenshots, 8)
 void __thiscall winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION003_HookScreenshots(winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION003 *_this, bool bHook)
 {
     TRACE("%p\n", _this);
@@ -152,7 +152,7 @@ void __thiscall winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION002_Trigg
     cppISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION002_TriggerScreenshot(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION002_HookScreenshots, 5)
+DEFINE_THISCALL_WRAPPER(winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION002_HookScreenshots, 8)
 void __thiscall winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION002_HookScreenshots(winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION002 *_this, bool bHook)
 {
     TRACE("%p\n", _this);
@@ -239,7 +239,7 @@ void __thiscall winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION001_Trigg
     cppISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION001_TriggerScreenshot(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION001_HookScreenshots, 5)
+DEFINE_THISCALL_WRAPPER(winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION001_HookScreenshots, 8)
 void __thiscall winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION001_HookScreenshots(winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION001 *_this, bool bHook)
 {
     TRACE("%p\n", _this);

--- a/lsteamclient/winISteamUGC.c
+++ b/lsteamclient/winISteamUGC.c
@@ -132,49 +132,49 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION010_AddExcludedTag(winISt
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION010_AddExcludedTag(_this->linux_side, handle, pTagName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnOnlyIDs, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnOnlyIDs, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnOnlyIDs(winISteamUGC_STEAMUGC_INTERFACE_VERSION010 *_this, UGCQueryHandle_t handle, bool bReturnOnlyIDs)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnOnlyIDs(_this->linux_side, handle, bReturnOnlyIDs);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnKeyValueTags, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnKeyValueTags, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnKeyValueTags(winISteamUGC_STEAMUGC_INTERFACE_VERSION010 *_this, UGCQueryHandle_t handle, bool bReturnKeyValueTags)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnKeyValueTags(_this->linux_side, handle, bReturnKeyValueTags);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnLongDescription, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnLongDescription, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnLongDescription(winISteamUGC_STEAMUGC_INTERFACE_VERSION010 *_this, UGCQueryHandle_t handle, bool bReturnLongDescription)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnLongDescription(_this->linux_side, handle, bReturnLongDescription);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnMetadata, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnMetadata, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnMetadata(winISteamUGC_STEAMUGC_INTERFACE_VERSION010 *_this, UGCQueryHandle_t handle, bool bReturnMetadata)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnMetadata(_this->linux_side, handle, bReturnMetadata);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnChildren, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnChildren, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnChildren(winISteamUGC_STEAMUGC_INTERFACE_VERSION010 *_this, UGCQueryHandle_t handle, bool bReturnChildren)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnChildren(_this->linux_side, handle, bReturnChildren);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnAdditionalPreviews, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnAdditionalPreviews, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnAdditionalPreviews(winISteamUGC_STEAMUGC_INTERFACE_VERSION010 *_this, UGCQueryHandle_t handle, bool bReturnAdditionalPreviews)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnAdditionalPreviews(_this->linux_side, handle, bReturnAdditionalPreviews);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnTotalOnly, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnTotalOnly, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetReturnTotalOnly(winISteamUGC_STEAMUGC_INTERFACE_VERSION010 *_this, UGCQueryHandle_t handle, bool bReturnTotalOnly)
 {
     TRACE("%p\n", _this);
@@ -209,7 +209,7 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetCloudFileNameFilte
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetCloudFileNameFilter(_this->linux_side, handle, pMatchCloudFileName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetMatchAnyTag, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetMatchAnyTag, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetMatchAnyTag(winISteamUGC_STEAMUGC_INTERFACE_VERSION010 *_this, UGCQueryHandle_t handle, bool bMatchAnyTag)
 {
     TRACE("%p\n", _this);
@@ -385,7 +385,7 @@ EItemUpdateStatus __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION010_GetItemU
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION010_GetItemUpdateProgress(_this->linux_side, handle, punBytesProcessed, punBytesTotal);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetUserItemVote, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetUserItemVote, 16)
 SteamAPICall_t __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SetUserItemVote(winISteamUGC_STEAMUGC_INTERFACE_VERSION010 *_this, PublishedFileId_t nPublishedFileID, bool bVoteUp)
 {
     TRACE("%p\n", _this);
@@ -465,7 +465,7 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION010_GetItemDownloadInfo(w
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION010_GetItemDownloadInfo(_this->linux_side, nPublishedFileID, punBytesDownloaded, punBytesTotal);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_DownloadItem, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_DownloadItem, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION010_DownloadItem(winISteamUGC_STEAMUGC_INTERFACE_VERSION010 *_this, PublishedFileId_t nPublishedFileID, bool bHighPriority)
 {
     TRACE("%p\n", _this);
@@ -481,7 +481,7 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION010_BInitWorkshopForGameS
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION010_BInitWorkshopForGameServer(_this->linux_side, unWorkshopDepotID, pszFolder ? lin_pszFolder : NULL);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SuspendDownloads, 5)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SuspendDownloads, 8)
 void __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION010_SuspendDownloads(winISteamUGC_STEAMUGC_INTERFACE_VERSION010 *_this, bool bSuspend)
 {
     TRACE("%p\n", _this);
@@ -764,49 +764,49 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION009_AddExcludedTag(winISt
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION009_AddExcludedTag(_this->linux_side, handle, pTagName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnOnlyIDs, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnOnlyIDs, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnOnlyIDs(winISteamUGC_STEAMUGC_INTERFACE_VERSION009 *_this, UGCQueryHandle_t handle, bool bReturnOnlyIDs)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnOnlyIDs(_this->linux_side, handle, bReturnOnlyIDs);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnKeyValueTags, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnKeyValueTags, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnKeyValueTags(winISteamUGC_STEAMUGC_INTERFACE_VERSION009 *_this, UGCQueryHandle_t handle, bool bReturnKeyValueTags)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnKeyValueTags(_this->linux_side, handle, bReturnKeyValueTags);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnLongDescription, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnLongDescription, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnLongDescription(winISteamUGC_STEAMUGC_INTERFACE_VERSION009 *_this, UGCQueryHandle_t handle, bool bReturnLongDescription)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnLongDescription(_this->linux_side, handle, bReturnLongDescription);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnMetadata, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnMetadata, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnMetadata(winISteamUGC_STEAMUGC_INTERFACE_VERSION009 *_this, UGCQueryHandle_t handle, bool bReturnMetadata)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnMetadata(_this->linux_side, handle, bReturnMetadata);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnChildren, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnChildren, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnChildren(winISteamUGC_STEAMUGC_INTERFACE_VERSION009 *_this, UGCQueryHandle_t handle, bool bReturnChildren)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnChildren(_this->linux_side, handle, bReturnChildren);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnAdditionalPreviews, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnAdditionalPreviews, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnAdditionalPreviews(winISteamUGC_STEAMUGC_INTERFACE_VERSION009 *_this, UGCQueryHandle_t handle, bool bReturnAdditionalPreviews)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnAdditionalPreviews(_this->linux_side, handle, bReturnAdditionalPreviews);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnTotalOnly, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnTotalOnly, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetReturnTotalOnly(winISteamUGC_STEAMUGC_INTERFACE_VERSION009 *_this, UGCQueryHandle_t handle, bool bReturnTotalOnly)
 {
     TRACE("%p\n", _this);
@@ -834,7 +834,7 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetCloudFileNameFilte
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetCloudFileNameFilter(_this->linux_side, handle, pMatchCloudFileName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetMatchAnyTag, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetMatchAnyTag, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetMatchAnyTag(winISteamUGC_STEAMUGC_INTERFACE_VERSION009 *_this, UGCQueryHandle_t handle, bool bMatchAnyTag)
 {
     TRACE("%p\n", _this);
@@ -1010,7 +1010,7 @@ EItemUpdateStatus __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION009_GetItemU
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION009_GetItemUpdateProgress(_this->linux_side, handle, punBytesProcessed, punBytesTotal);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetUserItemVote, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetUserItemVote, 16)
 SteamAPICall_t __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SetUserItemVote(winISteamUGC_STEAMUGC_INTERFACE_VERSION009 *_this, PublishedFileId_t nPublishedFileID, bool bVoteUp)
 {
     TRACE("%p\n", _this);
@@ -1090,7 +1090,7 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION009_GetItemDownloadInfo(w
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION009_GetItemDownloadInfo(_this->linux_side, nPublishedFileID, punBytesDownloaded, punBytesTotal);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_DownloadItem, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_DownloadItem, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION009_DownloadItem(winISteamUGC_STEAMUGC_INTERFACE_VERSION009 *_this, PublishedFileId_t nPublishedFileID, bool bHighPriority)
 {
     TRACE("%p\n", _this);
@@ -1106,7 +1106,7 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION009_BInitWorkshopForGameS
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION009_BInitWorkshopForGameServer(_this->linux_side, unWorkshopDepotID, pszFolder ? lin_pszFolder : NULL);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SuspendDownloads, 5)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SuspendDownloads, 8)
 void __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION009_SuspendDownloads(winISteamUGC_STEAMUGC_INTERFACE_VERSION009 *_this, bool bSuspend)
 {
     TRACE("%p\n", _this);
@@ -1340,42 +1340,42 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION008_AddExcludedTag(winISt
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION008_AddExcludedTag(_this->linux_side, handle, pTagName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnKeyValueTags, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnKeyValueTags, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnKeyValueTags(winISteamUGC_STEAMUGC_INTERFACE_VERSION008 *_this, UGCQueryHandle_t handle, bool bReturnKeyValueTags)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnKeyValueTags(_this->linux_side, handle, bReturnKeyValueTags);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnLongDescription, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnLongDescription, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnLongDescription(winISteamUGC_STEAMUGC_INTERFACE_VERSION008 *_this, UGCQueryHandle_t handle, bool bReturnLongDescription)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnLongDescription(_this->linux_side, handle, bReturnLongDescription);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnMetadata, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnMetadata, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnMetadata(winISteamUGC_STEAMUGC_INTERFACE_VERSION008 *_this, UGCQueryHandle_t handle, bool bReturnMetadata)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnMetadata(_this->linux_side, handle, bReturnMetadata);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnChildren, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnChildren, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnChildren(winISteamUGC_STEAMUGC_INTERFACE_VERSION008 *_this, UGCQueryHandle_t handle, bool bReturnChildren)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnChildren(_this->linux_side, handle, bReturnChildren);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnAdditionalPreviews, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnAdditionalPreviews, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnAdditionalPreviews(winISteamUGC_STEAMUGC_INTERFACE_VERSION008 *_this, UGCQueryHandle_t handle, bool bReturnAdditionalPreviews)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnAdditionalPreviews(_this->linux_side, handle, bReturnAdditionalPreviews);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnTotalOnly, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnTotalOnly, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetReturnTotalOnly(winISteamUGC_STEAMUGC_INTERFACE_VERSION008 *_this, UGCQueryHandle_t handle, bool bReturnTotalOnly)
 {
     TRACE("%p\n", _this);
@@ -1403,7 +1403,7 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetCloudFileNameFilte
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetCloudFileNameFilter(_this->linux_side, handle, pMatchCloudFileName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetMatchAnyTag, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetMatchAnyTag, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetMatchAnyTag(winISteamUGC_STEAMUGC_INTERFACE_VERSION008 *_this, UGCQueryHandle_t handle, bool bMatchAnyTag)
 {
     TRACE("%p\n", _this);
@@ -1579,7 +1579,7 @@ EItemUpdateStatus __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION008_GetItemU
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION008_GetItemUpdateProgress(_this->linux_side, handle, punBytesProcessed, punBytesTotal);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetUserItemVote, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetUserItemVote, 16)
 SteamAPICall_t __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SetUserItemVote(winISteamUGC_STEAMUGC_INTERFACE_VERSION008 *_this, PublishedFileId_t nPublishedFileID, bool bVoteUp)
 {
     TRACE("%p\n", _this);
@@ -1659,7 +1659,7 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION008_GetItemDownloadInfo(w
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION008_GetItemDownloadInfo(_this->linux_side, nPublishedFileID, punBytesDownloaded, punBytesTotal);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION008_DownloadItem, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION008_DownloadItem, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION008_DownloadItem(winISteamUGC_STEAMUGC_INTERFACE_VERSION008 *_this, PublishedFileId_t nPublishedFileID, bool bHighPriority)
 {
     TRACE("%p\n", _this);
@@ -1675,7 +1675,7 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION008_BInitWorkshopForGameS
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION008_BInitWorkshopForGameServer(_this->linux_side, unWorkshopDepotID, pszFolder ? lin_pszFolder : NULL);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SuspendDownloads, 5)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SuspendDownloads, 8)
 void __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION008_SuspendDownloads(winISteamUGC_STEAMUGC_INTERFACE_VERSION008 *_this, bool bSuspend)
 {
     TRACE("%p\n", _this);
@@ -1884,42 +1884,42 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION007_AddExcludedTag(winISt
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION007_AddExcludedTag(_this->linux_side, handle, pTagName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnKeyValueTags, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnKeyValueTags, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnKeyValueTags(winISteamUGC_STEAMUGC_INTERFACE_VERSION007 *_this, UGCQueryHandle_t handle, bool bReturnKeyValueTags)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnKeyValueTags(_this->linux_side, handle, bReturnKeyValueTags);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnLongDescription, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnLongDescription, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnLongDescription(winISteamUGC_STEAMUGC_INTERFACE_VERSION007 *_this, UGCQueryHandle_t handle, bool bReturnLongDescription)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnLongDescription(_this->linux_side, handle, bReturnLongDescription);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnMetadata, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnMetadata, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnMetadata(winISteamUGC_STEAMUGC_INTERFACE_VERSION007 *_this, UGCQueryHandle_t handle, bool bReturnMetadata)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnMetadata(_this->linux_side, handle, bReturnMetadata);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnChildren, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnChildren, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnChildren(winISteamUGC_STEAMUGC_INTERFACE_VERSION007 *_this, UGCQueryHandle_t handle, bool bReturnChildren)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnChildren(_this->linux_side, handle, bReturnChildren);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnAdditionalPreviews, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnAdditionalPreviews, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnAdditionalPreviews(winISteamUGC_STEAMUGC_INTERFACE_VERSION007 *_this, UGCQueryHandle_t handle, bool bReturnAdditionalPreviews)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnAdditionalPreviews(_this->linux_side, handle, bReturnAdditionalPreviews);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnTotalOnly, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnTotalOnly, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetReturnTotalOnly(winISteamUGC_STEAMUGC_INTERFACE_VERSION007 *_this, UGCQueryHandle_t handle, bool bReturnTotalOnly)
 {
     TRACE("%p\n", _this);
@@ -1947,7 +1947,7 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetCloudFileNameFilte
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetCloudFileNameFilter(_this->linux_side, handle, pMatchCloudFileName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetMatchAnyTag, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetMatchAnyTag, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetMatchAnyTag(winISteamUGC_STEAMUGC_INTERFACE_VERSION007 *_this, UGCQueryHandle_t handle, bool bMatchAnyTag)
 {
     TRACE("%p\n", _this);
@@ -2084,7 +2084,7 @@ EItemUpdateStatus __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION007_GetItemU
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION007_GetItemUpdateProgress(_this->linux_side, handle, punBytesProcessed, punBytesTotal);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetUserItemVote, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetUserItemVote, 16)
 SteamAPICall_t __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SetUserItemVote(winISteamUGC_STEAMUGC_INTERFACE_VERSION007 *_this, PublishedFileId_t nPublishedFileID, bool bVoteUp)
 {
     TRACE("%p\n", _this);
@@ -2164,7 +2164,7 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION007_GetItemDownloadInfo(w
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION007_GetItemDownloadInfo(_this->linux_side, nPublishedFileID, punBytesDownloaded, punBytesTotal);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION007_DownloadItem, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION007_DownloadItem, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION007_DownloadItem(winISteamUGC_STEAMUGC_INTERFACE_VERSION007 *_this, PublishedFileId_t nPublishedFileID, bool bHighPriority)
 {
     TRACE("%p\n", _this);
@@ -2180,7 +2180,7 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION007_BInitWorkshopForGameS
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION007_BInitWorkshopForGameServer(_this->linux_side, unWorkshopDepotID, pszFolder ? lin_pszFolder : NULL);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SuspendDownloads, 5)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SuspendDownloads, 8)
 void __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION007_SuspendDownloads(winISteamUGC_STEAMUGC_INTERFACE_VERSION007 *_this, bool bSuspend)
 {
     TRACE("%p\n", _this);
@@ -2370,35 +2370,35 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION005_AddExcludedTag(winISt
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION005_AddExcludedTag(_this->linux_side, handle, pTagName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetReturnLongDescription, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetReturnLongDescription, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetReturnLongDescription(winISteamUGC_STEAMUGC_INTERFACE_VERSION005 *_this, UGCQueryHandle_t handle, bool bReturnLongDescription)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetReturnLongDescription(_this->linux_side, handle, bReturnLongDescription);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetReturnMetadata, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetReturnMetadata, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetReturnMetadata(winISteamUGC_STEAMUGC_INTERFACE_VERSION005 *_this, UGCQueryHandle_t handle, bool bReturnMetadata)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetReturnMetadata(_this->linux_side, handle, bReturnMetadata);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetReturnChildren, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetReturnChildren, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetReturnChildren(winISteamUGC_STEAMUGC_INTERFACE_VERSION005 *_this, UGCQueryHandle_t handle, bool bReturnChildren)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetReturnChildren(_this->linux_side, handle, bReturnChildren);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetReturnAdditionalPreviews, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetReturnAdditionalPreviews, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetReturnAdditionalPreviews(winISteamUGC_STEAMUGC_INTERFACE_VERSION005 *_this, UGCQueryHandle_t handle, bool bReturnAdditionalPreviews)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetReturnAdditionalPreviews(_this->linux_side, handle, bReturnAdditionalPreviews);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetReturnTotalOnly, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetReturnTotalOnly, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetReturnTotalOnly(winISteamUGC_STEAMUGC_INTERFACE_VERSION005 *_this, UGCQueryHandle_t handle, bool bReturnTotalOnly)
 {
     TRACE("%p\n", _this);
@@ -2419,7 +2419,7 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetCloudFileNameFilte
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetCloudFileNameFilter(_this->linux_side, handle, pMatchCloudFileName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetMatchAnyTag, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetMatchAnyTag, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION005_SetMatchAnyTag(winISteamUGC_STEAMUGC_INTERFACE_VERSION005 *_this, UGCQueryHandle_t handle, bool bMatchAnyTag)
 {
     TRACE("%p\n", _this);
@@ -2594,7 +2594,7 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION005_GetItemDownloadInfo(w
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION005_GetItemDownloadInfo(_this->linux_side, nPublishedFileID, punBytesDownloaded, punBytesTotal);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION005_DownloadItem, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION005_DownloadItem, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION005_DownloadItem(winISteamUGC_STEAMUGC_INTERFACE_VERSION005 *_this, PublishedFileId_t nPublishedFileID, bool bHighPriority)
 {
     TRACE("%p\n", _this);
@@ -2723,14 +2723,14 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION003_AddExcludedTag(winISt
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION003_AddExcludedTag(_this->linux_side, handle, pTagName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION003_SetReturnLongDescription, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION003_SetReturnLongDescription, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION003_SetReturnLongDescription(winISteamUGC_STEAMUGC_INTERFACE_VERSION003 *_this, UGCQueryHandle_t handle, bool bReturnLongDescription)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION003_SetReturnLongDescription(_this->linux_side, handle, bReturnLongDescription);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION003_SetReturnTotalOnly, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION003_SetReturnTotalOnly, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION003_SetReturnTotalOnly(winISteamUGC_STEAMUGC_INTERFACE_VERSION003 *_this, UGCQueryHandle_t handle, bool bReturnTotalOnly)
 {
     TRACE("%p\n", _this);
@@ -2751,7 +2751,7 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION003_SetCloudFileNameFilte
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION003_SetCloudFileNameFilter(_this->linux_side, handle, pMatchCloudFileName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION003_SetMatchAnyTag, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION003_SetMatchAnyTag, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION003_SetMatchAnyTag(winISteamUGC_STEAMUGC_INTERFACE_VERSION003 *_this, UGCQueryHandle_t handle, bool bMatchAnyTag)
 {
     TRACE("%p\n", _this);
@@ -3005,14 +3005,14 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION002_AddExcludedTag(winISt
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION002_AddExcludedTag(_this->linux_side, handle, pTagName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION002_SetReturnLongDescription, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION002_SetReturnLongDescription, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION002_SetReturnLongDescription(winISteamUGC_STEAMUGC_INTERFACE_VERSION002 *_this, UGCQueryHandle_t handle, bool bReturnLongDescription)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION002_SetReturnLongDescription(_this->linux_side, handle, bReturnLongDescription);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION002_SetReturnTotalOnly, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION002_SetReturnTotalOnly, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION002_SetReturnTotalOnly(winISteamUGC_STEAMUGC_INTERFACE_VERSION002 *_this, UGCQueryHandle_t handle, bool bReturnTotalOnly)
 {
     TRACE("%p\n", _this);
@@ -3033,7 +3033,7 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION002_SetCloudFileNameFilte
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION002_SetCloudFileNameFilter(_this->linux_side, handle, pMatchCloudFileName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION002_SetMatchAnyTag, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION002_SetMatchAnyTag, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION002_SetMatchAnyTag(winISteamUGC_STEAMUGC_INTERFACE_VERSION002 *_this, UGCQueryHandle_t handle, bool bMatchAnyTag)
 {
     TRACE("%p\n", _this);
@@ -3287,14 +3287,14 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION001_AddExcludedTag(winISt
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION001_AddExcludedTag(_this->linux_side, handle, pTagName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION001_SetReturnLongDescription, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION001_SetReturnLongDescription, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION001_SetReturnLongDescription(winISteamUGC_STEAMUGC_INTERFACE_VERSION001 *_this, UGCQueryHandle_t handle, bool bReturnLongDescription)
 {
     TRACE("%p\n", _this);
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION001_SetReturnLongDescription(_this->linux_side, handle, bReturnLongDescription);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION001_SetReturnTotalOnly, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION001_SetReturnTotalOnly, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION001_SetReturnTotalOnly(winISteamUGC_STEAMUGC_INTERFACE_VERSION001 *_this, UGCQueryHandle_t handle, bool bReturnTotalOnly)
 {
     TRACE("%p\n", _this);
@@ -3308,7 +3308,7 @@ bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION001_SetCloudFileNameFilte
     return cppISteamUGC_STEAMUGC_INTERFACE_VERSION001_SetCloudFileNameFilter(_this->linux_side, handle, pMatchCloudFileName);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION001_SetMatchAnyTag, 13)
+DEFINE_THISCALL_WRAPPER(winISteamUGC_STEAMUGC_INTERFACE_VERSION001_SetMatchAnyTag, 16)
 bool __thiscall winISteamUGC_STEAMUGC_INTERFACE_VERSION001_SetMatchAnyTag(winISteamUGC_STEAMUGC_INTERFACE_VERSION001 *_this, UGCQueryHandle_t handle, bool bMatchAnyTag)
 {
     TRACE("%p\n", _this);

--- a/lsteamclient/winISteamUnifiedMessages.c
+++ b/lsteamclient/winISteamUnifiedMessages.c
@@ -34,7 +34,7 @@ bool __thiscall winISteamUnifiedMessages_STEAMUNIFIEDMESSAGES_INTERFACE_VERSION0
     return cppISteamUnifiedMessages_STEAMUNIFIEDMESSAGES_INTERFACE_VERSION001_GetMethodResponseInfo(_this->linux_side, hHandle, punResponseSize, peResult);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUnifiedMessages_STEAMUNIFIEDMESSAGES_INTERFACE_VERSION001_GetMethodResponseData, 21)
+DEFINE_THISCALL_WRAPPER(winISteamUnifiedMessages_STEAMUNIFIEDMESSAGES_INTERFACE_VERSION001_GetMethodResponseData, 24)
 bool __thiscall winISteamUnifiedMessages_STEAMUNIFIEDMESSAGES_INTERFACE_VERSION001_GetMethodResponseData(winISteamUnifiedMessages_STEAMUNIFIEDMESSAGES_INTERFACE_VERSION001 *_this, ClientUnifiedMessageHandle hHandle, void * pResponseBuffer, uint32 unResponseBufferSize, bool bAutoRelease)
 {
     TRACE("%p\n", _this);

--- a/lsteamclient/winISteamUser.c
+++ b/lsteamclient/winISteamUser.c
@@ -42,14 +42,14 @@ CSteamID *__thiscall winISteamUser_SteamUser019_GetSteamID(winISteamUser_SteamUs
     return _r;
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser019_InitiateGameConnection, 27)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser019_InitiateGameConnection, 32)
 int __thiscall winISteamUser_SteamUser019_InitiateGameConnection(winISteamUser_SteamUser019 *_this, void * pAuthBlob, int cbMaxAuthBlob, CSteamID steamIDGameServer, uint32 unIPServer, uint16 usPortServer, bool bSecure)
 {
     TRACE("%p\n", _this);
     return cppISteamUser_SteamUser019_InitiateGameConnection(_this->linux_side, pAuthBlob, cbMaxAuthBlob, steamIDGameServer, unIPServer, usPortServer, bSecure);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser019_TerminateGameConnection, 10)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser019_TerminateGameConnection, 12)
 void __thiscall winISteamUser_SteamUser019_TerminateGameConnection(winISteamUser_SteamUser019 *_this, uint32 unIPServer, uint16 usPortServer)
 {
     TRACE("%p\n", _this);
@@ -94,7 +94,7 @@ EVoiceResult __thiscall winISteamUser_SteamUser019_GetAvailableVoice(winISteamUs
     return cppISteamUser_SteamUser019_GetAvailableVoice(_this->linux_side, pcbCompressed, pcbUncompressed_Deprecated, nUncompressedVoiceDesiredSampleRate_Deprecated);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser019_GetVoice, 34)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser019_GetVoice, 40)
 EVoiceResult __thiscall winISteamUser_SteamUser019_GetVoice(winISteamUser_SteamUser019 *_this, bool bWantCompressed, void * pDestBuffer, uint32 cbDestBufferSize, uint32 * nBytesWritten, bool bWantUncompressed_Deprecated, void * pUncompressedDestBuffer_Deprecated, uint32 cbUncompressedDestBufferSize_Deprecated, uint32 * nUncompressBytesWritten_Deprecated, uint32 nUncompressedVoiceDesiredSampleRate_Deprecated)
 {
     TRACE("%p\n", _this);
@@ -157,7 +157,7 @@ bool __thiscall winISteamUser_SteamUser019_BIsBehindNAT(winISteamUser_SteamUser0
     return cppISteamUser_SteamUser019_BIsBehindNAT(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser019_AdvertiseGame, 18)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser019_AdvertiseGame, 20)
 void __thiscall winISteamUser_SteamUser019_AdvertiseGame(winISteamUser_SteamUser019 *_this, CSteamID steamIDGameServer, uint32 unIPServer, uint16 usPortServer)
 {
     TRACE("%p\n", _this);
@@ -178,7 +178,7 @@ bool __thiscall winISteamUser_SteamUser019_GetEncryptedAppTicket(winISteamUser_S
     return cppISteamUser_SteamUser019_GetEncryptedAppTicket(_this->linux_side, pTicket, cbMaxTicket, pcbTicket);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser019_GetGameBadgeLevel, 9)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser019_GetGameBadgeLevel, 12)
 int __thiscall winISteamUser_SteamUser019_GetGameBadgeLevel(winISteamUser_SteamUser019 *_this, int nSeries, bool bFoil)
 {
     TRACE("%p\n", _this);
@@ -305,14 +305,14 @@ CSteamID *__thiscall winISteamUser_SteamUser018_GetSteamID(winISteamUser_SteamUs
     return _r;
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser018_InitiateGameConnection, 27)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser018_InitiateGameConnection, 32)
 int __thiscall winISteamUser_SteamUser018_InitiateGameConnection(winISteamUser_SteamUser018 *_this, void * pAuthBlob, int cbMaxAuthBlob, CSteamID steamIDGameServer, uint32 unIPServer, uint16 usPortServer, bool bSecure)
 {
     TRACE("%p\n", _this);
     return cppISteamUser_SteamUser018_InitiateGameConnection(_this->linux_side, pAuthBlob, cbMaxAuthBlob, steamIDGameServer, unIPServer, usPortServer, bSecure);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser018_TerminateGameConnection, 10)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser018_TerminateGameConnection, 12)
 void __thiscall winISteamUser_SteamUser018_TerminateGameConnection(winISteamUser_SteamUser018 *_this, uint32 unIPServer, uint16 usPortServer)
 {
     TRACE("%p\n", _this);
@@ -357,7 +357,7 @@ EVoiceResult __thiscall winISteamUser_SteamUser018_GetAvailableVoice(winISteamUs
     return cppISteamUser_SteamUser018_GetAvailableVoice(_this->linux_side, pcbCompressed, pcbUncompressed, nUncompressedVoiceDesiredSampleRate);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser018_GetVoice, 34)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser018_GetVoice, 40)
 EVoiceResult __thiscall winISteamUser_SteamUser018_GetVoice(winISteamUser_SteamUser018 *_this, bool bWantCompressed, void * pDestBuffer, uint32 cbDestBufferSize, uint32 * nBytesWritten, bool bWantUncompressed, void * pUncompressedDestBuffer, uint32 cbUncompressedDestBufferSize, uint32 * nUncompressBytesWritten, uint32 nUncompressedVoiceDesiredSampleRate)
 {
     TRACE("%p\n", _this);
@@ -420,7 +420,7 @@ bool __thiscall winISteamUser_SteamUser018_BIsBehindNAT(winISteamUser_SteamUser0
     return cppISteamUser_SteamUser018_BIsBehindNAT(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser018_AdvertiseGame, 18)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser018_AdvertiseGame, 20)
 void __thiscall winISteamUser_SteamUser018_AdvertiseGame(winISteamUser_SteamUser018 *_this, CSteamID steamIDGameServer, uint32 unIPServer, uint16 usPortServer)
 {
     TRACE("%p\n", _this);
@@ -441,7 +441,7 @@ bool __thiscall winISteamUser_SteamUser018_GetEncryptedAppTicket(winISteamUser_S
     return cppISteamUser_SteamUser018_GetEncryptedAppTicket(_this->linux_side, pTicket, cbMaxTicket, pcbTicket);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser018_GetGameBadgeLevel, 9)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser018_GetGameBadgeLevel, 12)
 int __thiscall winISteamUser_SteamUser018_GetGameBadgeLevel(winISteamUser_SteamUser018 *_this, int nSeries, bool bFoil)
 {
     TRACE("%p\n", _this);
@@ -536,14 +536,14 @@ CSteamID *__thiscall winISteamUser_SteamUser017_GetSteamID(winISteamUser_SteamUs
     return _r;
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser017_InitiateGameConnection, 27)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser017_InitiateGameConnection, 32)
 int __thiscall winISteamUser_SteamUser017_InitiateGameConnection(winISteamUser_SteamUser017 *_this, void * pAuthBlob, int cbMaxAuthBlob, CSteamID steamIDGameServer, uint32 unIPServer, uint16 usPortServer, bool bSecure)
 {
     TRACE("%p\n", _this);
     return cppISteamUser_SteamUser017_InitiateGameConnection(_this->linux_side, pAuthBlob, cbMaxAuthBlob, steamIDGameServer, unIPServer, usPortServer, bSecure);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser017_TerminateGameConnection, 10)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser017_TerminateGameConnection, 12)
 void __thiscall winISteamUser_SteamUser017_TerminateGameConnection(winISteamUser_SteamUser017 *_this, uint32 unIPServer, uint16 usPortServer)
 {
     TRACE("%p\n", _this);
@@ -588,7 +588,7 @@ EVoiceResult __thiscall winISteamUser_SteamUser017_GetAvailableVoice(winISteamUs
     return cppISteamUser_SteamUser017_GetAvailableVoice(_this->linux_side, pcbCompressed, pcbUncompressed, nUncompressedVoiceDesiredSampleRate);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser017_GetVoice, 34)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser017_GetVoice, 40)
 EVoiceResult __thiscall winISteamUser_SteamUser017_GetVoice(winISteamUser_SteamUser017 *_this, bool bWantCompressed, void * pDestBuffer, uint32 cbDestBufferSize, uint32 * nBytesWritten, bool bWantUncompressed, void * pUncompressedDestBuffer, uint32 cbUncompressedDestBufferSize, uint32 * nUncompressBytesWritten, uint32 nUncompressedVoiceDesiredSampleRate)
 {
     TRACE("%p\n", _this);
@@ -651,7 +651,7 @@ bool __thiscall winISteamUser_SteamUser017_BIsBehindNAT(winISteamUser_SteamUser0
     return cppISteamUser_SteamUser017_BIsBehindNAT(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser017_AdvertiseGame, 18)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser017_AdvertiseGame, 20)
 void __thiscall winISteamUser_SteamUser017_AdvertiseGame(winISteamUser_SteamUser017 *_this, CSteamID steamIDGameServer, uint32 unIPServer, uint16 usPortServer)
 {
     TRACE("%p\n", _this);
@@ -672,7 +672,7 @@ bool __thiscall winISteamUser_SteamUser017_GetEncryptedAppTicket(winISteamUser_S
     return cppISteamUser_SteamUser017_GetEncryptedAppTicket(_this->linux_side, pTicket, cbMaxTicket, pcbTicket);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser017_GetGameBadgeLevel, 9)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser017_GetGameBadgeLevel, 12)
 int __thiscall winISteamUser_SteamUser017_GetGameBadgeLevel(winISteamUser_SteamUser017 *_this, int nSeries, bool bFoil)
 {
     TRACE("%p\n", _this);
@@ -759,14 +759,14 @@ CSteamID *__thiscall winISteamUser_SteamUser016_GetSteamID(winISteamUser_SteamUs
     return _r;
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser016_InitiateGameConnection, 27)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser016_InitiateGameConnection, 32)
 int __thiscall winISteamUser_SteamUser016_InitiateGameConnection(winISteamUser_SteamUser016 *_this, void * pAuthBlob, int cbMaxAuthBlob, CSteamID steamIDGameServer, uint32 unIPServer, uint16 usPortServer, bool bSecure)
 {
     TRACE("%p\n", _this);
     return cppISteamUser_SteamUser016_InitiateGameConnection(_this->linux_side, pAuthBlob, cbMaxAuthBlob, steamIDGameServer, unIPServer, usPortServer, bSecure);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser016_TerminateGameConnection, 10)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser016_TerminateGameConnection, 12)
 void __thiscall winISteamUser_SteamUser016_TerminateGameConnection(winISteamUser_SteamUser016 *_this, uint32 unIPServer, uint16 usPortServer)
 {
     TRACE("%p\n", _this);
@@ -811,7 +811,7 @@ EVoiceResult __thiscall winISteamUser_SteamUser016_GetAvailableVoice(winISteamUs
     return cppISteamUser_SteamUser016_GetAvailableVoice(_this->linux_side, pcbCompressed, pcbUncompressed, nUncompressedVoiceDesiredSampleRate);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser016_GetVoice, 34)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser016_GetVoice, 40)
 EVoiceResult __thiscall winISteamUser_SteamUser016_GetVoice(winISteamUser_SteamUser016 *_this, bool bWantCompressed, void * pDestBuffer, uint32 cbDestBufferSize, uint32 * nBytesWritten, bool bWantUncompressed, void * pUncompressedDestBuffer, uint32 cbUncompressedDestBufferSize, uint32 * nUncompressBytesWritten, uint32 nUncompressedVoiceDesiredSampleRate)
 {
     TRACE("%p\n", _this);
@@ -874,7 +874,7 @@ bool __thiscall winISteamUser_SteamUser016_BIsBehindNAT(winISteamUser_SteamUser0
     return cppISteamUser_SteamUser016_BIsBehindNAT(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser016_AdvertiseGame, 18)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser016_AdvertiseGame, 20)
 void __thiscall winISteamUser_SteamUser016_AdvertiseGame(winISteamUser_SteamUser016 *_this, CSteamID steamIDGameServer, uint32 unIPServer, uint16 usPortServer)
 {
     TRACE("%p\n", _this);
@@ -966,14 +966,14 @@ CSteamID *__thiscall winISteamUser_SteamUser014_GetSteamID(winISteamUser_SteamUs
     return _r;
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser014_InitiateGameConnection, 27)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser014_InitiateGameConnection, 32)
 int __thiscall winISteamUser_SteamUser014_InitiateGameConnection(winISteamUser_SteamUser014 *_this, void * pAuthBlob, int cbMaxAuthBlob, CSteamID steamIDGameServer, uint32 unIPServer, uint16 usPortServer, bool bSecure)
 {
     TRACE("%p\n", _this);
     return cppISteamUser_SteamUser014_InitiateGameConnection(_this->linux_side, pAuthBlob, cbMaxAuthBlob, steamIDGameServer, unIPServer, usPortServer, bSecure);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser014_TerminateGameConnection, 10)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser014_TerminateGameConnection, 12)
 void __thiscall winISteamUser_SteamUser014_TerminateGameConnection(winISteamUser_SteamUser014 *_this, uint32 unIPServer, uint16 usPortServer)
 {
     TRACE("%p\n", _this);
@@ -1018,7 +1018,7 @@ EVoiceResult __thiscall winISteamUser_SteamUser014_GetAvailableVoice(winISteamUs
     return cppISteamUser_SteamUser014_GetAvailableVoice(_this->linux_side, pcbCompressed, pcbUncompressed);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser014_GetVoice, 30)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser014_GetVoice, 36)
 EVoiceResult __thiscall winISteamUser_SteamUser014_GetVoice(winISteamUser_SteamUser014 *_this, bool bWantCompressed, void * pDestBuffer, uint32 cbDestBufferSize, uint32 * nBytesWritten, bool bWantUncompressed, void * pUncompressedDestBuffer, uint32 cbUncompressedDestBufferSize, uint32 * nUncompressBytesWritten)
 {
     TRACE("%p\n", _this);
@@ -1074,7 +1074,7 @@ bool __thiscall winISteamUser_SteamUser014_BIsBehindNAT(winISteamUser_SteamUser0
     return cppISteamUser_SteamUser014_BIsBehindNAT(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser014_AdvertiseGame, 18)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser014_AdvertiseGame, 20)
 void __thiscall winISteamUser_SteamUser014_AdvertiseGame(winISteamUser_SteamUser014 *_this, CSteamID steamIDGameServer, uint32 unIPServer, uint16 usPortServer)
 {
     TRACE("%p\n", _this);
@@ -1165,14 +1165,14 @@ CSteamID *__thiscall winISteamUser_SteamUser013_GetSteamID(winISteamUser_SteamUs
     return _r;
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser013_InitiateGameConnection, 27)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser013_InitiateGameConnection, 32)
 int __thiscall winISteamUser_SteamUser013_InitiateGameConnection(winISteamUser_SteamUser013 *_this, void * pAuthBlob, int cbMaxAuthBlob, CSteamID steamIDGameServer, uint32 unIPServer, uint16 usPortServer, bool bSecure)
 {
     TRACE("%p\n", _this);
     return cppISteamUser_SteamUser013_InitiateGameConnection(_this->linux_side, pAuthBlob, cbMaxAuthBlob, steamIDGameServer, unIPServer, usPortServer, bSecure);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser013_TerminateGameConnection, 10)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser013_TerminateGameConnection, 12)
 void __thiscall winISteamUser_SteamUser013_TerminateGameConnection(winISteamUser_SteamUser013 *_this, uint32 unIPServer, uint16 usPortServer)
 {
     TRACE("%p\n", _this);
@@ -1217,7 +1217,7 @@ EVoiceResult __thiscall winISteamUser_SteamUser013_GetAvailableVoice(winISteamUs
     return cppISteamUser_SteamUser013_GetAvailableVoice(_this->linux_side, pcbCompressed, pcbUncompressed);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser013_GetVoice, 30)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser013_GetVoice, 36)
 EVoiceResult __thiscall winISteamUser_SteamUser013_GetVoice(winISteamUser_SteamUser013 *_this, bool bWantCompressed, void * pDestBuffer, uint32 cbDestBufferSize, uint32 * nBytesWritten, bool bWantUncompressed, void * pUncompressedDestBuffer, uint32 cbUncompressedDestBufferSize, uint32 * nUncompressBytesWritten)
 {
     TRACE("%p\n", _this);
@@ -1332,14 +1332,14 @@ CSteamID *__thiscall winISteamUser_SteamUser012_GetSteamID(winISteamUser_SteamUs
     return _r;
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser012_InitiateGameConnection, 27)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser012_InitiateGameConnection, 32)
 int __thiscall winISteamUser_SteamUser012_InitiateGameConnection(winISteamUser_SteamUser012 *_this, void * pAuthBlob, int cbMaxAuthBlob, CSteamID steamIDGameServer, uint32 unIPServer, uint16 usPortServer, bool bSecure)
 {
     TRACE("%p\n", _this);
     return cppISteamUser_SteamUser012_InitiateGameConnection(_this->linux_side, pAuthBlob, cbMaxAuthBlob, steamIDGameServer, unIPServer, usPortServer, bSecure);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser012_TerminateGameConnection, 10)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser012_TerminateGameConnection, 12)
 void __thiscall winISteamUser_SteamUser012_TerminateGameConnection(winISteamUser_SteamUser012 *_this, uint32 unIPServer, uint16 usPortServer)
 {
     TRACE("%p\n", _this);
@@ -1491,14 +1491,14 @@ CSteamID *__thiscall winISteamUser_SteamUser011_GetSteamID(winISteamUser_SteamUs
     return _r;
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser011_InitiateGameConnection, 27)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser011_InitiateGameConnection, 32)
 int __thiscall winISteamUser_SteamUser011_InitiateGameConnection(winISteamUser_SteamUser011 *_this, void * pAuthBlob, int cbMaxAuthBlob, CSteamID steamIDGameServer, uint32 unIPServer, uint16 usPortServer, bool bSecure)
 {
     TRACE("%p\n", _this);
     return cppISteamUser_SteamUser011_InitiateGameConnection(_this->linux_side, pAuthBlob, cbMaxAuthBlob, steamIDGameServer, unIPServer, usPortServer, bSecure);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser011_TerminateGameConnection, 10)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser011_TerminateGameConnection, 12)
 void __thiscall winISteamUser_SteamUser011_TerminateGameConnection(winISteamUser_SteamUser011 *_this, uint32 unIPServer, uint16 usPortServer)
 {
     TRACE("%p\n", _this);
@@ -1610,14 +1610,14 @@ CSteamID *__thiscall winISteamUser_SteamUser010_GetSteamID(winISteamUser_SteamUs
     return _r;
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser010_InitiateGameConnection, 27)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser010_InitiateGameConnection, 32)
 int __thiscall winISteamUser_SteamUser010_InitiateGameConnection(winISteamUser_SteamUser010 *_this, void * pAuthBlob, int cbMaxAuthBlob, CSteamID steamIDGameServer, uint32 unIPServer, uint16 usPortServer, bool bSecure)
 {
     TRACE("%p\n", _this);
     return cppISteamUser_SteamUser010_InitiateGameConnection(_this->linux_side, pAuthBlob, cbMaxAuthBlob, steamIDGameServer, unIPServer, usPortServer, bSecure);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser010_TerminateGameConnection, 10)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser010_TerminateGameConnection, 12)
 void __thiscall winISteamUser_SteamUser010_TerminateGameConnection(winISteamUser_SteamUser010 *_this, uint32 unIPServer, uint16 usPortServer)
 {
     TRACE("%p\n", _this);
@@ -1686,14 +1686,14 @@ CSteamID *__thiscall winISteamUser_SteamUser009_GetSteamID(winISteamUser_SteamUs
     return _r;
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser009_InitiateGameConnection, 35)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser009_InitiateGameConnection, 40)
 int __thiscall winISteamUser_SteamUser009_InitiateGameConnection(winISteamUser_SteamUser009 *_this, void * pAuthBlob, int cbMaxAuthBlob, CSteamID steamIDGameServer, CGameID gameID, uint32 unIPServer, uint16 usPortServer, bool bSecure)
 {
     TRACE("%p\n", _this);
     return cppISteamUser_SteamUser009_InitiateGameConnection(_this->linux_side, pAuthBlob, cbMaxAuthBlob, steamIDGameServer, gameID, unIPServer, usPortServer, bSecure);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser009_TerminateGameConnection, 10)
+DEFINE_THISCALL_WRAPPER(winISteamUser_SteamUser009_TerminateGameConnection, 12)
 void __thiscall winISteamUser_SteamUser009_TerminateGameConnection(winISteamUser_SteamUser009 *_this, uint32 unIPServer, uint16 usPortServer)
 {
     TRACE("%p\n", _this);

--- a/lsteamclient/winISteamUserStats.c
+++ b/lsteamclient/winISteamUserStats.c
@@ -167,7 +167,7 @@ bool __thiscall winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION011_GetUserAc
     return cppISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION011_GetUserAchievementAndUnlockTime(_this->linux_side, steamIDUser, pchName, pbAchieved, punUnlockTime);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION011_ResetAllStats, 5)
+DEFINE_THISCALL_WRAPPER(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION011_ResetAllStats, 8)
 bool __thiscall winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION011_ResetAllStats(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION011 *_this, bool bAchievementsToo)
 {
     TRACE("%p\n", _this);
@@ -524,7 +524,7 @@ bool __thiscall winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION010_GetUserAc
     return cppISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION010_GetUserAchievementAndUnlockTime(_this->linux_side, steamIDUser, pchName, pbAchieved, punUnlockTime);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION010_ResetAllStats, 5)
+DEFINE_THISCALL_WRAPPER(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION010_ResetAllStats, 8)
 bool __thiscall winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION010_ResetAllStats(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION010 *_this, bool bAchievementsToo)
 {
     TRACE("%p\n", _this);
@@ -879,7 +879,7 @@ bool __thiscall winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION009_GetUserAc
     return cppISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION009_GetUserAchievementAndUnlockTime(_this->linux_side, steamIDUser, pchName, pbAchieved, punUnlockTime);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION009_ResetAllStats, 5)
+DEFINE_THISCALL_WRAPPER(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION009_ResetAllStats, 8)
 bool __thiscall winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION009_ResetAllStats(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION009 *_this, bool bAchievementsToo)
 {
     TRACE("%p\n", _this);
@@ -1162,7 +1162,7 @@ bool __thiscall winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION007_GetUserAc
     return cppISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION007_GetUserAchievementAndUnlockTime(_this->linux_side, steamIDUser, pchName, pbAchieved, punUnlockTime);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION007_ResetAllStats, 5)
+DEFINE_THISCALL_WRAPPER(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION007_ResetAllStats, 8)
 bool __thiscall winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION007_ResetAllStats(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION007 *_this, bool bAchievementsToo)
 {
     TRACE("%p\n", _this);
@@ -1415,7 +1415,7 @@ bool __thiscall winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION006_GetUserAc
     return cppISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION006_GetUserAchievement(_this->linux_side, steamIDUser, pchName, pbAchieved);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION006_ResetAllStats, 5)
+DEFINE_THISCALL_WRAPPER(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION006_ResetAllStats, 8)
 bool __thiscall winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION006_ResetAllStats(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION006 *_this, bool bAchievementsToo)
 {
     TRACE("%p\n", _this);
@@ -1666,7 +1666,7 @@ bool __thiscall winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION005_GetUserAc
     return cppISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION005_GetUserAchievement(_this->linux_side, steamIDUser, pchName, pbAchieved);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION005_ResetAllStats, 5)
+DEFINE_THISCALL_WRAPPER(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION005_ResetAllStats, 8)
 bool __thiscall winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION005_ResetAllStats(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION005 *_this, bool bAchievementsToo)
 {
     TRACE("%p\n", _this);

--- a/lsteamclient/winISteamUtils.c
+++ b/lsteamclient/winISteamUtils.c
@@ -225,7 +225,7 @@ bool __thiscall winISteamUtils_SteamUtils009_IsVRHeadsetStreamingEnabled(winISte
     return cppISteamUtils_SteamUtils009_IsVRHeadsetStreamingEnabled(_this->linux_side);
 }
 
-DEFINE_THISCALL_WRAPPER(winISteamUtils_SteamUtils009_SetVRHeadsetStreamingEnabled, 5)
+DEFINE_THISCALL_WRAPPER(winISteamUtils_SteamUtils009_SetVRHeadsetStreamingEnabled, 8)
 void __thiscall winISteamUtils_SteamUtils009_SetVRHeadsetStreamingEnabled(winISteamUtils_SteamUtils009 *_this, bool bEnabled)
 {
     TRACE("%p\n", _this);


### PR DESCRIPTION
The size of each parameter has to be rounded up to a multiple of 4 (register size) before adding them together.