### PR TITLE
build: Move environment variables to the end of configure script.

### DIFF
--- a/build/makefile_base.mak
+++ b/build/makefile_base.mak
@@ -834,33 +834,36 @@ WINE32_MAKE_ARGS := \
 $(WINE_CONFIGURE_FILES64): SHELL = $(CONTAINER_SHELL64)
 $(WINE_CONFIGURE_FILES64): $(MAKEFILE_DEP) | faudio64 vkd3d64 $(WINE_OBJ64) bison64
 	cd $(dir $@) && \
-		STRIP=$(STRIP_QUOTED) \
-		PATH="$(dir $(abspath $(BISON_BIN64))):$(PATH)" \
-		CFLAGS="-I$(abspath $(TOOLS_DIR64))/include -g $(COMMON_FLAGS)" \
-		CXXFLAGS="-I$(abspath $(TOOLS_DIR64))/include -g $(COMMON_FLAGS) -fno-gnu-unique -std=c++17" \
-		LDFLAGS=-L$(abspath $(TOOLS_DIR64))/lib \
-		PKG_CONFIG_PATH=$(abspath $(TOOLS_DIR64))/lib/pkgconfig \
-		CC=$(CC_QUOTED) \
-		CXX=$(CXX_QUOTED) \
 		../$(WINE)/configure \
 			--without-curses \
-			--enable-win64 --disable-tests --prefix=$(abspath $(DST_DIR))
+			--enable-win64 \
+			--disable-tests \
+			--prefix=$(abspath $(DST_DIR)) \
+			STRIP=$(STRIP_QUOTED) \
+			PATH="$(dir $(abspath $(BISON_BIN64))):$(PATH)" \
+			CFLAGS="-I$(abspath $(TOOLS_DIR64))/include -g $(COMMON_FLAGS)" \
+			CXXFLAGS="-I$(abspath $(TOOLS_DIR64))/include -g $(COMMON_FLAGS) -fno-gnu-unique -std=c++17" \
+			LDFLAGS=-L$(abspath $(TOOLS_DIR64))/lib \
+			PKG_CONFIG_PATH=$(abspath $(TOOLS_DIR64))/lib/pkgconfig \
+			CC=$(CC_QUOTED) \
+			CXX=$(CXX_QUOTED)
 
 # 32-bit configure
 $(WINE_CONFIGURE_FILES32): SHELL = $(CONTAINER_SHELL32)
 $(WINE_CONFIGURE_FILES32): $(MAKEFILE_DEP) | faudio32 vkd3d32 $(WINE_OBJ32) bison32
 	cd $(dir $@) && \
-		STRIP=$(STRIP_QUOTED) \
-		PATH="$(dir $(abspath $(BISON_BIN32))):$(PATH)" \
-		CFLAGS="-I$(abspath $(TOOLS_DIR32))/include -g $(COMMON_FLAGS)" \
-		CXXFLAGS="-I$(abspath $(TOOLS_DIR32))/include -g $(COMMON_FLAGS) -fno-gnu-unique -std=c++17" \
-		LDFLAGS=-L$(abspath $(TOOLS_DIR32))/lib \
-		PKG_CONFIG_PATH=$(abspath $(TOOLS_DIR32))/lib/pkgconfig \
-		CC=$(CC_QUOTED) \
-		CXX=$(CXX_QUOTED) \
 		../$(WINE)/configure \
 			--without-curses \
-			--disable-tests --prefix=$(abspath $(WINE_DST32))
+			--disable-tests \
+			--prefix=$(abspath $(WINE_DST32)) \
+			STRIP=$(STRIP_QUOTED) \
+			PATH="$(dir $(abspath $(BISON_BIN32))):$(PATH)" \
+			CFLAGS="-I$(abspath $(TOOLS_DIR32))/include -g $(COMMON_FLAGS)" \
+			CXXFLAGS="-I$(abspath $(TOOLS_DIR32))/include -g $(COMMON_FLAGS) -fno-gnu-unique -std=c++17" \
+			LDFLAGS=-L$(abspath $(TOOLS_DIR32))/lib \
+			PKG_CONFIG_PATH=$(abspath $(TOOLS_DIR32))/lib/pkgconfig \
+			CC=$(CC_QUOTED) \
+			CXX=$(CXX_QUOTED)
 
 ## wine goals
 WINE_TARGETS = wine wine_configure wine32 wine64 wine_configure32 wine_configure64
