### PR TITLE
proton: Place DXVK logs into the user home folder.

### DIFF
--- a/proton
+++ b/proton
@@ -278,6 +278,9 @@ if "SteamGameId" in env:
 else:
     env["WINEDEBUG"] = "-all"
 
+if env["DXVK_LOG_LEVEL"] != "none":
+    env["DXVK_LOG_PATH"] = os.environ["HOME"]
+
 def create_fonts_symlinks(prefix_path):
     fontsmap = [
         ( "LiberationSans-Regular.ttf", "arial.ttf" ),


### PR DESCRIPTION
This will prevent DXVK logs all over the steamapps directory, but places them in the same folder as the wine logs.