### PR TITLE
proton: Add PROTON_CMD

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,5 +260,6 @@ the Wine prefix. Removing the option will revert to the previous behavior.
 | <tt>noesync</tt>      | <tt>PROTON_NO_ESYNC</tt>       | Do not use eventfd-based in-process synchronization primitives. |
 | <tt>forcelgadd</tt>   | <tt>PROTON_FORCE_LARGE_ADDRESS_AWARE</tt> | Force Wine to enable the LARGE_ADDRESS_AWARE flag for all executables. |
 | <tt>oldglstr</tt>     | <tt>PROTON_OLD_GL_STRING</tt>  | Set some driver overrides to limit the length of the GL extension string, for old games that crash on very long extension strings. |
+|                       | <tt>PROTON_CMD</tt>            | Pass following string as parameter to `cmd /c` instead of running `%command%`. For example: `PROTON_CMD=regedit %command%` will run regedit in game's prefix. |
 
 <!-- Target:  GitHub Flavor Markdown.  To test locally:  pandoc -f markdown_github -t html README.md  -->

--- a/proton
+++ b/proton
@@ -295,7 +295,8 @@ if "SteamGameId" in env:
         with open(basedir + "/version", "r") as f:
             lfile.write("Proton: " + f.readline().strip() + "\n")
         lfile.write("SteamGameId: " + env["SteamGameId"] + "\n")
-        lfile.write("Command: " + str(sys.argv[2:]) + "\n")
+        command = env.get("PROTON_CMD") or ''.join(sys.argv[2:])
+        lfile.write("Command: " + command + "\n")
         lfile.write("======================\n")
         lfile.flush()
 else:
@@ -594,7 +595,10 @@ def run():
             dump_dbg_scripts()
         except OSError:
             log("Unable to write debug scripts! " + str(sys.exc_info()[1]))
-    run_wine([wine_path, "steam"] + sys.argv[2:])
+    if "PROTON_CMD" in env:
+        run_wine([wine_path, "steam", "cmd", "/c", env["PROTON_CMD"]])
+    else:
+        run_wine([wine_path, "steam"] + sys.argv[2:])
 
 if sys.version_info[0] == 2:
     binary_stdout = sys.stdout


### PR DESCRIPTION
This environment variable can be used to override executable passed by the Steam client, run .bat files or easily start wine commands such as winecfg or regedit.

It's not intended for whitelisting, but rather as a convenient option for users, who want to bypass game launchers, import some keys into the registry, etc.

## Example usage:

### Simple replacing of a game launcher

At the moment user needs to manually rename files (which might fail after the game update or verifying file integrity in Steam client). For example in Fallout:

    PROTON_CMD=falloutwHR.exe %command%

### Not-so-simple replacing of a game launcher

Some launchers do additional tasks before launching game's executable. For example instead of writing and cross-compiling custom launcher for Shenmue (758330) (https://github.com/ValveSoftware/Proton/issues/1981#issuecomment-450759700) user could pass:

    PROTON_CMD="cd sm1 && Shenmue.exe" %command%

Or instead of juggling files, links and directories around for Divinity Original Sin 2 (435150) (#413), something like this should work:

    PROTON_CMD="cd DefEd && bin/EoCApp.exe" %command%

When launcher does additional tasks, it is possible to implement them in a batch script:

    PROTON_CMD=run.bat %command%

### Modifying game prefix

    PROTON_CMD=winecfg %command%

    PROTON_CMD=regedit %command%

These are much easier and less error-prone than finding and defining proper environment variables manually or even using external tools such as `protontricks` just to switch Windows version.

## Implementation detail

All parameters passed by a user *or Steam client* after `%command%` are disregarded and would need to be placed in PROTON_CMD. `PROTON_CMD=foo %command% -bar` would need to be rewritten as: `PROTON_CMD="foo -bar" %command%`.

This is **by design**, to avoid game failing on unrecognized parameters when Steam client forces them into `%command%` - example of such title is e.g. [STAR WARS Galactic Battlegrounds Saga (356500)](https://steamdb.info/app/356500/config/).