### PR TITLE
build: Use MAKE variable for building modules.

### DIFF
--- a/build/makefile_base.mak
+++ b/build/makefile_base.mak
@@ -507,11 +507,11 @@ redist: dist | $(filter-out dist deploy install redist,$(MAKECMDGOALS))
 
 module32: SHELL = $(CONTAINER_SHELL32)
 module32:
-	cd $(WINE_OBJ32)/dlls/$(module) && make
+	+$(MAKE) -C $(WINE_OBJ32)/dlls/$(module)
 
 module64: SHELL = $(CONTAINER_SHELL64)
 module64:
-	cd $(WINE_OBJ64)/dlls/$(module) && make
+	+$(MAKE) -C $(WINE_OBJ64)/dlls/$(module)
 
 module: module32 module64
 


### PR DESCRIPTION
So that options like -j can be passed through.

Signed-off-by: Zhiyi Zhang <zzhang@codeweavers.com>