@@ -1090,13 +1093,13 @@ BISON_CONFIGURE_FILES64 := $(BISON_OBJ64)/Makefile
 $(BISON_CONFIGURE_FILES64): SHELL = $(CONTAINER_SHELL64)
 $(BISON_CONFIGURE_FILES64): $(MAKEFILE_DEP) $(BISON) | $(BISON_OBJ64)
 	cd "$(BISON_OBJ64)" && \
-		LIBS='-lrt' ../$(BISON)/configure --prefix=$(abspath $(BISON_OBJ64))/built
+		../$(BISON)/configure --prefix=$(abspath $(BISON_OBJ64))/built LIBS='-lrt'
 
 # 32-bit configure
 $(BISON_CONFIGURE_FILES32): SHELL = $(CONTAINER_SHELL32)
 $(BISON_CONFIGURE_FILES32): $(MAKEFILE_DEP) $(BISON) | $(BISON_OBJ32)
 	cd "$(BISON_OBJ32)" && \
-		LIBS='-lrt' ../$(BISON)/configure --prefix=$(abspath $(BISON_OBJ32))/built
+		../$(BISON)/configure --prefix=$(abspath $(BISON_OBJ32))/built LIBS='-lrt'
 
 
 ## bison goals
@@ -1312,16 +1315,16 @@ WINEWIDL_CONFIGURE_FILES32 := $(WINEWIDL_OBJ32)/Makefile
 $(WINEWIDL_CONFIGURE_FILES32): SHELL = $(CONTAINER_SHELL32)
 $(WINEWIDL_CONFIGURE_FILES32): $(MAKEFILE_DEP) | $(WINEWIDL_OBJ32) bison32
 	cd $(dir $@) && \
-		STRIP=$(STRIP_QUOTED) \
-		BISON=$(abspath $(BISON_BIN32)) \
-		CFLAGS=-I$(abspath $(TOOLS_DIR64))"/include -g $(COMMON_FLAGS)" \
-		LDFLAGS=-L$(abspath $(TOOLS_DIR32))/lib \
-		PKG_CONFIG_PATH=$(abspath $(TOOLS_DIR32))/lib/pkgconfig \
-		CC=$(CC_QUOTED) \
-		CXX=$(CXX_QUOTED) \
 		../$(WINE)/configure \
 			--without-curses \
-			--disable-tests
+			--disable-tests \
+			STRIP=$(STRIP_QUOTED) \
+			BISON=$(abspath $(BISON_BIN32)) \
+			CFLAGS=-I$(abspath $(TOOLS_DIR64))"/include -g $(COMMON_FLAGS)" \
+			LDFLAGS=-L$(abspath $(TOOLS_DIR32))/lib \
+			PKG_CONFIG_PATH=$(abspath $(TOOLS_DIR32))/lib/pkgconfig \
+			CC=$(CC_QUOTED) \
+			CXX=$(CXX_QUOTED)
 
 $(WINEWIDL32): SHELL = $(CONTAINER_SHELL32)
 $(WINEWIDL32): $(WINEWIDL_CONFIGURE_FILES32)
@@ -1331,16 +1334,17 @@ $(WINEWIDL32): $(WINEWIDL_CONFIGURE_FILES32)
 $(WINEWIDL_CONFIGURE_FILES64): SHELL = $(CONTAINER_SHELL64)
 $(WINEWIDL_CONFIGURE_FILES64): $(MAKEFILE_DEP) | $(WINEWIDL_OBJ64) bison64
 	cd $(dir $@) && \
