### PR TITLE
vrclient: Support for HmdSystemFactory export

### DIFF
--- a/vrclient_x64/vrclient_x64/vrclient_x64.spec
+++ b/vrclient_x64/vrclient_x64/vrclient_x64.spec
@@ -1,4 +1,4 @@
 # Generated from vrclient.dll by winedump
 
-1 stub HmdSystemFactory
+1 stdcall HmdSystemFactory(ptr ptr)
 2 stdcall VRClientCoreFactory(ptr ptr)


### PR DESCRIPTION
Fixes a crash in Half-Life 2 when opening the options menu, and other legacy VR titles