### PR TITLE
proton: Add option to disable DXVK for d3d9.

### DIFF
--- a/proton
+++ b/proton
@@ -449,6 +449,7 @@ class Session:
             self.check_environment("PROTON_USE_WINED3D11", "wined3d")
         self.check_environment("PROTON_NO_D3D11", "nod3d11")
         self.check_environment("PROTON_NO_D3D10", "nod3d10")
+        self.check_environment("PROTON_NO_D3D9", "nod3d9")
         self.check_environment("PROTON_NO_ESYNC", "noesync")
         self.check_environment("PROTON_NO_FSYNC", "nofsync")
         self.check_environment("PROTON_FORCE_LARGE_ADDRESS_AWARE", "forcelgadd")
@@ -500,6 +501,9 @@ class Session:
             self.dlloverrides["d3d10_1"] = ""
             self.dlloverrides["d3d10"] = ""
             self.dlloverrides["dxgi"] = ""
+
+        if "nod3d9" in self.compat_config:
+            self.dlloverrides["d3d9"] = ""
 
         s = ""
         for dll in self.dlloverrides:


### PR DESCRIPTION
Whilst the main game of Elite Dangerous (the "client") uses D3D11, the launcher uses D3D9 (via WPF in dotnet40).

Unfortunately, DXVK doesn't appear to render the launcher correctly. For example, the 'PLAY' button (which launches the game) does not appear.

By disabling just D3D9 for DXVK, the launcher will render correctly but the main game will still run using DXVK.

This patch introduces the option 'PROTON_NO_D3D9', which allows the disabling of just D3D9 rendering via DXVK.

Here's a couple of screen shots to better highlight the Elite Dangerous issue:
With DXVK rendering D3D9
![image](https://user-images.githubusercontent.com/8346438/74129302-55845380-4c33-11ea-9ae0-b2e57283a6aa.png)

After applying the suggested patch and using the following launch options:
![image](https://user-images.githubusercontent.com/8346438/74129355-7a78c680-4c33-11ea-9a21-5e3c35a34099.png)

![image](https://user-images.githubusercontent.com/8346438/74129514-dd6a5d80-4c33-11ea-8423-47acbca8b4c3.png)
