### PR TITLE
Require vagrant >= 2.2.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+Vagrant.require_version ">= 2.2.0"
+
 module OS
   def OS.windows?
     (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil


### PR DESCRIPTION
Require vagrant >= 2.2.0, the earliest version supporting `config.vagrant.plugins`

Closes #2766