-		STRIP=$(STRIP_QUOTED) \
-		BISON=$(abspath $(BISON_BIN64)) \
-		CFLAGS=-I$(abspath $(TOOLS_DIR64))"/include -g $(COMMON_FLAGS)" \
-		LDFLAGS=-L$(abspath $(TOOLS_DIR64))/lib \
-		PKG_CONFIG_PATH=$(abspath $(TOOLS_DIR64))/lib/pkgconfig \
-		CC=$(CC_QUOTED) \
-		CXX=$(CXX_QUOTED) \
 		../$(WINE)/configure \
 			--without-curses \
-			--enable-win64 --disable-tests
+			--enable-win64 \
+			--disable-tests \
+			STRIP=$(STRIP_QUOTED) \
+			BISON=$(abspath $(BISON_BIN64)) \
+			CFLAGS=-I$(abspath $(TOOLS_DIR64))"/include -g $(COMMON_FLAGS)" \
+			LDFLAGS=-L$(abspath $(TOOLS_DIR64))/lib \
+			PKG_CONFIG_PATH=$(abspath $(TOOLS_DIR64))/lib/pkgconfig \
+			CC=$(CC_QUOTED) \
+			CXX=$(CXX_QUOTED)
 
 $(WINEWIDL64): SHELL = $(CONTAINER_SHELL64)
 $(WINEWIDL64): $(WINEWIDL_CONFIGURE_FILES64)
@@ -1360,10 +1364,12 @@ $(VKD3D)/configure: $(MAKEFILE_DEP) $(VKD3D)/configure.ac
 $(VKD3D_CONFIGURE_FILES32): SHELL = $(CONTAINER_SHELL32)
 $(VKD3D_CONFIGURE_FILES32): $(MAKEFILE_DEP) $(VULKAN_H32) $(SPIRV_H32) $(VKD3D)/configure $(WINEWIDL32) | $(VKD3D_OBJ32)
 	cd $(abspath $(VKD3D_OBJ32)) && \
-	CFLAGS="-I$(abspath $(TOOLS_DIR32))/include -g $(COMMON_FLAGS) -DNDEBUG" \
-	LDFLAGS=-L$(abspath $(TOOLS_DIR32))/lib \
-	WIDL="$(abspath $(WINEWIDL32))" \
-	$(abspath $(VKD3D))/configure --disable-tests --prefix=$(abspath $(TOOLS_DIR32))
+		$(abspath $(VKD3D))/configure \
+			--disable-tests \
+			--prefix=$(abspath $(TOOLS_DIR32)) \
+			CFLAGS="-I$(abspath $(TOOLS_DIR32))/include -g $(COMMON_FLAGS) -DNDEBUG" \
+			LDFLAGS=-L$(abspath $(TOOLS_DIR32))/lib \
+			WIDL="$(abspath $(WINEWIDL32))"
 
 vkd3d32: SHELL = $(CONTAINER_SHELL32)
 vkd3d32: $(VKD3D_CONFIGURE_FILES32)
@@ -1375,10 +1381,12 @@ vkd3d32: $(VKD3D_CONFIGURE_FILES32)
 $(VKD3D_CONFIGURE_FILES64): SHELL = $(CONTAINER_SHELL64)
 $(VKD3D_CONFIGURE_FILES64): $(MAKEFILE_DEP) $(VULKAN_H64) $(SPIRV_H64) $(VKD3D)/configure $(WINEWIDL64) | $(VKD3D_OBJ64)
 	cd $(abspath $(VKD3D_OBJ64)) && \
