### PR TITLE
Add request for Proton log to Whitelist Request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/whitelist-request.md
+++ b/.github/ISSUE_TEMPLATE/whitelist-request.md
@@ -37,4 +37,6 @@ about: Games tested and found to have no issues.
    this issue to prevent chaos by too much info in one place.
 5. Please search for open issues and pull requests by the name of the game and
    find out whether they are relevant and should be referenced above.
+6. Please add `PROTON_LOG=1 %command%` to the game's launch options and drag
+   and drop the generated `$HOME/steam-$APPID.log` into this issue report
 -->


### PR DESCRIPTION
### What changes?
There's an extra item on the list asking for a Proton log.

### Rationale for change:
Some games are reported as whitelist-ready while not actually being free of issues (cutscenes/cinematics, other bugs). By asking for a log we can check if the whitelisted game is actually free of issues.

Example: #816 and #818 were initially reported as whitelist-ready but later turn out to not be whitelist-ready due to issues with video playback.

### Benefits of this change:
- Filtering out wrongly filed whitelist requests by checking the log for errors.
- Whitelist request tag will only have proper whitelist ready games.
- If whitelist request was "proper" we now have a known good log in case of regression.