### PR TITLE
proton: Refactor dump_dbg_scripts()

### DIFF
--- a/proton
+++ b/proton
@@ -546,27 +546,32 @@ class Session:
         else:
             self.env["WINEDLLOVERRIDES"] = s
 
-    def dump_dbg_env(self, f):
-        f.write("PATH=\"" + self.env["PATH"] + "\" \\\n")
-        f.write("\tTERM=\"xterm\" \\\n") #XXX
-        f.write("\tWINEDEBUG=\"-all\" \\\n")
-        f.write("\tWINEDLLPATH=\"" + self.env["WINEDLLPATH"] + "\" \\\n")
-        f.write("\t" + ld_path_var + "=\"" + self.env[ld_path_var] + "\" \\\n")
-        f.write("\tWINEPREFIX=\"" + self.env["WINEPREFIX"] + "\" \\\n")
-        if "WINEESYNC" in self.env:
-            f.write("\tWINEESYNC=\"" + self.env["WINEESYNC"] + "\" \\\n")
-        if "SteamGameId" in self.env:
-            f.write("\tSteamGameId=\"" + self.env["SteamGameId"] + "\" \\\n")
-        if "SteamAppId" in self.env:
-            f.write("\tSteamAppId=\"" + self.env["SteamAppId"] + "\" \\\n")
-        if "PROTON_VR_RUNTIME" in self.env:
-            f.write("\tPROTON_VR_RUNTIME=\"" + self.env["PROTON_VR_RUNTIME"] + "\" \\\n")
-        if "WINEDLLOVERRIDES" in self.env:
-            f.write("\tWINEDLLOVERRIDES=\"" + self.env["WINEDLLOVERRIDES"] + "\" \\\n")
-        if "STEAM_COMPAT_CLIENT_INSTALL_PATH" in self.env:
-            f.write("\tSTEAM_COMPAT_CLIENT_INSTALL_PATH=\"" + self.env["STEAM_COMPAT_CLIENT_INSTALL_PATH"] + "\" \\\n")
-        if "WINE_LARGE_ADDRESS_AWARE" in self.env:
-            f.write("\tWINE_LARGE_ADDRESS_AWARE=\"" + self.env["WINE_LARGE_ADDRESS_AWARE"] + "\" \\\n")
+    def dump_dbg_env(self):
+        envs_to_dump = ''
+        proton_env_vars = [
+            "WINEDLLPATH", "WINEPREFIX", ld_path_var,
+            "WINEESYNC", "SteamGameId", "SteamAppId", "PROTON_VR_RUNTIME",
+            "WINEDLLOVERRIDES", "STEAM_COMPAT_CLIENT_INSTALL_PATH",
+            "WINE_LARGE_ADDRESS_AWARE"]
+
+        for var in proton_env_vars:
+            if var in self.env:
+                envs_to_dump += '\t' + var + '="' + self.env[var] + '" \\\n'
+        return envs_to_dump
+
+    def dump_dbg_tpl(self, comment, command, additional_vars=''):
+        return str(
+            '#!/bin/bash\n'
+            '#' + comment + '\n'
+            '\n'
+            'cd "' + os.getcwd() + '"\n'
+            '' + additional_vars + ''
+            'DEF_CMD=("' + '" "'.join(sys.argv[2:]) + '")\n'
+            'PATH="' + self.env["PATH"] + '" \\\n'
+            '\tTERM="xterm" \\\n'
+            '\tWINEDEBUG="-all" \\\n'
+            '\t' + self.dump_dbg_env() + ''
+            '\t"' + g_proton.wine_bin + '" ' + command + '\n')
 
     def dump_dbg_scripts(self):
         exe_name = os.path.basename(sys.argv[2])
@@ -574,78 +579,33 @@ class Session:
         tmpdir = self.env.get("PROTON_DEBUG_DIR", "/tmp") + "/proton_" + os.environ["USER"] + "/"
         makedirs(tmpdir)
 
+        attach_wpid = str(
+            'EXE_NAME=${1:-"' + exe_name + '}\n'
+            'WPID_HEX=$("' + tmpdir + 'winedbg" --command \'info process\' | grep -i "$EXE_NAME" | cut -f2 -d\' \' | tr -d \'0\')\n'
+            'if [ -z "$WPID_HEX" ]; then \n'
+            '    echo "Program does not appear to be running: \\"$EXE_NAME\\""\n'
+            '    exit 1\n'
+            'fi\n'
+            'WPID_DEC=$(printf %d 0x$WPID_HEX)\n')
+
         with open(tmpdir + "winedbg", "w") as f:
-            f.write("#!/bin/bash\n")
-            f.write("#Run winedbg with args\n\n")
-            f.write("cd \"" + os.getcwd() + "\"\n")
-            self.dump_dbg_env(f)
-            f.write("\t\"" + g_proton.wine_bin + "\" winedbg \"$@\"\n")
+            f.write(self.dump_dbg_tpl('Run winedbg with args', 'winedbg "$@"'))
         os.chmod(tmpdir + "winedbg", 0o755)
 
         with open(tmpdir + "winedbg_run", "w") as f:
-            f.write("#!/bin/bash\n")
-            f.write("#Run winedbg and prepare to run game or given program\n\n")
-            f.write("cd \"" + os.getcwd() + "\"\n")
-            f.write("DEF_CMD=(")
-            first = True
-            for arg in sys.argv[2:]:
-                if first:
-                    f.write("\"" + arg + "\"")
-                    first = False
-                else:
-                    f.write(" \"" + arg + "\"")
-            f.write(")\n")
-            self.dump_dbg_env(f)
-            f.write("\t\"" + g_proton.wine_bin + "\" winedbg \"${@:-${DEF_CMD[@]}}\"\n")
+            f.write(self.dump_dbg_tpl('Run winedbg and prepare to run game or given program', 'winedbg "${@:-${DEF_CMD[@]}}"'))
         os.chmod(tmpdir + "winedbg_run", 0o755)
 
         with open(tmpdir + "gdb_attach", "w") as f:
-            f.write("#!/bin/bash\n")
-            f.write("#Run winedbg in gdb mode and auto-attach to already-running program\n\n")
-            f.write("cd \"" + os.getcwd() + "\"\n")
-            f.write("EXE_NAME=${1:-\"" + exe_name + "\"}\n")
-            f.write("WPID_HEX=$(\"" + tmpdir + "winedbg\" --command 'info process' | grep -i \"$EXE_NAME\" | cut -f2 -d' ' | tr -d '0')\n")
-            f.write("if [ -z \"$WPID_HEX\" ]; then \n")
-            f.write("    echo \"Program does not appear to be running: \\\"$EXE_NAME\\\"\"\n")
-            f.write("    exit 1\n")
-            f.write("fi\n")
-            f.write("WPID_DEC=$(printf %d 0x$WPID_HEX)\n")
-            self.dump_dbg_env(f)
-            f.write("\t\"" + g_proton.wine_bin + "\" winedbg --gdb $WPID_DEC\n")
+            f.write(self.dump_dbg_tpl('Run winedbg in gdb mode and auto-attach to already-running program', 'winedbg --gdb $WPID_DEC', attach_wpid))
         os.chmod(tmpdir + "gdb_attach", 0o755)
 
         with open(tmpdir + "gdb_run", "w") as f:
-            f.write("#!/bin/bash\n")
-            f.write("#Run winedbg in gdb mode and prepare to run game or given program\n\n")
-            f.write("cd \"" + os.getcwd() + "\"\n")
-            f.write("DEF_CMD=(")
-            first = True
-            for arg in sys.argv[2:]:
-                if first:
-                    f.write("\"" + arg + "\"")
-                    first = False
-                else:
-                    f.write(" \"" + arg + "\"")
-            f.write(")\n")
-            self.dump_dbg_env(f)
-            f.write("\t\"" + g_proton.wine_bin + "\" winedbg --gdb \"${@:-${DEF_CMD[@]}}\"\n")
+            f.write(self.dump_dbg_tpl('Run winedbg in gdb mode and prepare to run game or given program', 'winedbg --gdb "${@:-${DEF_CMD[@]}}"'))
         os.chmod(tmpdir + "gdb_run", 0o755)
 
         with open(tmpdir + "run", "w") as f:
-            f.write("#!/bin/bash\n")
-            f.write("#Run game or given command in environment\n\n")
-            f.write("cd \"" + os.getcwd() + "\"\n")
-            f.write("DEF_CMD=(")
-            first = True
-            for arg in sys.argv[2:]:
-                if first:
-                    f.write("\"" + arg + "\"")
-                    first = False
-                else:
-                    f.write(" \"" + arg + "\"")
-            f.write(")\n")
-            self.dump_dbg_env(f)
-            f.write("\t\"" + g_proton.wine_bin + "\" steam.exe \"${@:-${DEF_CMD[@]}}\"\n")
+            f.write(self.dump_dbg_tpl('Run game or given command in environment', 'steam.exe "${@:-${DEF_CMD[@]}}"'))
         os.chmod(tmpdir + "run", 0o755)
 
     def run_proc(self, args, local_env=None):


### PR DESCRIPTION
I merged this code using an plain text editor, just to figure out for myself if there any difference in the debug script generators. Resulting code wasn't even tested.

Just in case, if it could be useful.

Why some tricks used:
* single quotes to avoid multiple `\"`, a few rare `\'` was added instead
* several separate text strings on new line are treated by `python` as single line text string
  _was used to made the code similar (by indentation) to the bash script it supposed to generate_
  _(with the variable success, obviously, after everything was collapsed)_
* `for idx, val in enumerate(list):` was used to drop `first = True` variable,
  but such loops was replaced by `'arr=("' + '" "'.join(list) + '")'` construction late, to generate `bash` array in a single line