-	CFLAGS="-I$(abspath $(TOOLS_DIR64))/include -g $(COMMON_FLAGS) -DNDEBUG" \
-	LDFLAGS=-L$(abspath $(TOOLS_DIR64))/lib \
-	WIDL="$(abspath $(WINEWIDL64))" \
-	$(abspath $(VKD3D))/configure --disable-tests --prefix=$(abspath $(TOOLS_DIR64))
+		$(abspath $(VKD3D))/configure \
+			--disable-tests \
+			--prefix=$(abspath $(TOOLS_DIR64)) \
+			CFLAGS="-I$(abspath $(TOOLS_DIR64))/include -g $(COMMON_FLAGS) -DNDEBUG" \
+			LDFLAGS=-L$(abspath $(TOOLS_DIR64))/lib \
+			WIDL="$(abspath $(WINEWIDL64))"
 
 vkd3d64: SHELL = $(CONTAINER_SHELL64)
 vkd3d64: $(VKD3D_CONFIGURE_FILES64)

--- a/build/makefile_base.mak
+++ b/build/makefile_base.mak
@@ -153,8 +153,6 @@ else
     MESON_STRIP_ARG := --strip
     VKD3D_INSTALL_TARGET := install-strip
 endif
-WINE32_AUTOCONF :=
-WINE64_AUTOCONF :=
 
 OPTIMIZE_FLAGS := -O2 -march=nocona $(call cc-option,$(CC),-mtune=core-avx2,) -mfpmath=sse
 SANITY_FLAGS   := -fwrapv -fno-strict-aliasing
@@ -845,7 +843,6 @@ $(WINE_CONFIGURE_FILES64): $(MAKEFILE_DEP) | faudio64 vkd3d64 $(WINE_OBJ64) biso
 		CC=$(CC_QUOTED) \
 		CXX=$(CXX_QUOTED) \
 		../$(WINE)/configure \
-			$(WINE64_AUTOCONF) \
 			--without-curses \
 			--enable-win64 --disable-tests --prefix=$(abspath $(DST_DIR))
 
@@ -862,7 +859,6 @@ $(WINE_CONFIGURE_FILES32): $(MAKEFILE_DEP) | faudio32 vkd3d32 $(WINE_OBJ32) biso
 		CC=$(CC_QUOTED) \
 		CXX=$(CXX_QUOTED) \
 		../$(WINE)/configure \
-			$(WINE32_AUTOCONF) \
 			--without-curses \
 			--disable-tests --prefix=$(abspath $(WINE_DST32))
 
@@ -1324,7 +1320,6 @@ $(WINEWIDL_CONFIGURE_FILES32): $(MAKEFILE_DEP) | $(WINEWIDL_OBJ32) bison32
 		CC=$(CC_QUOTED) \
 		CXX=$(CXX_QUOTED) \
 		../$(WINE)/configure \
-			$(WINE32_AUTOCONF) \
 			--without-curses \
 			--disable-tests
 
@@ -1344,7 +1339,6 @@ $(WINEWIDL_CONFIGURE_FILES64): $(MAKEFILE_DEP) | $(WINEWIDL_OBJ64) bison64
 		CC=$(CC_QUOTED) \
 		CXX=$(CXX_QUOTED) \
 		../$(WINE)/configure \
-			$(WINE64_AUTOCONF) \
 			--without-curses \
 			--enable-win64 --disable-tests
 


### PR DESCRIPTION
@aeikum 

"ENV=VAR ./configure" is different from "./configure ENV=VAR".
The latter caches command line variables in config.status.
So "config.status --recheck" succeeds executing configure script
Otherwise, "config.status --recheck" often fails when only source
is updated because some variables are not cached. Examples include
being not able to find bison or vkd3d.h when they are obviously present,
which are because of missing BISON and VKD3D_CFLAGS variables.

Another way to fix the build issue is to mark those variables needed to be kept as [precious variables](https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Setting-Output-Variables.html). But then we have to keep track of those variables as well.

Related links:
1. https://stackoverflow.com/questions/13848154/passing-environment-variables-to-autoconfs-configure
2. https://unix.stackexchange.com/questions/290381/why-does-configure-take-variables-as-arguments