### PR TITLE
Update makedirs function to not supress OSErrors

### DIFF
--- a/proton
+++ b/proton
@@ -49,8 +49,7 @@ def makedirs(path):
             return
         
         os.makedirs(path)
-    except OSError as err:
-        log("Error when creating directory {0}: {1}".format(path, err))
+    except FileExistsError:
         pass
 
 def try_copy(src, dst):
@@ -170,9 +169,9 @@ class CompatData:
                 try:
                     if not any(os.scandir(d)):
                         os.rmdir(d)
-                except OSError as err:
-                    log("Error deleting directory {0}: {1}".format(d, err))
-                    pass
+                except OSError as e:
+                    if e.errno != errno.ENOTEMPTY:
+                        raise
 
         os.remove(self.tracked_files_file)
         os.remove(self.version_file)

--- a/proton
+++ b/proton
@@ -45,9 +45,11 @@ def file_is_wine_fake_dll(path):
 
 def makedirs(path):
     try:
+        if os.path.lexists(path):
+            return
+        
         os.makedirs(path)
     except OSError:
-        #already exists
         pass
 
 def try_copy(src, dst):

--- a/proton
+++ b/proton
@@ -168,7 +168,7 @@ class CompatData:
                         dirs.append(path)
             for d in dirs:
                 try:
-                    if len(os.listdir(d)) != 0:
+                    if not any(os.scandir(d)):
                         os.rmdir(d)
                 except OSError as err:
                     log("Error deleting directory {0}: {1}".format(d, err))

--- a/proton
+++ b/proton
@@ -168,9 +168,10 @@ class CompatData:
                         dirs.append(path)
             for d in dirs:
                 try:
-                    os.rmdir(d)
-                except OSError:
-                    #not empty
+                    if len(os.listdir(d)) != 0:
+                        os.rmdir(d)
+                except OSError as err:
+                    log("Error deleting directory {0}: {1}".format(d, err))
                     pass
 
         os.remove(self.tracked_files_file)

--- a/proton
+++ b/proton
@@ -260,7 +260,7 @@ class CompatData:
                     rel_dir = rel_dir + "/"
                 dst_dir = src_dir.replace(g_proton.default_pfx_dir, self.prefix_dir, 1)
                 if not os.path.exists(dst_dir):
-                    os.makedirs(dst_dir)
+                    makedirs(dst_dir)
                     tracked_files.write(rel_dir + "\n")
                 for dir_ in dirs:
                     src_file = os.path.join(src_dir, dir_)

--- a/proton
+++ b/proton
@@ -49,7 +49,8 @@ def makedirs(path):
             return
         
         os.makedirs(path)
-    except OSError:
+    except OSError as err:
+        log("Error when creating directory {0}: {1}".format(path, err))
         pass
 
 def try_copy(src, dst):


### PR DESCRIPTION
The current implementation of makedirs suppresses every OSError possible and assumes the directory already exists when one is raised. This is problematic as there are many reasons why the error could occur, and suppressing it could make it hard to trace the problem back in the future.

My implementation fixes this by checking whether the path exists before attempting to create it, and logs every other OSError appropriately.

I also took the liberty of changing a stray `os.makedirs` call to our `makedirs` function.