### PR TITLE
Limit CPU count to 32 for VirtualBox hosts.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,7 +44,7 @@ Vagrant.configure(2) do |config|
   config.vagrant.plugins = "vagrant-sshfs"
 
   config.vm.provider "virtualbox" do |v|
-    v.cpus = cpus
+    v.cpus = [cpus, 32].min     # virtualbox limit is 32 cpus
     v.memory = memory
   end
 


### PR DESCRIPTION
VirtualBox (see [manual](https://www.virtualbox.org/manual/ch01.html), search for "cpus"):

  >  can present up to 32 virtual CPUs to each virtual machine

which is fewer than detected on some newer processors. Here is the error message one might get from `make install` on a 36-core machine:

```
==> debian10: Running 'pre-boot' VM customizations...
A customization command failed:

["modifyvm", :id, "--cpus", 36]

The following error was experienced:

for controlling VirtualBox. The command and stderr is shown below.

Command: ["modifyvm", "5c612de1-02dd-4291-9409-e85402bb9900", "--cpus", "36"]

Stderr: VBoxManage: error: Invalid virtual CPU count: 36 (must be in range [1, 32])
VBoxManage: error: Details: code NS_ERROR_INVALID_ARG (0x80070057), component SessionMachine, interface IMachine, callee nsISupports
VBoxManage: error: Context: "COMSETTER(CPUCount)(ValueUnion.u32)" at line 830 of file VBoxManageModifyVM.cpp

Please fix this customization and try again.
```

This PR simply limits CPUs to 32 when using VirtualBox.