### PR TITLE
Include a vagrant executible in the source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,48 +73,48 @@ help:
 	@echo "      in the \"mytest\" build directory and place it into vagrant_share/dsound/."
 
 vagrant:
-	vagrant up
-	vagrant rsync
+	./vagrant up
+	./vagrant rsync
 
 clean: vagrant
-	vagrant ssh -c 'rm -rf $(BUILD_DIR)/'
+	./vagrant ssh -c 'rm -rf $(BUILD_DIR)/'
 
 configure: vagrant
 	@vagrant ssh -c 'if [ ! -e $(BUILD_DIR)/Makefile ]; then if ! schroot -i -c dxvk_crosscc >/dev/null 2>&1; then echo !!!! You must run \"vagrant provision\" !!!!; exit 1; fi; mkdir -p $(BUILD_DIR); (cd $(BUILD_DIR) && $(CONFIGURE_CMD)); fi'
 
 proton: configure
-	vagrant ssh -c 'make -C $(BUILD_DIR)/ dist'
+	./vagrant ssh -c 'make -C $(BUILD_DIR)/ dist'
 	echo "Proton built in VM. Use 'install' or 'deploy' targets to retrieve the build."
 
 install: configure
-	vagrant ssh -c 'make -C $(BUILD_DIR)/ STEAM_DIR=/vagrant/ install'
+	./vagrant ssh -c 'make -C $(BUILD_DIR)/ STEAM_DIR=/vagrant/ install'
 	mkdir -p $(STEAM_DIR)/compatibilitytools.d/
 	cp -R vagrant_share/compatibilitytools.d/$(_build_name) $(STEAM_DIR)/compatibilitytools.d/
 	echo "Proton installed to your local Steam installation"
 
 deploy: configure
-	vagrant ssh -c 'make -C $(BUILD_DIR)/ deploy'
+	./vagrant ssh -c 'make -C $(BUILD_DIR)/ deploy'
 	mkdir -p vagrant_share/$(DEPLOY_DIR)
-	vagrant ssh -c 'cp $(BUILD_DIR)/deploy/* /vagrant/$(DEPLOY_DIR)'
+	./vagrant ssh -c 'cp $(BUILD_DIR)/deploy/* /vagrant/$(DEPLOY_DIR)'
 	echo "Proton deployed to vagrant_share/$(DEPLOY_DIR)"
 
 module: configure
-	vagrant ssh -c 'make -C $(BUILD_DIR)/ module=$(module) module'
+	./vagrant ssh -c 'make -C $(BUILD_DIR)/ module=$(module) module'
 	mkdir -p vagrant_share/$(module)/lib/wine/
-	vagrant ssh -c 'cp $(BUILD_DIR)/obj-wine32/dlls/$(module)/$(module)*.so /vagrant/$(module)/lib/wine/'
+	./vagrant ssh -c 'cp $(BUILD_DIR)/obj-wine32/dlls/$(module)/$(module)*.so /vagrant/$(module)/lib/wine/'
 	mkdir -p vagrant_share/$(module)/lib64/wine/
-	vagrant ssh -c 'cp $(BUILD_DIR)/obj-wine64/dlls/$(module)/$(module)*.so /vagrant/$(module)/lib64/wine/'
+	./vagrant ssh -c 'cp $(BUILD_DIR)/obj-wine64/dlls/$(module)/$(module)*.so /vagrant/$(module)/lib64/wine/'
 
 dxvk: configure
-	vagrant ssh -c 'make -C $(BUILD_DIR)/ dxvk'
+	./vagrant ssh -c 'make -C $(BUILD_DIR)/ dxvk'
 	mkdir -p vagrant_share/dxvk/lib/wine/dxvk/
-	vagrant ssh -c 'cp $(BUILD_DIR)/dist/dist/lib/wine/dxvk/*.dll /vagrant/dxvk/lib/wine/dxvk/'
+	./vagrant ssh -c 'cp $(BUILD_DIR)/dist/dist/lib/wine/dxvk/*.dll /vagrant/dxvk/lib/wine/dxvk/'
 	mkdir -p vagrant_share/dxvk/lib64/wine/dxvk/
-	vagrant ssh -c 'cp $(BUILD_DIR)/dist/dist/lib64/wine/dxvk/*.dll /vagrant/dxvk/lib64/wine/dxvk/'
+	./vagrant ssh -c 'cp $(BUILD_DIR)/dist/dist/lib64/wine/dxvk/*.dll /vagrant/dxvk/lib64/wine/dxvk/'
 
 lsteamclient: configure
-	vagrant ssh -c 'make -C $(BUILD_DIR)/ lsteamclient'
+	./vagrant ssh -c 'make -C $(BUILD_DIR)/ lsteamclient'
 	mkdir -p vagrant_share/lsteamclient/lib/wine
-	vagrant ssh -c 'cp $(BUILD_DIR)/dist/dist/lib/wine/lsteamclient.dll.so /vagrant/lsteamclient/lib/wine'
+	./vagrant ssh -c 'cp $(BUILD_DIR)/dist/dist/lib/wine/lsteamclient.dll.so /vagrant/lsteamclient/lib/wine'
 	mkdir -p vagrant_share/lsteamclient/lib64/wine
-	vagrant ssh -c 'cp $(BUILD_DIR)/dist/dist/lib64/wine/lsteamclient.dll.so /vagrant/lsteamclient/lib64/wine'
+	./vagrant ssh -c 'cp $(BUILD_DIR)/dist/dist/lib64/wine/lsteamclient.dll.so /vagrant/lsteamclient/lib64/wine'


### PR DESCRIPTION
The current rubygem way of installing vagrant (that's in the readme) will just lead you to installing this executable anyway. Might as well include it with the source to make installation easier.