### PR TITLE
RFC: Disable esync when running the install script.

### DIFF
--- a/proton
+++ b/proton
@@ -459,10 +459,10 @@ class Session:
         self.check_environment("PROTON_OLD_GL_STRING", "oldglstr")
 
         if not "noesync" in self.compat_config:
-            self.env["WINEESYNC"] = "1"
+            self.env["WINEESYNC"] = "1" if "SteamGameId" in self.env else "0"
 
         if not "nofsync" in self.compat_config:
-            self.env["WINEFSYNC"] = "1"
+            self.env["WINEFSYNC"] = "1" if "SteamGameId" in self.env else "0"
 
         if "oldglstr" in self.compat_config:
             #mesa override


### PR DESCRIPTION
Origin fails to install/update when esync is enabled.  We can work around this by disabling esync during the install script.  If I'm not mistaken, wineserver is restarted before the game itself is run, so this should be safe.  One concern though is how this would affect non-steam games run through Proton.