### PR TITLE
Ignore vagrant working directories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /syn-*
 
 /vrclient_x64/vrclient_x64/Makefile
+
+/.vagrant/
+/vagrant_share/


### PR DESCRIPTION
It would be nice to have a clean git state after running a build using vagrant.