### PR TITLE
Implement SDK 148 - SteamNetworkingSockets008

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 /.vagrant/
 /vagrant_share/
+.vscode

--- a/lsteamclient/cppISteamNetworkingSockets_SteamNetworkingSockets008.cpp
+++ b/lsteamclient/cppISteamNetworkingSockets_SteamNetworkingSockets008.cpp
@@ -1,0 +1,185 @@
+#include "steam_defs.h"
+#pragma push_macro("__cdecl")
+#undef __cdecl
+#include "steamworks_sdk_148a/steam_api.h"
+#include "steamworks_sdk_148a/steamnetworkingtypes.h"
+#include "steamworks_sdk_148a/isteamnetworkingsockets.h"
+#include "steamworks_sdk_148a/isteamnetworkingutils.h"
+#pragma pop_macro("__cdecl")
+#include "steamclient_private.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+#define SDKVER_148a
+#include "struct_converters.h"
+#include "cppISteamNetworkingSockets_SteamNetworkingSockets008.h"
+
+HSteamListenSocket cppISteamNetworkingSockets_SteamNetworkingSockets008_CreateListenSocketIP( void *linux_side, const SteamNetworkingIPAddr * localAddress, int nOptions, const SteamNetworkingConfigValue_t * pOptions )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->CreateListenSocketIP( (const SteamNetworkingIPAddr) *localAddress,nOptions,pOptions );
+}
+HSteamNetConnection cppISteamNetworkingSockets_SteamNetworkingSockets008_ConnectByIPAddress( void *linux_side, const SteamNetworkingIPAddr * address, int nOptions, const SteamNetworkingConfigValue_t * pOptions )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->ConnectByIPAddress( (const SteamNetworkingIPAddr) *address,nOptions,pOptions );
+}
+
+HSteamListenSocket cppISteamNetworkingSockets_SteamNetworkingSockets008_CreateListenSocketP2P( void *linux_side, int nVirtualPort, int nOptions, const SteamNetworkingConfigValue_t * pOptions )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->CreateListenSocketP2P( nVirtualPort,nOptions,pOptions );
+}
+HSteamNetConnection cppISteamNetworkingSockets_SteamNetworkingSockets008_ConnectP2P( void *linux_side, const SteamNetworkingIdentity * identityRemote, int nVirtualPort, int nOptions, const SteamNetworkingConfigValue_t * pOptions )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->ConnectP2P( *identityRemote,nVirtualPort,nOptions,pOptions );
+}
+
+EResult cppISteamNetworkingSockets_SteamNetworkingSockets008_AcceptConnection( void *linux_side, HSteamNetConnection hConn )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->AcceptConnection( hConn );
+}
+bool cppISteamNetworkingSockets_SteamNetworkingSockets008_CloseConnection( void *linux_side, HSteamNetConnection hPeer, int nReason, const char * pszDebug, bool bEnableLinger )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->CloseConnection( hPeer,nReason,pszDebug,bEnableLinger );
+}
+bool cppISteamNetworkingSockets_SteamNetworkingSockets008_CloseListenSocket( void *linux_side, HSteamListenSocket hSocket )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->CloseListenSocket( hSocket );
+}
+bool cppISteamNetworkingSockets_SteamNetworkingSockets008_SetConnectionUserData( void *linux_side, HSteamNetConnection hPeer, int64 nUserData )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->SetConnectionUserData( hPeer,nUserData );
+}
+int64 cppISteamNetworkingSockets_SteamNetworkingSockets008_GetConnectionUserData( void *linux_side, HSteamNetConnection hPeer )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->GetConnectionUserData( hPeer );
+}
+void cppISteamNetworkingSockets_SteamNetworkingSockets008_SetConnectionName( void *linux_side, HSteamNetConnection hPeer, const char * pszName )
+{
+	((ISteamNetworkingSockets*)linux_side)->SetConnectionName( hPeer,pszName );
+}
+bool cppISteamNetworkingSockets_SteamNetworkingSockets008_GetConnectionName( void *linux_side, HSteamNetConnection hPeer, char * pszName, int nMaxLen )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->GetConnectionName( hPeer,pszName,nMaxLen );
+}
+EResult cppISteamNetworkingSockets_SteamNetworkingSockets008_SendMessageToConnection( void *linux_side, HSteamNetConnection hConn, const void * pData, uint32 cbData, int nSendFlags, int64 * pOutMessageNumber )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->SendMessageToConnection( hConn,pData,cbData,nSendFlags,pOutMessageNumber );
+}
+// steamclient_manual_148.cpp
+// void cppISteamNetworkingSockets_SteamNetworkingSockets008_SendMessages( void *linux_side, int nMessages, winSteamNetworkingMessage_t_148a *const * pMessages, int64 * pOutMessageNumberOrResult )
+// {
+// 	((ISteamNetworkingSockets*)linux_side)->SendMessages( nMessages,(SteamNetworkingMessage_t *const *) pMessages,pOutMessageNumberOrResult );
+// }
+EResult cppISteamNetworkingSockets_SteamNetworkingSockets008_FlushMessagesOnConnection( void *linux_side, HSteamNetConnection hConn )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->FlushMessagesOnConnection( hConn );
+}
+// steamclient_manual_148.cpp
+// int cppISteamNetworkingSockets_SteamNetworkingSockets008_ReceiveMessagesOnConnection( void *linux_side, HSteamNetConnection hConn, winSteamNetworkingMessage_t_148a ** ppOutMessages, int nMaxMessages )
+// {
+// 	return ((ISteamNetworkingSockets*)linux_side)->ReceiveMessagesOnConnection( hConn, (SteamNetworkingMessage_t **) ppOutMessages,nMaxMessages );
+// }
+bool cppISteamNetworkingSockets_SteamNetworkingSockets008_GetConnectionInfo( void *linux_side, HSteamNetConnection hConn, SteamNetConnectionInfo_t * pInfo )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->GetConnectionInfo( hConn,pInfo );
+}
+bool cppISteamNetworkingSockets_SteamNetworkingSockets008_GetQuickConnectionStatus( void *linux_side, HSteamNetConnection hConn, SteamNetworkingQuickConnectionStatus * pStats )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->GetQuickConnectionStatus( hConn,pStats );
+}
+int cppISteamNetworkingSockets_SteamNetworkingSockets008_GetDetailedConnectionStatus( void *linux_side, HSteamNetConnection hConn, char * pszBuf, int cbBuf )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->GetDetailedConnectionStatus( hConn,pszBuf,cbBuf );
+}
+bool cppISteamNetworkingSockets_SteamNetworkingSockets008_GetListenSocketAddress( void *linux_side, HSteamListenSocket hSocket, SteamNetworkingIPAddr * address )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->GetListenSocketAddress( hSocket,address );
+}
+bool cppISteamNetworkingSockets_SteamNetworkingSockets008_CreateSocketPair( void *linux_side, HSteamNetConnection * pOutConnection1, HSteamNetConnection * pOutConnection2, bool bUseNetworkLoopback, const SteamNetworkingIdentity * pIdentity1, const SteamNetworkingIdentity * pIdentity2 )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->CreateSocketPair( pOutConnection1,pOutConnection2,bUseNetworkLoopback,pIdentity1,pIdentity2 );
+}
+bool cppISteamNetworkingSockets_SteamNetworkingSockets008_GetIdentity( void *linux_side, SteamNetworkingIdentity * pIdentity )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->GetIdentity( pIdentity );
+}
+ESteamNetworkingAvailability cppISteamNetworkingSockets_SteamNetworkingSockets008_InitAuthentication( void *linux_side )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->InitAuthentication(  );
+}
+ESteamNetworkingAvailability cppISteamNetworkingSockets_SteamNetworkingSockets008_GetAuthenticationStatus( void *linux_side, SteamNetAuthenticationStatus_t * pDetails )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->GetAuthenticationStatus( pDetails );
+}
+
+bool cppISteamNetworkingSockets_SteamNetworkingSockets008_ReceivedRelayAuthTicket( void *linux_side, const void * pvTicket, int cbTicket, SteamDatagramRelayAuthTicket * pOutParsedTicket )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->ReceivedRelayAuthTicket( pvTicket,cbTicket,pOutParsedTicket );
+}
+int cppISteamNetworkingSockets_SteamNetworkingSockets008_FindRelayAuthTicketForServer( void *linux_side, const SteamNetworkingIdentity * identityGameServer, int nVirtualPort, SteamDatagramRelayAuthTicket * pOutParsedTicket )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->FindRelayAuthTicketForServer( *identityGameServer,nVirtualPort,pOutParsedTicket );
+}
+HSteamNetConnection cppISteamNetworkingSockets_SteamNetworkingSockets008_ConnectToHostedDedicatedServer( void *linux_side, const SteamNetworkingIdentity * identityTarget, int nVirtualPort, int nOptions, const SteamNetworkingConfigValue_t * pOptions )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->ConnectToHostedDedicatedServer( *identityTarget,nVirtualPort,nOptions,pOptions );
+}
+uint16 cppISteamNetworkingSockets_SteamNetworkingSockets008_GetHostedDedicatedServerPort( void *linux_side )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->GetHostedDedicatedServerPort(  );
+}
+SteamNetworkingPOPID cppISteamNetworkingSockets_SteamNetworkingSockets008_GetHostedDedicatedServerPOPID( void *linux_side )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->GetHostedDedicatedServerPOPID(  );
+}
+EResult cppISteamNetworkingSockets_SteamNetworkingSockets008_GetHostedDedicatedServerAddress( void *linux_side, SteamDatagramHostedAddress * pRouting )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->GetHostedDedicatedServerAddress( pRouting );
+}
+HSteamListenSocket cppISteamNetworkingSockets_SteamNetworkingSockets008_CreateHostedDedicatedServerListenSocket( void *linux_side, int nVirtualPort, int nOptions, const SteamNetworkingConfigValue_t * pOptions )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->CreateHostedDedicatedServerListenSocket( nVirtualPort,nOptions,pOptions );
+}
+EResult cppISteamNetworkingSockets_SteamNetworkingSockets008_GetGameCoordinatorServerLogin( void *linux_side, SteamDatagramGameCoordinatorServerLogin * pLoginInfo, int * pcbSignedBlob, void * pBlob )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->GetGameCoordinatorServerLogin( pLoginInfo,pcbSignedBlob,pBlob );
+}
+HSteamNetConnection cppISteamNetworkingSockets_SteamNetworkingSockets008_ConnectP2PCustomSignaling( void *linux_side, ISteamNetworkingConnectionCustomSignaling * pSignaling, const SteamNetworkingIdentity * pPeerIdentity, int nOptions, const SteamNetworkingConfigValue_t * pOptions )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->ConnectP2PCustomSignaling( pSignaling,pPeerIdentity,nOptions,pOptions );
+}
+bool cppISteamNetworkingSockets_SteamNetworkingSockets008_ReceivedP2PCustomSignal( void *linux_side, const void * pMsg, int cbMsg, ISteamNetworkingCustomSignalingRecvContext * pContext )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->ReceivedP2PCustomSignal( pMsg,cbMsg,pContext );
+}
+
+// New methods
+bool cppISteamNetworkingSockets_SteamNetworkingSockets008_GetCertificateRequest( void *linux_side, int * pcbBlob, void * pBlob, SteamNetworkingErrMsg * errMsg )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->GetCertificateRequest( pcbBlob,pBlob,*errMsg );
+}
+bool cppISteamNetworkingSockets_SteamNetworkingSockets008_SetCertificate( void *linux_side, const void * pCertificate, int cbCertificate, SteamNetworkingErrMsg * errMsg )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->SetCertificate( pCertificate,cbCertificate,*errMsg );
+}
+HSteamNetPollGroup cppISteamNetworkingSockets_SteamNetworkingSockets008_CreatePollGroup( void *linux_side )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->CreatePollGroup(  );
+}
+bool cppISteamNetworkingSockets_SteamNetworkingSockets008_DestroyPollGroup( void *linux_side, HSteamNetPollGroup hPollGroup )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->DestroyPollGroup( hPollGroup );
+}
+bool cppISteamNetworkingSockets_SteamNetworkingSockets008_SetConnectionPollGroup( void *linux_side, HSteamNetConnection hConn, HSteamNetPollGroup hPollGroup )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->SetConnectionPollGroup( hConn,hPollGroup );
+}
+
+// @todo define in steamclient_manual_148.cpp
+// int cppISteamNetworkingSockets_SteamNetworkingSockets008_ReceiveMessagesOnPollGroup( void *linux_side, HSteamNetPollGroup hPollGroup, winSteamNetworkingMessage_t_148a ** ppOutMessages, int nMaxMessages )
+// {
+// 	return ((ISteamNetworkingSockets*)linux_side)->ReceiveMessagesOnPollGroup( hPollGroup,(SteamNetworkingMessage_t **)ppOutMessages,nMaxMessages );
+// }
+
+#ifdef __cplusplus
+}
+#endif

--- a/lsteamclient/cppISteamNetworkingSockets_SteamNetworkingSockets008.h
+++ b/lsteamclient/cppISteamNetworkingSockets_SteamNetworkingSockets008.h
@@ -1,0 +1,44 @@
+extern HSteamListenSocket cppISteamNetworkingSockets_SteamNetworkingSockets008_CreateListenSocketIP( void *, const SteamNetworkingIPAddr *, int, const SteamNetworkingConfigValue_t * );
+extern HSteamNetConnection cppISteamNetworkingSockets_SteamNetworkingSockets008_ConnectByIPAddress( void *, const SteamNetworkingIPAddr *, int, const SteamNetworkingConfigValue_t * );
+extern HSteamListenSocket cppISteamNetworkingSockets_SteamNetworkingSockets008_CreateListenSocketP2P( void *, int, int, const SteamNetworkingConfigValue_t * );
+extern HSteamNetConnection cppISteamNetworkingSockets_SteamNetworkingSockets008_ConnectP2P( void *, const SteamNetworkingIdentity *, int, int, const SteamNetworkingConfigValue_t * );
+extern EResult cppISteamNetworkingSockets_SteamNetworkingSockets008_AcceptConnection( void *, HSteamNetConnection );
+extern bool cppISteamNetworkingSockets_SteamNetworkingSockets008_CloseConnection( void *, HSteamNetConnection, int, const char *, bool );
+extern bool cppISteamNetworkingSockets_SteamNetworkingSockets008_CloseListenSocket( void *, HSteamListenSocket );
+extern bool cppISteamNetworkingSockets_SteamNetworkingSockets008_SetConnectionUserData( void *, HSteamNetConnection, int64 );
+extern int64 cppISteamNetworkingSockets_SteamNetworkingSockets008_GetConnectionUserData( void *, HSteamNetConnection );
+extern void cppISteamNetworkingSockets_SteamNetworkingSockets008_SetConnectionName( void *, HSteamNetConnection, const char * );
+extern bool cppISteamNetworkingSockets_SteamNetworkingSockets008_GetConnectionName( void *, HSteamNetConnection, char *, int );
+extern EResult cppISteamNetworkingSockets_SteamNetworkingSockets008_SendMessageToConnection( void *, HSteamNetConnection, const void *, uint32, int, int64 * );
+extern void cppISteamNetworkingSockets_SteamNetworkingSockets008_SendMessages( void *, int nMessages, winSteamNetworkingMessage_t_148a *const *, int64 * );
+extern EResult cppISteamNetworkingSockets_SteamNetworkingSockets008_FlushMessagesOnConnection( void *, HSteamNetConnection );
+extern int cppISteamNetworkingSockets_SteamNetworkingSockets008_ReceiveMessagesOnConnection( void *, HSteamNetConnection, winSteamNetworkingMessage_t_148a **, int );
+extern bool cppISteamNetworkingSockets_SteamNetworkingSockets008_GetConnectionInfo( void *, HSteamNetConnection, SteamNetConnectionInfo_t * );
+extern bool cppISteamNetworkingSockets_SteamNetworkingSockets008_GetQuickConnectionStatus( void *, HSteamNetConnection, SteamNetworkingQuickConnectionStatus * );
+extern int cppISteamNetworkingSockets_SteamNetworkingSockets008_GetDetailedConnectionStatus( void *, HSteamNetConnection, char *, int );
+extern bool cppISteamNetworkingSockets_SteamNetworkingSockets008_GetListenSocketAddress( void *, HSteamListenSocket, SteamNetworkingIPAddr * );
+extern bool cppISteamNetworkingSockets_SteamNetworkingSockets008_CreateSocketPair(void *, HSteamNetConnection *, HSteamNetConnection *, bool, const SteamNetworkingIdentity *, const SteamNetworkingIdentity *);
+extern bool cppISteamNetworkingSockets_SteamNetworkingSockets008_GetIdentity( void *, SteamNetworkingIdentity * );
+extern ESteamNetworkingAvailability cppISteamNetworkingSockets_SteamNetworkingSockets008_InitAuthentication( void * );
+extern ESteamNetworkingAvailability cppISteamNetworkingSockets_SteamNetworkingSockets008_GetAuthenticationStatus( void *, SteamNetAuthenticationStatus_t * );
+extern bool cppISteamNetworkingSockets_SteamNetworkingSockets008_ReceivedRelayAuthTicket( void *, const void *, int, SteamDatagramRelayAuthTicket * );
+extern int cppISteamNetworkingSockets_SteamNetworkingSockets008_FindRelayAuthTicketForServer( void *, const SteamNetworkingIdentity *, int, SteamDatagramRelayAuthTicket * );
+extern HSteamNetConnection cppISteamNetworkingSockets_SteamNetworkingSockets008_ConnectToHostedDedicatedServer( void *, const SteamNetworkingIdentity *, int, int, const SteamNetworkingConfigValue_t * );
+extern uint16 cppISteamNetworkingSockets_SteamNetworkingSockets008_GetHostedDedicatedServerPort( void * );
+extern SteamNetworkingPOPID cppISteamNetworkingSockets_SteamNetworkingSockets008_GetHostedDedicatedServerPOPID( void * );
+extern EResult cppISteamNetworkingSockets_SteamNetworkingSockets008_GetHostedDedicatedServerAddress( void *, SteamDatagramHostedAddress * );
+extern HSteamListenSocket cppISteamNetworkingSockets_SteamNetworkingSockets008_CreateHostedDedicatedServerListenSocket( void *, int, int, const SteamNetworkingConfigValue_t * );
+extern EResult cppISteamNetworkingSockets_SteamNetworkingSockets008_GetGameCoordinatorServerLogin( void *, SteamDatagramGameCoordinatorServerLogin *, int *, void * );
+extern HSteamNetConnection cppISteamNetworkingSockets_SteamNetworkingSockets008_ConnectP2PCustomSignaling( void *, ISteamNetworkingConnectionCustomSignaling *, const SteamNetworkingIdentity *, int, const SteamNetworkingConfigValue_t * );
+extern bool cppISteamNetworkingSockets_SteamNetworkingSockets008_ReceivedP2PCustomSignal( void *, const void *, int, ISteamNetworkingCustomSignalingRecvContext * );
+
+// Removed methods
+//extern int cppISteamNetworkingSockets_SteamNetworkingSockets008_ReceiveMessagesOnListenSocket(void *, HSteamListenSocket, winSteamNetworkingMessage_t_148a **, int);
+
+// New methods
+extern bool cppISteamNetworkingSockets_SteamNetworkingSockets008_GetCertificateRequest( void *, int *, void *, SteamNetworkingErrMsg * );
+extern bool cppISteamNetworkingSockets_SteamNetworkingSockets008_SetCertificate( void *, const void *, int, SteamNetworkingErrMsg * );
+extern HSteamNetPollGroup cppISteamNetworkingSockets_SteamNetworkingSockets008_CreatePollGroup( void * );
+extern bool cppISteamNetworkingSockets_SteamNetworkingSockets008_DestroyPollGroup( void *, HSteamNetPollGroup );
+extern bool cppISteamNetworkingSockets_SteamNetworkingSockets008_SetConnectionPollGroup( void *, HSteamNetConnection, HSteamNetPollGroup );
+extern int cppISteamNetworkingSockets_SteamNetworkingSockets008_ReceiveMessagesOnPollGroup( void *, HSteamNetPollGroup, winSteamNetworkingMessage_t_148a **, int );

--- a/lsteamclient/gen_wrapper.py
+++ b/lsteamclient/gen_wrapper.py
@@ -15,6 +15,7 @@ import re
 import math
 
 sdk_versions = [
+    "148a",
     "147",
     "146",
     "145",
@@ -183,6 +184,11 @@ manually_handled_methods = {
             "ReceiveMessagesOnListenSocket"
         ],
         "cppISteamNetworkingSockets_SteamNetworkingSockets006": [
+            "ReceiveMessagesOnConnection",
+            "ReceiveMessagesOnListenSocket",
+            "SendMessages"
+        ],
+        "cppISteamNetworkingSockets_SteamNetworkingSockets008": [
             "ReceiveMessagesOnConnection",
             "ReceiveMessagesOnListenSocket",
             "SendMessages"

--- a/lsteamclient/steam_defs.h
+++ b/lsteamclient/steam_defs.h
@@ -284,6 +284,10 @@ typedef uint32 HSteamListenSocket;
 typedef uint32 SteamNetworkingPOPID;
 typedef uint32 RemotePlaySessionID_t;
 
+//sdk148
+typedef char SteamNetworkingErrMsg[1024];
+typedef uint32 HSteamNetPollGroup;
+
 #pragma pack( push, 4 )
 typedef struct CallbackMsg_t
 {

--- a/lsteamclient/steamclient_manual_148.cpp
+++ b/lsteamclient/steamclient_manual_148.cpp
@@ -1,0 +1,208 @@
+extern "C" {
+#include <stdarg.h>
+
+#include "windef.h"
+#include "winbase.h"
+#include "wine/debug.h"
+
+WINE_DEFAULT_DEBUG_CHANNEL(steamclient);
+}
+
+#include "steam_defs.h"
+#pragma push_macro("__cdecl")
+#undef __cdecl
+#include "steamworks_sdk_148a/steam_api.h"
+#include "steamworks_sdk_148a/isteamnetworkingsockets.h"
+#include "steamworks_sdk_148a/isteamnetworkingutils.h"
+#include "steamworks_sdk_148a/steamnetworkingtypes.h"
+#pragma pop_macro("__cdecl")
+#include "steamclient_private.h"
+
+extern "C" {
+#define SDKVER_148a
+#include "struct_converters.h"
+
+#include "queue.h"
+
+/***** manual struct converter for SteamNetworkingMessage_t *****/
+
+struct msg_wrapper {
+    struct winSteamNetworkingMessage_t_148a win_msg;
+    struct SteamNetworkingMessage_t *lin_msg;
+
+    void (*orig_FreeData)(SteamNetworkingMessage_t *);
+
+    SLIST_ENTRY(msg_wrapper) entry;
+};
+
+static SLIST_HEAD(free_msgs_head, msg_wrapper) free_msgs = SLIST_HEAD_INITIALIZER(free_msgs);
+static CRITICAL_SECTION free_msgs_lock = { NULL, -1, 0, 0, 0, 0 };
+
+static void __attribute__((ms_abi)) win_FreeData(struct winSteamNetworkingMessage_t_148a *win_msg)
+{
+    struct msg_wrapper *msg = CONTAINING_RECORD(win_msg, struct msg_wrapper, win_msg);
+    TRACE("%p\n", msg);
+    if(msg->orig_FreeData)
+    {
+        msg->lin_msg->m_pData = msg->win_msg.m_pData;
+        msg->orig_FreeData(msg->lin_msg);
+    }
+}
+
+static void __attribute__((ms_abi)) win_Release(struct winSteamNetworkingMessage_t_148a *win_msg)
+{
+    struct msg_wrapper *msg = CONTAINING_RECORD(win_msg, struct msg_wrapper, win_msg);
+    TRACE("%p\n", msg);
+    msg->lin_msg->m_pfnRelease(msg->lin_msg);
+    msg->lin_msg = NULL;
+    msg->orig_FreeData = NULL;
+    EnterCriticalSection(&free_msgs_lock);
+    SLIST_INSERT_HEAD(&free_msgs, msg, entry);
+    LeaveCriticalSection(&free_msgs_lock);
+}
+
+static void lin_FreeData(struct SteamNetworkingMessage_t *lin_msg)
+{
+    struct msg_wrapper *msg = (struct msg_wrapper *)lin_msg->m_pData; /* ! see assignment, below */
+    TRACE("%p\n", msg);
+    if(msg->win_msg.m_pfnFreeData)
+        ((void (__attribute__((ms_abi))*)(struct winSteamNetworkingMessage_t_148a *))msg->win_msg.m_pfnFreeData)(&msg->win_msg);
+}
+
+static struct msg_wrapper *clone_msg(struct SteamNetworkingMessage_t *lin_msg)
+{
+    struct msg_wrapper *msg;
+
+    EnterCriticalSection(&free_msgs_lock);
+    
+    msg = SLIST_FIRST(&free_msgs);
+
+    if(!msg){
+        int n;
+        /* allocs can be pricey, so alloc in blocks */
+#define MSGS_PER_BLOCK 16
+        struct msg_wrapper *msgs = (struct msg_wrapper *)HeapAlloc(GetProcessHeap(), 0, sizeof(struct msg_wrapper) * MSGS_PER_BLOCK);
+        for(n = 1; n < MSGS_PER_BLOCK; ++n)
+            SLIST_INSERT_HEAD(&free_msgs, &msgs[n], entry);
+        msg = &msgs[0];
+    }else
+        SLIST_REMOVE_HEAD(&free_msgs, entry);
+
+    LeaveCriticalSection(&free_msgs_lock);
+
+    msg->lin_msg = lin_msg;
+
+    msg->win_msg.m_pData = msg->lin_msg->m_pData;
+    msg->win_msg.m_cbSize = msg->lin_msg->m_cbSize;
+    msg->win_msg.m_conn = msg->lin_msg->m_conn;
+    msg->win_msg.m_identityPeer = msg->lin_msg->m_identityPeer;
+    msg->win_msg.m_nConnUserData = msg->lin_msg->m_nConnUserData;
+    msg->win_msg.m_usecTimeReceived= msg->lin_msg->m_usecTimeReceived;
+    msg->win_msg.m_nMessageNumber = msg->lin_msg->m_nMessageNumber;
+    msg->win_msg.m_pfnFreeData = (void*)win_FreeData;
+    msg->win_msg.m_pfnRelease = (void*)win_Release;
+    msg->win_msg.m_nChannel = msg->lin_msg->m_nChannel;
+    msg->win_msg.m_nFlags = msg->lin_msg->m_nFlags;
+    msg->win_msg.m_nUserData = msg->lin_msg->m_nUserData;
+
+    msg->orig_FreeData = msg->lin_msg->m_pfnFreeData;
+    msg->lin_msg->m_pfnFreeData = lin_FreeData;
+    /* ! store the wrapper here and restore the original pointer from win_msg before calling orig_FreeData */
+    msg->lin_msg->m_pData = msg;
+
+    return msg;
+}
+
+void lin_to_win_struct_SteamNetworkingMessage_t_148a(int n_messages, struct SteamNetworkingMessage_t **l, struct winSteamNetworkingMessage_t_148a **w, int max_messages)
+{
+    int i;
+
+    if(n_messages > 0)
+        TRACE("%u %p %p\n", n_messages, l, w);
+
+    for(i = 0; i < n_messages; ++i)
+    {
+        struct msg_wrapper *msg;
+
+        msg = clone_msg(l[i]);
+
+        w[i] = &msg->win_msg;
+
+        TRACE("done with %u, returned wrapper %p\n", i, msg);
+    }
+
+    for(; i < max_messages; ++i)
+        w[i] = NULL;
+}
+
+int cppISteamNetworkingSockets_SteamNetworkingSockets008_ReceiveMessagesOnConnection(
+        void *linux_side, HSteamNetConnection hConn,
+        winSteamNetworkingMessage_t_148a **ppOutMessages, int nMaxMessages)
+{
+    SteamNetworkingMessage_t *lin_ppOutMessages[nMaxMessages];
+    int retval = ((ISteamNetworkingSockets*)linux_side)->ReceiveMessagesOnConnection(hConn, lin_ppOutMessages, nMaxMessages);
+    lin_to_win_struct_SteamNetworkingMessage_t_148a(retval, lin_ppOutMessages, ppOutMessages, nMaxMessages);
+    return retval;
+}
+
+// Removed.
+// int cppISteamNetworkingSockets_SteamNetworkingSockets008_ReceiveMessagesOnListenSocket(
+//         void *linux_side, HSteamListenSocket hSocket,
+//         winSteamNetworkingMessage_t_148a **ppOutMessages, int nMaxMessages)
+// {
+//     SteamNetworkingMessage_t *lin_ppOutMessages[nMaxMessages];
+//     int retval = ((ISteamNetworkingSockets*)linux_side)->ReceiveMessagesOnListenSocket(hSocket, lin_ppOutMessages, nMaxMessages);
+//     lin_to_win_struct_SteamNetworkingMessage_t_148a(retval, lin_ppOutMessages, ppOutMessages, nMaxMessages);
+//     return retval;
+// }
+
+void cppISteamNetworkingSockets_SteamNetworkingSockets008_SendMessages(
+        void *linux_side, int nMessages, winSteamNetworkingMessage_t_148a **pMessages,
+        int64 *pOutMessageNumberOrResult)
+{
+#define MAX_SEND_MESSAGES 64
+    /* use the stack to avoid heap allocation */
+    struct SteamNetworkingMessage_t *lin_msgs[MAX_SEND_MESSAGES];
+    int i;
+
+    if (nMessages > MAX_SEND_MESSAGES)
+    {
+        /* if we ever hit this, increase MAX_SEND_MESSAGES appropriately */
+        FIXME("Trying to send %u messages, which is more than %u! Will break up into pieces.\n", nMessages, MAX_SEND_MESSAGES);
+    }
+
+    while(nMessages)
+    {
+        for(i = 0; i < nMessages && i < MAX_SEND_MESSAGES; ++i)
+        {
+            struct msg_wrapper *msg = CONTAINING_RECORD(pMessages[i], struct msg_wrapper, win_msg);
+            lin_msgs[i] = msg->lin_msg;
+
+            lin_msgs[i]->m_pData = msg->win_msg.m_pData;
+            lin_msgs[i]->m_cbSize = msg->win_msg.m_cbSize;
+            lin_msgs[i]->m_conn = msg->win_msg.m_conn;
+            lin_msgs[i]->m_identityPeer = msg->win_msg.m_identityPeer;
+            lin_msgs[i]->m_nConnUserData = msg->win_msg.m_nConnUserData;
+            lin_msgs[i]->m_usecTimeReceived= msg->win_msg.m_usecTimeReceived;
+            lin_msgs[i]->m_nMessageNumber = msg->win_msg.m_nMessageNumber;
+            lin_msgs[i]->m_nChannel = msg->win_msg.m_nChannel;
+            lin_msgs[i]->m_nFlags = msg->win_msg.m_nFlags;
+            lin_msgs[i]->m_nUserData = msg->win_msg.m_nUserData;
+        }
+
+        ((ISteamNetworkingSockets*)linux_side)->SendMessages(i, lin_msgs, pOutMessageNumberOrResult);
+
+        nMessages -= i;
+        pMessages += i;
+        if(pOutMessageNumberOrResult)
+            pOutMessageNumberOrResult += i;
+    }
+}
+
+// @todo Implement manual override
+int cppISteamNetworkingSockets_SteamNetworkingSockets008_ReceiveMessagesOnPollGroup( void *linux_side, HSteamNetPollGroup hPollGroup, winSteamNetworkingMessage_t_148a ** ppOutMessages, int nMaxMessages )
+{
+	return ((ISteamNetworkingSockets*)linux_side)->ReceiveMessagesOnPollGroup( hPollGroup,(SteamNetworkingMessage_t **)ppOutMessages,nMaxMessages );
+}
+
+}

--- a/lsteamclient/steamworks_sdk_148a/isteamapplist.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamapplist.h
@@ -1,0 +1,67 @@
+//====== Copyright © 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to app data in Steam
+//
+//=============================================================================
+
+#ifndef ISTEAMAPPLIST_H
+#define ISTEAMAPPLIST_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+#include "steamtypes.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: This is a restricted interface that can only be used by previously approved apps,
+//	contact your Steam Account Manager if you believe you need access to this API.
+//	This interface lets you detect installed apps for the local Steam client, useful for debugging tools
+//	to offer lists of apps to debug via Steam.
+//-----------------------------------------------------------------------------
+class ISteamAppList
+{
+public:
+	virtual uint32 GetNumInstalledApps() = 0;
+	virtual uint32 GetInstalledApps( AppId_t *pvecAppID, uint32 unMaxAppIDs ) = 0;
+
+	virtual int  GetAppName( AppId_t nAppID, STEAM_OUT_STRING() char *pchName, int cchNameMax ) = 0; // returns -1 if no name was found
+	virtual int  GetAppInstallDir( AppId_t nAppID, char *pchDirectory, int cchNameMax ) = 0; // returns -1 if no dir was found
+
+	virtual int GetAppBuildId( AppId_t nAppID ) = 0; // return the buildid of this app, may change at any time based on backend updates to the game
+};
+
+#define STEAMAPPLIST_INTERFACE_VERSION "STEAMAPPLIST_INTERFACE_VERSION001"
+
+// Global interface accessor
+inline ISteamAppList *SteamAppList();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamAppList *, SteamAppList, STEAMAPPLIST_INTERFACE_VERSION );
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+
+
+//---------------------------------------------------------------------------------
+// Purpose: Sent when a new app is installed
+//---------------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( SteamAppInstalled_t, k_iSteamAppListCallbacks + 1 );
+	STEAM_CALLBACK_MEMBER( 0,	AppId_t,	m_nAppID )			// ID of the app that installs
+STEAM_CALLBACK_END(1)
+
+
+//---------------------------------------------------------------------------------
+// Purpose: Sent when an app is uninstalled
+//---------------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( SteamAppUninstalled_t, k_iSteamAppListCallbacks + 2 );
+	STEAM_CALLBACK_MEMBER( 0,	AppId_t,	m_nAppID )			// ID of the app that installs
+STEAM_CALLBACK_END(1)
+
+
+#pragma pack( pop )
+#endif // ISTEAMAPPLIST_H

--- a/lsteamclient/steamworks_sdk_148a/isteamapps.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamapps.h
@@ -1,0 +1,202 @@
+//====== Copyright © 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to app data in Steam
+//
+//=============================================================================
+
+#ifndef ISTEAMAPPS_H
+#define ISTEAMAPPS_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+
+const int k_cubAppProofOfPurchaseKeyMax = 240;			// max supported length of a legacy cd key 
+
+
+//-----------------------------------------------------------------------------
+// Purpose: interface to app data
+//-----------------------------------------------------------------------------
+class ISteamApps
+{
+public:
+	virtual bool BIsSubscribed() = 0;
+	virtual bool BIsLowViolence() = 0;
+	virtual bool BIsCybercafe() = 0;
+	virtual bool BIsVACBanned() = 0;
+	virtual const char *GetCurrentGameLanguage() = 0;
+	virtual const char *GetAvailableGameLanguages() = 0;
+
+	// only use this member if you need to check ownership of another game related to yours, a demo for example
+	virtual bool BIsSubscribedApp( AppId_t appID ) = 0;
+
+	// Takes AppID of DLC and checks if the user owns the DLC & if the DLC is installed
+	virtual bool BIsDlcInstalled( AppId_t appID ) = 0;
+
+	// returns the Unix time of the purchase of the app
+	virtual uint32 GetEarliestPurchaseUnixTime( AppId_t nAppID ) = 0;
+
+	// Checks if the user is subscribed to the current app through a free weekend
+	// This function will return false for users who have a retail or other type of license
+	// Before using, please ask your Valve technical contact how to package and secure your free weekened
+	virtual bool BIsSubscribedFromFreeWeekend() = 0;
+
+	// Returns the number of DLC pieces for the running app
+	virtual int GetDLCCount() = 0;
+
+	// Returns metadata for DLC by index, of range [0, GetDLCCount()]
+	virtual bool BGetDLCDataByIndex( int iDLC, AppId_t *pAppID, bool *pbAvailable, char *pchName, int cchNameBufferSize ) = 0;
+
+	// Install/Uninstall control for optional DLC
+	virtual void InstallDLC( AppId_t nAppID ) = 0;
+	virtual void UninstallDLC( AppId_t nAppID ) = 0;
+	
+	// Request legacy cd-key for yourself or owned DLC. If you are interested in this
+	// data then make sure you provide us with a list of valid keys to be distributed
+	// to users when they purchase the game, before the game ships.
+	// You'll receive an AppProofOfPurchaseKeyResponse_t callback when
+	// the key is available (which may be immediately).
+	virtual void RequestAppProofOfPurchaseKey( AppId_t nAppID ) = 0;
+
+	virtual bool GetCurrentBetaName( char *pchName, int cchNameBufferSize ) = 0; // returns current beta branch name, 'public' is the default branch
+	virtual bool MarkContentCorrupt( bool bMissingFilesOnly ) = 0; // signal Steam that game files seems corrupt or missing
+	virtual uint32 GetInstalledDepots( AppId_t appID, DepotId_t *pvecDepots, uint32 cMaxDepots ) = 0; // return installed depots in mount order
+
+	// returns current app install folder for AppID, returns folder name length
+	virtual uint32 GetAppInstallDir( AppId_t appID, char *pchFolder, uint32 cchFolderBufferSize ) = 0;
+	virtual bool BIsAppInstalled( AppId_t appID ) = 0; // returns true if that app is installed (not necessarily owned)
+	
+	// returns the SteamID of the original owner. If this CSteamID is different from ISteamUser::GetSteamID(),
+	// the user has a temporary license borrowed via Family Sharing
+	virtual CSteamID GetAppOwner() = 0; 
+
+	// Returns the associated launch param if the game is run via steam://run/<appid>//?param1=value1&param2=value2&param3=value3 etc.
+	// Parameter names starting with the character '@' are reserved for internal use and will always return and empty string.
+	// Parameter names starting with an underscore '_' are reserved for steam features -- they can be queried by the game,
+	// but it is advised that you not param names beginning with an underscore for your own features.
+	// Check for new launch parameters on callback NewUrlLaunchParameters_t
+	virtual const char *GetLaunchQueryParam( const char *pchKey ) = 0; 
+
+	// get download progress for optional DLC
+	virtual bool GetDlcDownloadProgress( AppId_t nAppID, uint64 *punBytesDownloaded, uint64 *punBytesTotal ) = 0; 
+
+	// return the buildid of this app, may change at any time based on backend updates to the game
+	virtual int GetAppBuildId() = 0;
+
+	// Request all proof of purchase keys for the calling appid and asociated DLC.
+	// A series of AppProofOfPurchaseKeyResponse_t callbacks will be sent with
+	// appropriate appid values, ending with a final callback where the m_nAppId
+	// member is k_uAppIdInvalid (zero).
+	virtual void RequestAllProofOfPurchaseKeys() = 0;
+
+	STEAM_CALL_RESULT( FileDetailsResult_t )
+	virtual SteamAPICall_t GetFileDetails( const char* pszFileName ) = 0;
+
+	// Get command line if game was launched via Steam URL, e.g. steam://run/<appid>//<command line>/.
+	// This method of passing a connect string (used when joining via rich presence, accepting an
+	// invite, etc) is preferable to passing the connect string on the operating system command
+	// line, which is a security risk.  In order for rich presence joins to go through this
+	// path and not be placed on the OS command line, you must set a value in your app's
+	// configuration on Steam.  Ask Valve for help with this.
+	//
+	// If game was already running and launched again, the NewUrlLaunchParameters_t will be fired.
+	virtual int GetLaunchCommandLine( char *pszCommandLine, int cubCommandLine ) = 0;
+
+	// Check if user borrowed this game via Family Sharing, If true, call GetAppOwner() to get the lender SteamID
+	virtual bool BIsSubscribedFromFamilySharing() = 0;
+};
+
+#define STEAMAPPS_INTERFACE_VERSION "STEAMAPPS_INTERFACE_VERSION008"
+
+// Global interface accessor
+inline ISteamApps *SteamApps();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamApps *, SteamApps, STEAMAPPS_INTERFACE_VERSION );
+
+// Global accessor for the gameserver client
+inline ISteamApps *SteamGameServerApps();
+STEAM_DEFINE_GAMESERVER_INTERFACE_ACCESSOR( ISteamApps *, SteamGameServerApps, STEAMAPPS_INTERFACE_VERSION );
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+//-----------------------------------------------------------------------------
+// Purpose: posted after the user gains ownership of DLC & that DLC is installed
+//-----------------------------------------------------------------------------
+struct DlcInstalled_t
+{
+	enum { k_iCallback = k_iSteamAppsCallbacks + 5 };
+	AppId_t m_nAppID;		// AppID of the DLC
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: possible results when registering an activation code
+//-----------------------------------------------------------------------------
+enum ERegisterActivationCodeResult
+{
+	k_ERegisterActivationCodeResultOK = 0,
+	k_ERegisterActivationCodeResultFail = 1,
+	k_ERegisterActivationCodeResultAlreadyRegistered = 2,
+	k_ERegisterActivationCodeResultTimeout = 3,
+	k_ERegisterActivationCodeAlreadyOwned = 4,
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: response to RegisterActivationCode()
+//-----------------------------------------------------------------------------
+struct RegisterActivationCodeResponse_t
+{
+	enum { k_iCallback = k_iSteamAppsCallbacks + 8 };
+	ERegisterActivationCodeResult m_eResult;
+	uint32 m_unPackageRegistered;						// package that was registered. Only set on success
+};
+
+
+//---------------------------------------------------------------------------------
+// Purpose: posted after the user gains executes a Steam URL with command line or query parameters
+// such as steam://run/<appid>//-commandline/?param1=value1&param2=value2&param3=value3 etc
+// while the game is already running.  The new params can be queried
+// with GetLaunchQueryParam and GetLaunchCommandLine
+//---------------------------------------------------------------------------------
+struct NewUrlLaunchParameters_t
+{
+	enum { k_iCallback = k_iSteamAppsCallbacks + 14 };
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: response to RequestAppProofOfPurchaseKey/RequestAllProofOfPurchaseKeys
+// for supporting third-party CD keys, or other proof-of-purchase systems.
+//-----------------------------------------------------------------------------
+struct AppProofOfPurchaseKeyResponse_t
+{
+	enum { k_iCallback = k_iSteamAppsCallbacks + 21 };
+	EResult m_eResult;
+	uint32	m_nAppID;
+	uint32	m_cchKeyLength;
+	char	m_rgchKey[k_cubAppProofOfPurchaseKeyMax];
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: response to GetFileDetails
+//-----------------------------------------------------------------------------
+struct FileDetailsResult_t
+{
+	enum { k_iCallback = k_iSteamAppsCallbacks + 23 };
+	EResult		m_eResult;
+	uint64		m_ulFileSize;	// original file size in bytes
+	uint8		m_FileSHA[20];	// original file SHA1 hash
+	uint32		m_unFlags;		// 
+};
+
+
+#pragma pack( pop )
+#endif // ISTEAMAPPS_H

--- a/lsteamclient/steamworks_sdk_148a/isteamappticket.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamappticket.h
@@ -1,0 +1,28 @@
+//====== Copyright 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: a private, but well versioned, interface to get at critical bits
+// of a steam3 appticket - consumed by the simple drm wrapper to let it 
+// ask about ownership with greater confidence.
+//
+//=============================================================================
+
+#ifndef ISTEAMAPPTICKET_H
+#define ISTEAMAPPTICKET_H
+#pragma once
+
+//-----------------------------------------------------------------------------
+// Purpose: hand out a reasonable "future proof" view of an app ownership ticket
+// the raw (signed) buffer, and indices into that buffer where the appid and 
+// steamid are located.  the sizes of the appid and steamid are implicit in 
+// (each version of) the interface - currently uin32 appid and uint64 steamid
+//-----------------------------------------------------------------------------
+class ISteamAppTicket
+{
+public:
+    virtual uint32 GetAppOwnershipTicketData( uint32 nAppID, void *pvBuffer, uint32 cbBufferLength, uint32 *piAppId, uint32 *piSteamId, uint32 *piSignature, uint32 *pcbSignature ) = 0;
+};
+
+#define STEAMAPPTICKET_INTERFACE_VERSION "STEAMAPPTICKET_INTERFACE_VERSION001"
+
+
+#endif // ISTEAMAPPTICKET_H

--- a/lsteamclient/steamworks_sdk_148a/isteamclient.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamclient.h
@@ -1,0 +1,179 @@
+﻿//====== Copyright Valve Corporation, All rights reserved. ====================
+//
+// Internal low-level access to Steamworks interfaces.
+//
+// Most users of the Steamworks SDK do not need to include this file.
+// You should only include this if you are doing something special.
+//=============================================================================
+
+#ifndef ISTEAMCLIENT_H
+#define ISTEAMCLIENT_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: Interface to creating a new steam instance, or to
+//			connect to an existing steam instance, whether it's in a
+//			different process or is local.
+//
+//			For most scenarios this is all handled automatically via SteamAPI_Init().
+//			You'll only need these APIs if you have a more complex versioning scheme,
+//			or if you want to implement a multiplexed gameserver where a single process
+//			is handling multiple games at once with independent gameserver SteamIDs.
+//-----------------------------------------------------------------------------
+class ISteamClient
+{
+public:
+	// Creates a communication pipe to the Steam client.
+	// NOT THREADSAFE - ensure that no other threads are accessing Steamworks API when calling
+	virtual HSteamPipe CreateSteamPipe() = 0;
+
+	// Releases a previously created communications pipe
+	// NOT THREADSAFE - ensure that no other threads are accessing Steamworks API when calling
+	virtual bool BReleaseSteamPipe( HSteamPipe hSteamPipe ) = 0;
+
+	// connects to an existing global user, failing if none exists
+	// used by the game to coordinate with the steamUI
+	// NOT THREADSAFE - ensure that no other threads are accessing Steamworks API when calling
+	virtual HSteamUser ConnectToGlobalUser( HSteamPipe hSteamPipe ) = 0;
+
+	// used by game servers, create a steam user that won't be shared with anyone else
+	// NOT THREADSAFE - ensure that no other threads are accessing Steamworks API when calling
+	virtual HSteamUser CreateLocalUser( HSteamPipe *phSteamPipe, EAccountType eAccountType ) = 0;
+
+	// removes an allocated user
+	// NOT THREADSAFE - ensure that no other threads are accessing Steamworks API when calling
+	virtual void ReleaseUser( HSteamPipe hSteamPipe, HSteamUser hUser ) = 0;
+
+	// retrieves the ISteamUser interface associated with the handle
+	virtual ISteamUser *GetISteamUser( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// retrieves the ISteamGameServer interface associated with the handle
+	virtual ISteamGameServer *GetISteamGameServer( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// set the local IP and Port to bind to
+	// this must be set before CreateLocalUser()
+	virtual void SetLocalIPBinding( const SteamIPAddress_t &unIP, uint16 usPort ) = 0; 
+
+	// returns the ISteamFriends interface
+	virtual ISteamFriends *GetISteamFriends( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// returns the ISteamUtils interface
+	virtual ISteamUtils *GetISteamUtils( HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// returns the ISteamMatchmaking interface
+	virtual ISteamMatchmaking *GetISteamMatchmaking( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// returns the ISteamMatchmakingServers interface
+	virtual ISteamMatchmakingServers *GetISteamMatchmakingServers( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// returns the a generic interface
+	virtual void *GetISteamGenericInterface( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// returns the ISteamUserStats interface
+	virtual ISteamUserStats *GetISteamUserStats( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// returns the ISteamGameServerStats interface
+	virtual ISteamGameServerStats *GetISteamGameServerStats( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// returns apps interface
+	virtual ISteamApps *GetISteamApps( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// networking
+	virtual ISteamNetworking *GetISteamNetworking( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// remote storage
+	virtual ISteamRemoteStorage *GetISteamRemoteStorage( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// user screenshots
+	virtual ISteamScreenshots *GetISteamScreenshots( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// game search
+	virtual ISteamGameSearch *GetISteamGameSearch( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// Deprecated. Applications should use SteamAPI_RunCallbacks() or SteamGameServer_RunCallbacks() instead.
+	STEAM_PRIVATE_API( virtual void RunFrame() = 0; )
+
+	// returns the number of IPC calls made since the last time this function was called
+	// Used for perf debugging so you can understand how many IPC calls your game makes per frame
+	// Every IPC call is at minimum a thread context switch if not a process one so you want to rate
+	// control how often you do them.
+	virtual uint32 GetIPCCallCount() = 0;
+
+	// API warning handling
+	// 'int' is the severity; 0 for msg, 1 for warning
+	// 'const char *' is the text of the message
+	// callbacks will occur directly after the API function is called that generated the warning or message.
+	virtual void SetWarningMessageHook( SteamAPIWarningMessageHook_t pFunction ) = 0;
+
+	// Trigger global shutdown for the DLL
+	virtual bool BShutdownIfAllPipesClosed() = 0;
+
+	// Expose HTTP interface
+	virtual ISteamHTTP *GetISteamHTTP( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// Deprecated - the ISteamUnifiedMessages interface is no longer intended for public consumption.
+	STEAM_PRIVATE_API( virtual void *DEPRECATED_GetISteamUnifiedMessages( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0 ; )
+
+	// Exposes the ISteamController interface - deprecated in favor of Steam Input
+	virtual ISteamController *GetISteamController( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// Exposes the ISteamUGC interface
+	virtual ISteamUGC *GetISteamUGC( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// returns app list interface, only available on specially registered apps
+	virtual ISteamAppList *GetISteamAppList( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+	
+	// Music Player
+	virtual ISteamMusic *GetISteamMusic( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// Music Player Remote
+	virtual ISteamMusicRemote *GetISteamMusicRemote(HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion) = 0;
+
+	// html page display
+	virtual ISteamHTMLSurface *GetISteamHTMLSurface(HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion) = 0;
+
+	// Helper functions for internal Steam usage
+	STEAM_PRIVATE_API( virtual void DEPRECATED_Set_SteamAPI_CPostAPIResultInProcess( void (*)() ) = 0; )
+	STEAM_PRIVATE_API( virtual void DEPRECATED_Remove_SteamAPI_CPostAPIResultInProcess( void (*)() ) = 0; )
+	STEAM_PRIVATE_API( virtual void Set_SteamAPI_CCheckCallbackRegisteredInProcess( SteamAPI_CheckCallbackRegistered_t func ) = 0; )
+
+	// inventory
+	virtual ISteamInventory *GetISteamInventory( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// Video
+	virtual ISteamVideo *GetISteamVideo( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// Parental controls
+	virtual ISteamParentalSettings *GetISteamParentalSettings( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// Exposes the Steam Input interface for controller support
+	virtual ISteamInput *GetISteamInput( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// Steam Parties interface
+	virtual ISteamParties *GetISteamParties( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// Steam Remote Play interface
+	virtual ISteamRemotePlay *GetISteamRemotePlay( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	STEAM_PRIVATE_API( virtual void DestroyAllInterfaces() = 0; )
+
+};
+#define STEAMCLIENT_INTERFACE_VERSION		"SteamClient020"
+
+#ifndef STEAM_API_EXPORTS
+
+// Global ISteamClient interface accessor
+inline ISteamClient *SteamClient();
+STEAM_DEFINE_INTERFACE_ACCESSOR( ISteamClient *, SteamClient, SteamInternal_CreateInterface( STEAMCLIENT_INTERFACE_VERSION ), "global", STEAMCLIENT_INTERFACE_VERSION );
+
+// The internal ISteamClient used for the gameserver interface.
+// (This is actually the same thing.  You really shouldn't need to access any of this stuff directly.)
+inline ISteamClient *SteamGameServerClient() { return SteamClient(); }
+
+#endif
+
+#endif // ISTEAMCLIENT_H

--- a/lsteamclient/steamworks_sdk_148a/isteamcontroller.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamcontroller.h
@@ -1,0 +1,576 @@
+//====== Copyright 1996-2018, Valve Corporation, All rights reserved. =======
+//    Note: The older ISteamController interface has been deprecated in favor of ISteamInput - this interface
+//			was updated in this SDK but will be removed from future SDK's. The Steam Client will retain
+//			compatibility with the older interfaces so your any existing integrations should be unaffected.
+//
+// Purpose: Steam Input is a flexible input API that supports over three hundred devices including all 
+//          common variants of Xbox, Playstation, Nintendo Switch Pro, and Steam Controllers.
+//			For more info including a getting started guide for developers 
+//			please visit: https://partner.steamgames.com/doc/features/steam_controller
+//
+//=============================================================================
+
+#ifndef ISTEAMCONTROLLER_H
+#define ISTEAMCONTROLLER_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+#include "isteaminput.h"
+
+#define STEAM_CONTROLLER_MAX_COUNT 16
+
+#define STEAM_CONTROLLER_MAX_ANALOG_ACTIONS 16
+
+#define STEAM_CONTROLLER_MAX_DIGITAL_ACTIONS 128
+
+#define STEAM_CONTROLLER_MAX_ORIGINS 8
+
+#define STEAM_CONTROLLER_MAX_ACTIVE_LAYERS 16
+
+// When sending an option to a specific controller handle, you can send to all controllers via this command
+#define STEAM_CONTROLLER_HANDLE_ALL_CONTROLLERS UINT64_MAX
+
+#define STEAM_CONTROLLER_MIN_ANALOG_ACTION_DATA -1.0f
+#define STEAM_CONTROLLER_MAX_ANALOG_ACTION_DATA 1.0f
+
+#ifndef ISTEAMINPUT_H
+enum ESteamControllerPad
+{
+	k_ESteamControllerPad_Left,
+	k_ESteamControllerPad_Right
+};
+#endif
+
+// Note: Please do not use action origins as a way to identify controller types. There is no
+// guarantee that they will be added in a contiguous manner - use GetInputTypeForHandle instead
+// Versions of Steam that add new controller types in the future will extend this enum if you're
+// using a lookup table please check the bounds of any origins returned by Steam.
+enum EControllerActionOrigin
+{
+	// Steam Controller
+	k_EControllerActionOrigin_None,
+	k_EControllerActionOrigin_A,
+	k_EControllerActionOrigin_B,
+	k_EControllerActionOrigin_X,
+	k_EControllerActionOrigin_Y,
+	k_EControllerActionOrigin_LeftBumper,
+	k_EControllerActionOrigin_RightBumper,
+	k_EControllerActionOrigin_LeftGrip,
+	k_EControllerActionOrigin_RightGrip,
+	k_EControllerActionOrigin_Start,
+	k_EControllerActionOrigin_Back,
+	k_EControllerActionOrigin_LeftPad_Touch,
+	k_EControllerActionOrigin_LeftPad_Swipe,
+	k_EControllerActionOrigin_LeftPad_Click,
+	k_EControllerActionOrigin_LeftPad_DPadNorth,
+	k_EControllerActionOrigin_LeftPad_DPadSouth,
+	k_EControllerActionOrigin_LeftPad_DPadWest,
+	k_EControllerActionOrigin_LeftPad_DPadEast,
+	k_EControllerActionOrigin_RightPad_Touch,
+	k_EControllerActionOrigin_RightPad_Swipe,
+	k_EControllerActionOrigin_RightPad_Click,
+	k_EControllerActionOrigin_RightPad_DPadNorth,
+	k_EControllerActionOrigin_RightPad_DPadSouth,
+	k_EControllerActionOrigin_RightPad_DPadWest,
+	k_EControllerActionOrigin_RightPad_DPadEast,
+	k_EControllerActionOrigin_LeftTrigger_Pull,
+	k_EControllerActionOrigin_LeftTrigger_Click,
+	k_EControllerActionOrigin_RightTrigger_Pull,
+	k_EControllerActionOrigin_RightTrigger_Click,
+	k_EControllerActionOrigin_LeftStick_Move,
+	k_EControllerActionOrigin_LeftStick_Click,
+	k_EControllerActionOrigin_LeftStick_DPadNorth,
+	k_EControllerActionOrigin_LeftStick_DPadSouth,
+	k_EControllerActionOrigin_LeftStick_DPadWest,
+	k_EControllerActionOrigin_LeftStick_DPadEast,
+	k_EControllerActionOrigin_Gyro_Move,
+	k_EControllerActionOrigin_Gyro_Pitch,
+	k_EControllerActionOrigin_Gyro_Yaw,
+	k_EControllerActionOrigin_Gyro_Roll,
+	
+	// PS4 Dual Shock
+	k_EControllerActionOrigin_PS4_X,
+	k_EControllerActionOrigin_PS4_Circle,
+	k_EControllerActionOrigin_PS4_Triangle,
+	k_EControllerActionOrigin_PS4_Square,
+	k_EControllerActionOrigin_PS4_LeftBumper,
+	k_EControllerActionOrigin_PS4_RightBumper,
+	k_EControllerActionOrigin_PS4_Options,  //Start
+	k_EControllerActionOrigin_PS4_Share,	//Back
+	k_EControllerActionOrigin_PS4_LeftPad_Touch,
+	k_EControllerActionOrigin_PS4_LeftPad_Swipe,
+	k_EControllerActionOrigin_PS4_LeftPad_Click,
+	k_EControllerActionOrigin_PS4_LeftPad_DPadNorth,
+	k_EControllerActionOrigin_PS4_LeftPad_DPadSouth,
+	k_EControllerActionOrigin_PS4_LeftPad_DPadWest,
+	k_EControllerActionOrigin_PS4_LeftPad_DPadEast,
+	k_EControllerActionOrigin_PS4_RightPad_Touch,
+	k_EControllerActionOrigin_PS4_RightPad_Swipe,
+	k_EControllerActionOrigin_PS4_RightPad_Click,
+	k_EControllerActionOrigin_PS4_RightPad_DPadNorth,
+	k_EControllerActionOrigin_PS4_RightPad_DPadSouth,
+	k_EControllerActionOrigin_PS4_RightPad_DPadWest,
+	k_EControllerActionOrigin_PS4_RightPad_DPadEast,
+	k_EControllerActionOrigin_PS4_CenterPad_Touch,
+	k_EControllerActionOrigin_PS4_CenterPad_Swipe,
+	k_EControllerActionOrigin_PS4_CenterPad_Click,
+	k_EControllerActionOrigin_PS4_CenterPad_DPadNorth,
+	k_EControllerActionOrigin_PS4_CenterPad_DPadSouth,
+	k_EControllerActionOrigin_PS4_CenterPad_DPadWest,
+	k_EControllerActionOrigin_PS4_CenterPad_DPadEast,
+	k_EControllerActionOrigin_PS4_LeftTrigger_Pull,
+	k_EControllerActionOrigin_PS4_LeftTrigger_Click,
+	k_EControllerActionOrigin_PS4_RightTrigger_Pull,
+	k_EControllerActionOrigin_PS4_RightTrigger_Click,
+	k_EControllerActionOrigin_PS4_LeftStick_Move,
+	k_EControllerActionOrigin_PS4_LeftStick_Click,
+	k_EControllerActionOrigin_PS4_LeftStick_DPadNorth,
+	k_EControllerActionOrigin_PS4_LeftStick_DPadSouth,
+	k_EControllerActionOrigin_PS4_LeftStick_DPadWest,
+	k_EControllerActionOrigin_PS4_LeftStick_DPadEast,
+	k_EControllerActionOrigin_PS4_RightStick_Move,
+	k_EControllerActionOrigin_PS4_RightStick_Click,
+	k_EControllerActionOrigin_PS4_RightStick_DPadNorth,
+	k_EControllerActionOrigin_PS4_RightStick_DPadSouth,
+	k_EControllerActionOrigin_PS4_RightStick_DPadWest,
+	k_EControllerActionOrigin_PS4_RightStick_DPadEast,
+	k_EControllerActionOrigin_PS4_DPad_North,
+	k_EControllerActionOrigin_PS4_DPad_South,
+	k_EControllerActionOrigin_PS4_DPad_West,
+	k_EControllerActionOrigin_PS4_DPad_East,
+	k_EControllerActionOrigin_PS4_Gyro_Move,
+	k_EControllerActionOrigin_PS4_Gyro_Pitch,
+	k_EControllerActionOrigin_PS4_Gyro_Yaw,
+	k_EControllerActionOrigin_PS4_Gyro_Roll,
+
+	// XBox One
+	k_EControllerActionOrigin_XBoxOne_A,
+	k_EControllerActionOrigin_XBoxOne_B,
+	k_EControllerActionOrigin_XBoxOne_X,
+	k_EControllerActionOrigin_XBoxOne_Y,
+	k_EControllerActionOrigin_XBoxOne_LeftBumper,
+	k_EControllerActionOrigin_XBoxOne_RightBumper,
+	k_EControllerActionOrigin_XBoxOne_Menu,  //Start
+	k_EControllerActionOrigin_XBoxOne_View,  //Back
+	k_EControllerActionOrigin_XBoxOne_LeftTrigger_Pull,
+	k_EControllerActionOrigin_XBoxOne_LeftTrigger_Click,
+	k_EControllerActionOrigin_XBoxOne_RightTrigger_Pull,
+	k_EControllerActionOrigin_XBoxOne_RightTrigger_Click,
+	k_EControllerActionOrigin_XBoxOne_LeftStick_Move,
+	k_EControllerActionOrigin_XBoxOne_LeftStick_Click,
+	k_EControllerActionOrigin_XBoxOne_LeftStick_DPadNorth,
+	k_EControllerActionOrigin_XBoxOne_LeftStick_DPadSouth,
+	k_EControllerActionOrigin_XBoxOne_LeftStick_DPadWest,
+	k_EControllerActionOrigin_XBoxOne_LeftStick_DPadEast,
+	k_EControllerActionOrigin_XBoxOne_RightStick_Move,
+	k_EControllerActionOrigin_XBoxOne_RightStick_Click,
+	k_EControllerActionOrigin_XBoxOne_RightStick_DPadNorth,
+	k_EControllerActionOrigin_XBoxOne_RightStick_DPadSouth,
+	k_EControllerActionOrigin_XBoxOne_RightStick_DPadWest,
+	k_EControllerActionOrigin_XBoxOne_RightStick_DPadEast,
+	k_EControllerActionOrigin_XBoxOne_DPad_North,
+	k_EControllerActionOrigin_XBoxOne_DPad_South,
+	k_EControllerActionOrigin_XBoxOne_DPad_West,
+	k_EControllerActionOrigin_XBoxOne_DPad_East,
+
+	// XBox 360
+	k_EControllerActionOrigin_XBox360_A,
+	k_EControllerActionOrigin_XBox360_B,
+	k_EControllerActionOrigin_XBox360_X,
+	k_EControllerActionOrigin_XBox360_Y,
+	k_EControllerActionOrigin_XBox360_LeftBumper,
+	k_EControllerActionOrigin_XBox360_RightBumper,
+	k_EControllerActionOrigin_XBox360_Start,  //Start
+	k_EControllerActionOrigin_XBox360_Back,  //Back
+	k_EControllerActionOrigin_XBox360_LeftTrigger_Pull,
+	k_EControllerActionOrigin_XBox360_LeftTrigger_Click,
+	k_EControllerActionOrigin_XBox360_RightTrigger_Pull,
+	k_EControllerActionOrigin_XBox360_RightTrigger_Click,
+	k_EControllerActionOrigin_XBox360_LeftStick_Move,
+	k_EControllerActionOrigin_XBox360_LeftStick_Click,
+	k_EControllerActionOrigin_XBox360_LeftStick_DPadNorth,
+	k_EControllerActionOrigin_XBox360_LeftStick_DPadSouth,
+	k_EControllerActionOrigin_XBox360_LeftStick_DPadWest,
+	k_EControllerActionOrigin_XBox360_LeftStick_DPadEast,
+	k_EControllerActionOrigin_XBox360_RightStick_Move,
+	k_EControllerActionOrigin_XBox360_RightStick_Click,
+	k_EControllerActionOrigin_XBox360_RightStick_DPadNorth,
+	k_EControllerActionOrigin_XBox360_RightStick_DPadSouth,
+	k_EControllerActionOrigin_XBox360_RightStick_DPadWest,
+	k_EControllerActionOrigin_XBox360_RightStick_DPadEast,
+	k_EControllerActionOrigin_XBox360_DPad_North,
+	k_EControllerActionOrigin_XBox360_DPad_South,
+	k_EControllerActionOrigin_XBox360_DPad_West,
+	k_EControllerActionOrigin_XBox360_DPad_East,	
+
+	// SteamController V2
+	k_EControllerActionOrigin_SteamV2_A,
+	k_EControllerActionOrigin_SteamV2_B,
+	k_EControllerActionOrigin_SteamV2_X,
+	k_EControllerActionOrigin_SteamV2_Y,
+	k_EControllerActionOrigin_SteamV2_LeftBumper,
+	k_EControllerActionOrigin_SteamV2_RightBumper,
+	k_EControllerActionOrigin_SteamV2_LeftGrip_Lower,
+	k_EControllerActionOrigin_SteamV2_LeftGrip_Upper,
+	k_EControllerActionOrigin_SteamV2_RightGrip_Lower,
+	k_EControllerActionOrigin_SteamV2_RightGrip_Upper,
+	k_EControllerActionOrigin_SteamV2_LeftBumper_Pressure,
+	k_EControllerActionOrigin_SteamV2_RightBumper_Pressure,
+	k_EControllerActionOrigin_SteamV2_LeftGrip_Pressure,
+	k_EControllerActionOrigin_SteamV2_RightGrip_Pressure,
+	k_EControllerActionOrigin_SteamV2_LeftGrip_Upper_Pressure,
+	k_EControllerActionOrigin_SteamV2_RightGrip_Upper_Pressure,
+	k_EControllerActionOrigin_SteamV2_Start,
+	k_EControllerActionOrigin_SteamV2_Back,
+	k_EControllerActionOrigin_SteamV2_LeftPad_Touch,
+	k_EControllerActionOrigin_SteamV2_LeftPad_Swipe,
+	k_EControllerActionOrigin_SteamV2_LeftPad_Click,
+	k_EControllerActionOrigin_SteamV2_LeftPad_Pressure,
+	k_EControllerActionOrigin_SteamV2_LeftPad_DPadNorth,
+	k_EControllerActionOrigin_SteamV2_LeftPad_DPadSouth,
+	k_EControllerActionOrigin_SteamV2_LeftPad_DPadWest,
+	k_EControllerActionOrigin_SteamV2_LeftPad_DPadEast,
+	k_EControllerActionOrigin_SteamV2_RightPad_Touch,
+	k_EControllerActionOrigin_SteamV2_RightPad_Swipe,
+	k_EControllerActionOrigin_SteamV2_RightPad_Click,
+	k_EControllerActionOrigin_SteamV2_RightPad_Pressure,
+	k_EControllerActionOrigin_SteamV2_RightPad_DPadNorth,
+	k_EControllerActionOrigin_SteamV2_RightPad_DPadSouth,
+	k_EControllerActionOrigin_SteamV2_RightPad_DPadWest,
+	k_EControllerActionOrigin_SteamV2_RightPad_DPadEast,
+	k_EControllerActionOrigin_SteamV2_LeftTrigger_Pull,
+	k_EControllerActionOrigin_SteamV2_LeftTrigger_Click,
+	k_EControllerActionOrigin_SteamV2_RightTrigger_Pull,
+	k_EControllerActionOrigin_SteamV2_RightTrigger_Click,
+	k_EControllerActionOrigin_SteamV2_LeftStick_Move,
+	k_EControllerActionOrigin_SteamV2_LeftStick_Click,
+	k_EControllerActionOrigin_SteamV2_LeftStick_DPadNorth,
+	k_EControllerActionOrigin_SteamV2_LeftStick_DPadSouth,
+	k_EControllerActionOrigin_SteamV2_LeftStick_DPadWest,
+	k_EControllerActionOrigin_SteamV2_LeftStick_DPadEast,
+	k_EControllerActionOrigin_SteamV2_Gyro_Move,
+	k_EControllerActionOrigin_SteamV2_Gyro_Pitch,
+	k_EControllerActionOrigin_SteamV2_Gyro_Yaw,
+	k_EControllerActionOrigin_SteamV2_Gyro_Roll,
+
+	// Switch - Pro or Joycons used as a single input device.
+	// This does not apply to a single joycon
+	k_EControllerActionOrigin_Switch_A,
+	k_EControllerActionOrigin_Switch_B,
+	k_EControllerActionOrigin_Switch_X,
+	k_EControllerActionOrigin_Switch_Y,
+	k_EControllerActionOrigin_Switch_LeftBumper,
+	k_EControllerActionOrigin_Switch_RightBumper,
+	k_EControllerActionOrigin_Switch_Plus,  //Start
+	k_EControllerActionOrigin_Switch_Minus,	//Back
+	k_EControllerActionOrigin_Switch_Capture,
+	k_EControllerActionOrigin_Switch_LeftTrigger_Pull,
+	k_EControllerActionOrigin_Switch_LeftTrigger_Click,
+	k_EControllerActionOrigin_Switch_RightTrigger_Pull,
+	k_EControllerActionOrigin_Switch_RightTrigger_Click,
+	k_EControllerActionOrigin_Switch_LeftStick_Move,
+	k_EControllerActionOrigin_Switch_LeftStick_Click,
+	k_EControllerActionOrigin_Switch_LeftStick_DPadNorth,
+	k_EControllerActionOrigin_Switch_LeftStick_DPadSouth,
+	k_EControllerActionOrigin_Switch_LeftStick_DPadWest,
+	k_EControllerActionOrigin_Switch_LeftStick_DPadEast,
+	k_EControllerActionOrigin_Switch_RightStick_Move,
+	k_EControllerActionOrigin_Switch_RightStick_Click,
+	k_EControllerActionOrigin_Switch_RightStick_DPadNorth,
+	k_EControllerActionOrigin_Switch_RightStick_DPadSouth,
+	k_EControllerActionOrigin_Switch_RightStick_DPadWest,
+	k_EControllerActionOrigin_Switch_RightStick_DPadEast,
+	k_EControllerActionOrigin_Switch_DPad_North,
+	k_EControllerActionOrigin_Switch_DPad_South,
+	k_EControllerActionOrigin_Switch_DPad_West,
+	k_EControllerActionOrigin_Switch_DPad_East,
+	k_EControllerActionOrigin_Switch_ProGyro_Move,  // Primary Gyro in Pro Controller, or Right JoyCon
+	k_EControllerActionOrigin_Switch_ProGyro_Pitch,  // Primary Gyro in Pro Controller, or Right JoyCon
+	k_EControllerActionOrigin_Switch_ProGyro_Yaw,  // Primary Gyro in Pro Controller, or Right JoyCon
+	k_EControllerActionOrigin_Switch_ProGyro_Roll,  // Primary Gyro in Pro Controller, or Right JoyCon
+	// Switch JoyCon Specific
+	k_EControllerActionOrigin_Switch_RightGyro_Move,  // Right JoyCon Gyro generally should correspond to Pro's single gyro
+	k_EControllerActionOrigin_Switch_RightGyro_Pitch,  // Right JoyCon Gyro generally should correspond to Pro's single gyro
+	k_EControllerActionOrigin_Switch_RightGyro_Yaw,  // Right JoyCon Gyro generally should correspond to Pro's single gyro
+	k_EControllerActionOrigin_Switch_RightGyro_Roll,  // Right JoyCon Gyro generally should correspond to Pro's single gyro
+	k_EControllerActionOrigin_Switch_LeftGyro_Move,
+	k_EControllerActionOrigin_Switch_LeftGyro_Pitch,
+	k_EControllerActionOrigin_Switch_LeftGyro_Yaw,
+	k_EControllerActionOrigin_Switch_LeftGyro_Roll,
+	k_EControllerActionOrigin_Switch_LeftGrip_Lower, // Left JoyCon SR Button
+	k_EControllerActionOrigin_Switch_LeftGrip_Upper, // Left JoyCon SL Button
+	k_EControllerActionOrigin_Switch_RightGrip_Lower,  // Right JoyCon SL Button
+	k_EControllerActionOrigin_Switch_RightGrip_Upper,  // Right JoyCon SR Button
+
+	// Added in SDK 1.45
+	k_EControllerActionOrigin_PS4_DPad_Move,
+	k_EControllerActionOrigin_XBoxOne_DPad_Move,
+	k_EControllerActionOrigin_XBox360_DPad_Move,
+	k_EControllerActionOrigin_Switch_DPad_Move,
+
+	k_EControllerActionOrigin_Count, // If Steam has added support for new controllers origins will go here.
+	k_EControllerActionOrigin_MaximumPossibleValue = 32767, // Origins are currently a maximum of 16 bits.
+};
+
+#ifndef ISTEAMINPUT_H
+enum EXboxOrigin
+{
+	k_EXboxOrigin_A,
+	k_EXboxOrigin_B,
+	k_EXboxOrigin_X,
+	k_EXboxOrigin_Y,
+	k_EXboxOrigin_LeftBumper,
+	k_EXboxOrigin_RightBumper,
+	k_EXboxOrigin_Menu,  //Start
+	k_EXboxOrigin_View,  //Back
+	k_EXboxOrigin_LeftTrigger_Pull,
+	k_EXboxOrigin_LeftTrigger_Click,
+	k_EXboxOrigin_RightTrigger_Pull,
+	k_EXboxOrigin_RightTrigger_Click,
+	k_EXboxOrigin_LeftStick_Move,
+	k_EXboxOrigin_LeftStick_Click,
+	k_EXboxOrigin_LeftStick_DPadNorth,
+	k_EXboxOrigin_LeftStick_DPadSouth,
+	k_EXboxOrigin_LeftStick_DPadWest,
+	k_EXboxOrigin_LeftStick_DPadEast,
+	k_EXboxOrigin_RightStick_Move,
+	k_EXboxOrigin_RightStick_Click,
+	k_EXboxOrigin_RightStick_DPadNorth,
+	k_EXboxOrigin_RightStick_DPadSouth,
+	k_EXboxOrigin_RightStick_DPadWest,
+	k_EXboxOrigin_RightStick_DPadEast,
+	k_EXboxOrigin_DPad_North,
+	k_EXboxOrigin_DPad_South,
+	k_EXboxOrigin_DPad_West,
+	k_EXboxOrigin_DPad_East,
+};
+
+enum ESteamInputType
+{
+	k_ESteamInputType_Unknown,
+	k_ESteamInputType_SteamController,
+	k_ESteamInputType_XBox360Controller,
+	k_ESteamInputType_XBoxOneController,
+	k_ESteamInputType_GenericGamepad,		// DirectInput controllers
+	k_ESteamInputType_PS4Controller,
+	k_ESteamInputType_AppleMFiController,	// Unused
+	k_ESteamInputType_AndroidController,	// Unused
+	k_ESteamInputType_SwitchJoyConPair,		// Unused
+	k_ESteamInputType_SwitchJoyConSingle,	// Unused
+	k_ESteamInputType_SwitchProController,
+	k_ESteamInputType_MobileTouch,			// Steam Link App On-screen Virtual Controller
+	k_ESteamInputType_PS3Controller,		// Currently uses PS4 Origins
+	k_ESteamInputType_Count,
+	k_ESteamInputType_MaximumPossibleValue = 255,
+};
+#endif
+
+enum ESteamControllerLEDFlag
+{
+	k_ESteamControllerLEDFlag_SetColor,
+	k_ESteamControllerLEDFlag_RestoreUserDefault
+};
+
+// ControllerHandle_t is used to refer to a specific controller.
+// This handle will consistently identify a controller, even if it is disconnected and re-connected
+typedef uint64 ControllerHandle_t;
+
+
+// These handles are used to refer to a specific in-game action or action set
+// All action handles should be queried during initialization for performance reasons
+typedef uint64 ControllerActionSetHandle_t;
+typedef uint64 ControllerDigitalActionHandle_t;
+typedef uint64 ControllerAnalogActionHandle_t;
+
+#pragma pack( push, 1 )
+
+#ifdef ISTEAMINPUT_H
+#define ControllerAnalogActionData_t InputAnalogActionData_t
+#define ControllerDigitalActionData_t InputDigitalActionData_t
+#define ControllerMotionData_t  InputMotionData_t
+#else
+struct ControllerAnalogActionData_t
+{
+	// Type of data coming from this action, this will match what got specified in the action set
+	EControllerSourceMode eMode;
+	
+	// The current state of this action; will be delta updates for mouse actions
+	float x, y;
+	
+	// Whether or not this action is currently available to be bound in the active action set
+	bool bActive;
+};
+
+struct ControllerDigitalActionData_t
+{
+	// The current state of this action; will be true if currently pressed
+	bool bState;
+	
+	// Whether or not this action is currently available to be bound in the active action set
+	bool bActive;
+};
+
+struct ControllerMotionData_t
+{
+	// Sensor-fused absolute rotation; will drift in heading
+	float rotQuatX;
+	float rotQuatY;
+	float rotQuatZ;
+	float rotQuatW;
+	
+	// Positional acceleration
+	float posAccelX;
+	float posAccelY;
+	float posAccelZ;
+
+	// Angular velocity
+	float rotVelX;
+	float rotVelY;
+	float rotVelZ;
+};
+#endif
+#pragma pack( pop )
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Steam Input API
+//-----------------------------------------------------------------------------
+class ISteamController
+{
+public:
+	
+	// Init and Shutdown must be called when starting/ending use of this interface
+	virtual bool Init() = 0;
+	virtual bool Shutdown() = 0;
+	
+	// Synchronize API state with the latest Steam Controller inputs available. This
+	// is performed automatically by SteamAPI_RunCallbacks, but for the absolute lowest
+	// possible latency, you call this directly before reading controller state. This must
+	// be called from somewhere before GetConnectedControllers will return any handles
+	virtual void RunFrame() = 0;
+
+	// Enumerate currently connected controllers
+	// handlesOut should point to a STEAM_CONTROLLER_MAX_COUNT sized array of ControllerHandle_t handles
+	// Returns the number of handles written to handlesOut
+	virtual int GetConnectedControllers( STEAM_OUT_ARRAY_COUNT( STEAM_CONTROLLER_MAX_COUNT, Receives list of connected controllers ) ControllerHandle_t *handlesOut ) = 0;
+	
+	//-----------------------------------------------------------------------------
+	// ACTION SETS
+	//-----------------------------------------------------------------------------
+
+	// Lookup the handle for an Action Set. Best to do this once on startup, and store the handles for all future API calls.
+	virtual ControllerActionSetHandle_t GetActionSetHandle( const char *pszActionSetName ) = 0;
+	
+	// Reconfigure the controller to use the specified action set (ie 'Menu', 'Walk' or 'Drive')
+	// This is cheap, and can be safely called repeatedly. It's often easier to repeatedly call it in
+	// your state loops, instead of trying to place it in all of your state transitions.
+	virtual void ActivateActionSet( ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetHandle ) = 0;
+	virtual ControllerActionSetHandle_t GetCurrentActionSet( ControllerHandle_t controllerHandle ) = 0;
+
+	// ACTION SET LAYERS
+	virtual void ActivateActionSetLayer( ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetLayerHandle ) = 0;
+	virtual void DeactivateActionSetLayer( ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetLayerHandle ) = 0;
+	virtual void DeactivateAllActionSetLayers( ControllerHandle_t controllerHandle ) = 0;
+	// Enumerate currently active layers
+	// handlesOut should point to a STEAM_CONTROLLER_MAX_ACTIVE_LAYERS sized array of ControllerActionSetHandle_t handles.
+	// Returns the number of handles written to handlesOut
+	virtual int GetActiveActionSetLayers( ControllerHandle_t controllerHandle, STEAM_OUT_ARRAY_COUNT( STEAM_CONTROLLER_MAX_ACTIVE_LAYERS, Receives list of active layers ) ControllerActionSetHandle_t *handlesOut ) = 0;
+
+	//-----------------------------------------------------------------------------
+	// ACTIONS
+	//-----------------------------------------------------------------------------
+
+	// Lookup the handle for a digital action. Best to do this once on startup, and store the handles for all future API calls.
+	virtual ControllerDigitalActionHandle_t GetDigitalActionHandle( const char *pszActionName ) = 0;
+	
+	// Returns the current state of the supplied digital game action
+	virtual ControllerDigitalActionData_t GetDigitalActionData( ControllerHandle_t controllerHandle, ControllerDigitalActionHandle_t digitalActionHandle ) = 0;
+	
+	// Get the origin(s) for a digital action within an action set. Returns the number of origins supplied in originsOut. Use this to display the appropriate on-screen prompt for the action.
+	// originsOut should point to a STEAM_CONTROLLER_MAX_ORIGINS sized array of EControllerActionOrigin handles. The EControllerActionOrigin enum will get extended as support for new controller controllers gets added to
+	// the Steam client and will exceed the values from this header, please check bounds if you are using a look up table.
+	virtual int GetDigitalActionOrigins( ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetHandle, ControllerDigitalActionHandle_t digitalActionHandle, STEAM_OUT_ARRAY_COUNT( STEAM_CONTROLLER_MAX_ORIGINS, Receives list of aciton origins ) EControllerActionOrigin *originsOut ) = 0;
+	
+	// Lookup the handle for an analog action. Best to do this once on startup, and store the handles for all future API calls.
+	virtual ControllerAnalogActionHandle_t GetAnalogActionHandle( const char *pszActionName ) = 0;
+	
+	// Returns the current state of these supplied analog game action
+	virtual ControllerAnalogActionData_t GetAnalogActionData( ControllerHandle_t controllerHandle, ControllerAnalogActionHandle_t analogActionHandle ) = 0;
+
+	// Get the origin(s) for an analog action within an action set. Returns the number of origins supplied in originsOut. Use this to display the appropriate on-screen prompt for the action.
+	// originsOut should point to a STEAM_CONTROLLER_MAX_ORIGINS sized array of EControllerActionOrigin handles. The EControllerActionOrigin enum will get extended as support for new controller controllers gets added to
+	// the Steam client and will exceed the values from this header, please check bounds if you are using a look up table.
+	virtual int GetAnalogActionOrigins( ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetHandle, ControllerAnalogActionHandle_t analogActionHandle, STEAM_OUT_ARRAY_COUNT( STEAM_CONTROLLER_MAX_ORIGINS, Receives list of action origins ) EControllerActionOrigin *originsOut ) = 0;
+	
+	// Get a local path to art for on-screen glyph for a particular origin - this call is cheap
+	virtual const char *GetGlyphForActionOrigin( EControllerActionOrigin eOrigin ) = 0;
+	
+	// Returns a localized string (from Steam's language setting) for the specified origin - this call is serialized
+	virtual const char *GetStringForActionOrigin( EControllerActionOrigin eOrigin ) = 0;
+
+	virtual void StopAnalogActionMomentum( ControllerHandle_t controllerHandle, ControllerAnalogActionHandle_t eAction ) = 0;
+
+	// Returns raw motion data from the specified controller
+	virtual ControllerMotionData_t GetMotionData( ControllerHandle_t controllerHandle ) = 0;
+
+	//-----------------------------------------------------------------------------
+	// OUTPUTS
+	//-----------------------------------------------------------------------------
+
+	// Trigger a haptic pulse on a controller
+	virtual void TriggerHapticPulse( ControllerHandle_t controllerHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec ) = 0;
+
+	// Trigger a pulse with a duty cycle of usDurationMicroSec / usOffMicroSec, unRepeat times.
+	// nFlags is currently unused and reserved for future use.
+	virtual void TriggerRepeatedHapticPulse( ControllerHandle_t controllerHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec, unsigned short usOffMicroSec, unsigned short unRepeat, unsigned int nFlags ) = 0;
+	
+	// Trigger a vibration event on supported controllers.  
+	virtual void TriggerVibration( ControllerHandle_t controllerHandle, unsigned short usLeftSpeed, unsigned short usRightSpeed ) = 0;
+
+	// Set the controller LED color on supported controllers.  
+	virtual void SetLEDColor( ControllerHandle_t controllerHandle, uint8 nColorR, uint8 nColorG, uint8 nColorB, unsigned int nFlags ) = 0;
+
+	//-----------------------------------------------------------------------------
+	// Utility functions availible without using the rest of Steam Input API
+	//-----------------------------------------------------------------------------
+
+	// Invokes the Steam overlay and brings up the binding screen if the user is using Big Picture Mode
+	// If the user is not in Big Picture Mode it will open up the binding in a new window
+	virtual bool ShowBindingPanel( ControllerHandle_t controllerHandle ) = 0;
+
+	// Returns the input type for a particular handle
+	virtual ESteamInputType GetInputTypeForHandle( ControllerHandle_t controllerHandle ) = 0;
+
+	// Returns the associated controller handle for the specified emulated gamepad - can be used with the above 2 functions
+	// to identify controllers presented to your game over Xinput. Returns 0 if the Xinput index isn't associated with Steam Input
+	virtual ControllerHandle_t GetControllerForGamepadIndex( int nIndex ) = 0;
+
+	// Returns the associated gamepad index for the specified controller, if emulating a gamepad or -1 if not associated with an Xinput index
+	virtual int GetGamepadIndexForController( ControllerHandle_t ulControllerHandle ) = 0;
+	
+	// Returns a localized string (from Steam's language setting) for the specified Xbox controller origin.
+	virtual const char *GetStringForXboxOrigin( EXboxOrigin eOrigin ) = 0;
+
+	// Get a local path to art for on-screen glyph for a particular Xbox controller origin. 
+	virtual const char *GetGlyphForXboxOrigin( EXboxOrigin eOrigin ) = 0;
+
+	// Get the equivalent ActionOrigin for a given Xbox controller origin this can be chained with GetGlyphForActionOrigin to provide future proof glyphs for
+	// non-Steam Input API action games. Note - this only translates the buttons directly and doesn't take into account any remapping a user has made in their configuration
+	virtual EControllerActionOrigin GetActionOriginFromXboxOrigin( ControllerHandle_t controllerHandle, EXboxOrigin eOrigin ) = 0;
+
+	// Convert an origin to another controller type - for inputs not present on the other controller type this will return k_EControllerActionOrigin_None
+	virtual EControllerActionOrigin TranslateActionOrigin( ESteamInputType eDestinationInputType, EControllerActionOrigin eSourceOrigin ) = 0;
+
+	// Get the binding revision for a given device. Returns false if the handle was not valid or if a mapping is not yet loaded for the device
+	virtual bool GetControllerBindingRevision( ControllerHandle_t controllerHandle, int *pMajor, int *pMinor ) = 0;
+};
+
+#define STEAMCONTROLLER_INTERFACE_VERSION "SteamController007"
+
+// Global interface accessor
+inline ISteamController *SteamController();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamController *, SteamController, STEAMCONTROLLER_INTERFACE_VERSION );
+
+#endif // ISTEAMCONTROLLER_H

--- a/lsteamclient/steamworks_sdk_148a/isteamfriends.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamfriends.h
@@ -1,0 +1,685 @@
+//====== Copyright Valve Corporation, All rights reserved. ====================
+//
+// Purpose: interface to both friends list data and general information about users
+//
+//=============================================================================
+
+#ifndef ISTEAMFRIENDS_H
+#define ISTEAMFRIENDS_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: set of relationships to other users
+//-----------------------------------------------------------------------------
+enum EFriendRelationship
+{
+	k_EFriendRelationshipNone = 0,
+	k_EFriendRelationshipBlocked = 1,			// this doesn't get stored; the user has just done an Ignore on an friendship invite
+	k_EFriendRelationshipRequestRecipient = 2,
+	k_EFriendRelationshipFriend = 3,
+	k_EFriendRelationshipRequestInitiator = 4,
+	k_EFriendRelationshipIgnored = 5,			// this is stored; the user has explicit blocked this other user from comments/chat/etc
+	k_EFriendRelationshipIgnoredFriend = 6,
+	k_EFriendRelationshipSuggested_DEPRECATED = 7,		// was used by the original implementation of the facebook linking feature, but now unused.
+
+	// keep this updated
+	k_EFriendRelationshipMax = 8,
+};
+
+// maximum length of friend group name (not including terminating nul!)
+const int k_cchMaxFriendsGroupName = 64;
+
+// maximum number of groups a single user is allowed
+const int k_cFriendsGroupLimit = 100;
+
+// friends group identifier type
+typedef int16 FriendsGroupID_t;
+
+// invalid friends group identifier constant
+const FriendsGroupID_t k_FriendsGroupID_Invalid = -1;
+
+const int k_cEnumerateFollowersMax = 50;
+
+
+//-----------------------------------------------------------------------------
+// Purpose: list of states a friend can be in
+//-----------------------------------------------------------------------------
+enum EPersonaState
+{
+	k_EPersonaStateOffline = 0,			// friend is not currently logged on
+	k_EPersonaStateOnline = 1,			// friend is logged on
+	k_EPersonaStateBusy = 2,			// user is on, but busy
+	k_EPersonaStateAway = 3,			// auto-away feature
+	k_EPersonaStateSnooze = 4,			// auto-away for a long time
+	k_EPersonaStateLookingToTrade = 5,	// Online, trading
+	k_EPersonaStateLookingToPlay = 6,	// Online, wanting to play
+	k_EPersonaStateInvisible = 7,		// Online, but appears offline to friends.  This status is never published to clients.
+	k_EPersonaStateMax,
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: flags for enumerating friends list, or quickly checking a the relationship between users
+//-----------------------------------------------------------------------------
+enum EFriendFlags
+{
+	k_EFriendFlagNone			= 0x00,
+	k_EFriendFlagBlocked		= 0x01,
+	k_EFriendFlagFriendshipRequested	= 0x02,
+	k_EFriendFlagImmediate		= 0x04,			// "regular" friend
+	k_EFriendFlagClanMember		= 0x08,
+	k_EFriendFlagOnGameServer	= 0x10,	
+	// k_EFriendFlagHasPlayedWith	= 0x20,	// not currently used
+	// k_EFriendFlagFriendOfFriend	= 0x40, // not currently used
+	k_EFriendFlagRequestingFriendship = 0x80,
+	k_EFriendFlagRequestingInfo = 0x100,
+	k_EFriendFlagIgnored		= 0x200,
+	k_EFriendFlagIgnoredFriend	= 0x400,
+	// k_EFriendFlagSuggested		= 0x800,	// not used
+	k_EFriendFlagChatMember		= 0x1000,
+	k_EFriendFlagAll			= 0xFFFF,
+};
+
+
+// friend game played information
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+struct FriendGameInfo_t
+{
+	CGameID m_gameID;
+	uint32 m_unGameIP;
+	uint16 m_usGamePort;
+	uint16 m_usQueryPort;
+	CSteamID m_steamIDLobby;
+};
+#pragma pack( pop )
+
+// maximum number of characters in a user's name. Two flavors; one for UTF-8 and one for UTF-16.
+// The UTF-8 version has to be very generous to accomodate characters that get large when encoded
+// in UTF-8.
+enum
+{
+	k_cchPersonaNameMax = 128,
+	k_cwchPersonaNameMax = 32,
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: user restriction flags
+//-----------------------------------------------------------------------------
+enum EUserRestriction
+{
+	k_nUserRestrictionNone		= 0,	// no known chat/content restriction
+	k_nUserRestrictionUnknown	= 1,	// we don't know yet (user offline)
+	k_nUserRestrictionAnyChat	= 2,	// user is not allowed to (or can't) send/recv any chat
+	k_nUserRestrictionVoiceChat	= 4,	// user is not allowed to (or can't) send/recv voice chat
+	k_nUserRestrictionGroupChat	= 8,	// user is not allowed to (or can't) send/recv group chat
+	k_nUserRestrictionRating	= 16,	// user is too young according to rating in current region
+	k_nUserRestrictionGameInvites	= 32,	// user cannot send or recv game invites (e.g. mobile)
+	k_nUserRestrictionTrading	= 64,	// user cannot participate in trading (console, mobile)
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: information about user sessions
+//-----------------------------------------------------------------------------
+struct FriendSessionStateInfo_t
+{
+	uint32 m_uiOnlineSessionInstances;
+	uint8 m_uiPublishedToFriendsSessionInstance;
+};
+
+
+
+// size limit on chat room or member metadata
+const uint32 k_cubChatMetadataMax = 8192;
+
+// size limits on Rich Presence data
+enum { k_cchMaxRichPresenceKeys = 30 };
+enum { k_cchMaxRichPresenceKeyLength = 64 };
+enum { k_cchMaxRichPresenceValueLength = 256 };
+
+// These values are passed as parameters to the store
+enum EOverlayToStoreFlag
+{
+	k_EOverlayToStoreFlag_None = 0,
+	k_EOverlayToStoreFlag_AddToCart = 1,
+	k_EOverlayToStoreFlag_AddToCartAndShow = 2,
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Tells Steam where to place the browser window inside the overlay
+//-----------------------------------------------------------------------------
+enum EActivateGameOverlayToWebPageMode
+{
+	k_EActivateGameOverlayToWebPageMode_Default = 0,		// Browser will open next to all other windows that the user has open in the overlay.
+															// The window will remain open, even if the user closes then re-opens the overlay.
+
+	k_EActivateGameOverlayToWebPageMode_Modal = 1			// Browser will be opened in a special overlay configuration which hides all other windows
+															// that the user has open in the overlay. When the user closes the overlay, the browser window
+															// will also close. When the user closes the browser window, the overlay will automatically close.
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: interface to accessing information about individual users,
+//			that can be a friend, in a group, on a game server or in a lobby with the local user
+//-----------------------------------------------------------------------------
+class ISteamFriends
+{
+public:
+	// returns the local players name - guaranteed to not be NULL.
+	// this is the same name as on the users community profile page
+	// this is stored in UTF-8 format
+	// like all the other interface functions that return a char *, it's important that this pointer is not saved
+	// off; it will eventually be free'd or re-allocated
+	virtual const char *GetPersonaName() = 0;
+
+	// Sets the player name, stores it on the server and publishes the changes to all friends who are online.
+	// Changes take place locally immediately, and a PersonaStateChange_t is posted, presuming success.
+	//
+	// The final results are available through the return value SteamAPICall_t, using SetPersonaNameResponse_t.
+	//
+	// If the name change fails to happen on the server, then an additional global PersonaStateChange_t will be posted
+	// to change the name back, in addition to the SetPersonaNameResponse_t callback.
+	STEAM_CALL_RESULT( SetPersonaNameResponse_t )
+	virtual SteamAPICall_t SetPersonaName( const char *pchPersonaName ) = 0;
+
+	// gets the status of the current user
+	virtual EPersonaState GetPersonaState() = 0;
+
+	// friend iteration
+	// takes a set of k_EFriendFlags, and returns the number of users the client knows about who meet that criteria
+	// then GetFriendByIndex() can then be used to return the id's of each of those users
+	virtual int GetFriendCount( int iFriendFlags ) = 0;
+
+	// returns the steamID of a user
+	// iFriend is a index of range [0, GetFriendCount())
+	// iFriendsFlags must be the same value as used in GetFriendCount()
+	// the returned CSteamID can then be used by all the functions below to access details about the user
+	virtual CSteamID GetFriendByIndex( int iFriend, int iFriendFlags ) = 0;
+
+	// returns a relationship to a user
+	virtual EFriendRelationship GetFriendRelationship( CSteamID steamIDFriend ) = 0;
+
+	// returns the current status of the specified user
+	// this will only be known by the local user if steamIDFriend is in their friends list; on the same game server; in a chat room or lobby; or in a small group with the local user
+	virtual EPersonaState GetFriendPersonaState( CSteamID steamIDFriend ) = 0;
+
+	// returns the name another user - guaranteed to not be NULL.
+	// same rules as GetFriendPersonaState() apply as to whether or not the user knowns the name of the other user
+	// note that on first joining a lobby, chat room or game server the local user will not known the name of the other users automatically; that information will arrive asyncronously
+	// 
+	virtual const char *GetFriendPersonaName( CSteamID steamIDFriend ) = 0;
+
+	// returns true if the friend is actually in a game, and fills in pFriendGameInfo with an extra details 
+	virtual bool GetFriendGamePlayed( CSteamID steamIDFriend, STEAM_OUT_STRUCT() FriendGameInfo_t *pFriendGameInfo ) = 0;
+	// accesses old friends names - returns an empty string when their are no more items in the history
+	virtual const char *GetFriendPersonaNameHistory( CSteamID steamIDFriend, int iPersonaName ) = 0;
+	// friends steam level
+	virtual int GetFriendSteamLevel( CSteamID steamIDFriend ) = 0;
+
+	// Returns nickname the current user has set for the specified player. Returns NULL if the no nickname has been set for that player.
+	// DEPRECATED: GetPersonaName follows the Steam nickname preferences, so apps shouldn't need to care about nicknames explicitly.
+	virtual const char *GetPlayerNickname( CSteamID steamIDPlayer ) = 0;
+
+	// friend grouping (tag) apis
+	// returns the number of friends groups
+	virtual int GetFriendsGroupCount() = 0;
+	// returns the friends group ID for the given index (invalid indices return k_FriendsGroupID_Invalid)
+	virtual FriendsGroupID_t GetFriendsGroupIDByIndex( int iFG ) = 0;
+	// returns the name for the given friends group (NULL in the case of invalid friends group IDs)
+	virtual const char *GetFriendsGroupName( FriendsGroupID_t friendsGroupID ) = 0;
+	// returns the number of members in a given friends group
+	virtual int GetFriendsGroupMembersCount( FriendsGroupID_t friendsGroupID ) = 0;
+	// gets up to nMembersCount members of the given friends group, if fewer exist than requested those positions' SteamIDs will be invalid
+	virtual void GetFriendsGroupMembersList( FriendsGroupID_t friendsGroupID, STEAM_OUT_ARRAY_CALL(nMembersCount, GetFriendsGroupMembersCount, friendsGroupID ) CSteamID *pOutSteamIDMembers, int nMembersCount ) = 0;
+
+	// returns true if the specified user meets any of the criteria specified in iFriendFlags
+	// iFriendFlags can be the union (binary or, |) of one or more k_EFriendFlags values
+	virtual bool HasFriend( CSteamID steamIDFriend, int iFriendFlags ) = 0;
+
+	// clan (group) iteration and access functions
+	virtual int GetClanCount() = 0;
+	virtual CSteamID GetClanByIndex( int iClan ) = 0;
+	virtual const char *GetClanName( CSteamID steamIDClan ) = 0;
+	virtual const char *GetClanTag( CSteamID steamIDClan ) = 0;
+	// returns the most recent information we have about what's happening in a clan
+	virtual bool GetClanActivityCounts( CSteamID steamIDClan, int *pnOnline, int *pnInGame, int *pnChatting ) = 0;
+
+	// for clans a user is a member of, they will have reasonably up-to-date information, but for others you'll have to download the info to have the latest
+	STEAM_CALL_RESULT( DownloadClanActivityCountsResult_t )
+	virtual SteamAPICall_t DownloadClanActivityCounts( STEAM_ARRAY_COUNT(cClansToRequest) CSteamID *psteamIDClans, int cClansToRequest ) = 0;
+
+	// iterators for getting users in a chat room, lobby, game server or clan
+	// note that large clans that cannot be iterated by the local user
+	// note that the current user must be in a lobby to retrieve CSteamIDs of other users in that lobby
+	// steamIDSource can be the steamID of a group, game server, lobby or chat room
+	virtual int GetFriendCountFromSource( CSteamID steamIDSource ) = 0;
+	virtual CSteamID GetFriendFromSourceByIndex( CSteamID steamIDSource, int iFriend ) = 0;
+
+	// returns true if the local user can see that steamIDUser is a member or in steamIDSource
+	virtual bool IsUserInSource( CSteamID steamIDUser, CSteamID steamIDSource ) = 0;
+
+	// User is in a game pressing the talk button (will suppress the microphone for all voice comms from the Steam friends UI)
+	virtual void SetInGameVoiceSpeaking( CSteamID steamIDUser, bool bSpeaking ) = 0;
+
+	// activates the game overlay, with an optional dialog to open 
+	// valid options include "Friends", "Community", "Players", "Settings", "OfficialGameGroup", "Stats", "Achievements",
+	// "chatroomgroup/nnnn"
+	virtual void ActivateGameOverlay( const char *pchDialog ) = 0;
+
+	// activates game overlay to a specific place
+	// valid options are
+	//		"steamid" - opens the overlay web browser to the specified user or groups profile
+	//		"chat" - opens a chat window to the specified user, or joins the group chat 
+	//		"jointrade" - opens a window to a Steam Trading session that was started with the ISteamEconomy/StartTrade Web API
+	//		"stats" - opens the overlay web browser to the specified user's stats
+	//		"achievements" - opens the overlay web browser to the specified user's achievements
+	//		"friendadd" - opens the overlay in minimal mode prompting the user to add the target user as a friend
+	//		"friendremove" - opens the overlay in minimal mode prompting the user to remove the target friend
+	//		"friendrequestaccept" - opens the overlay in minimal mode prompting the user to accept an incoming friend invite
+	//		"friendrequestignore" - opens the overlay in minimal mode prompting the user to ignore an incoming friend invite
+	virtual void ActivateGameOverlayToUser( const char *pchDialog, CSteamID steamID ) = 0;
+
+	// activates game overlay web browser directly to the specified URL
+	// full address with protocol type is required, e.g. http://www.steamgames.com/
+	virtual void ActivateGameOverlayToWebPage( const char *pchURL, EActivateGameOverlayToWebPageMode eMode = k_EActivateGameOverlayToWebPageMode_Default ) = 0;
+
+	// activates game overlay to store page for app
+	virtual void ActivateGameOverlayToStore( AppId_t nAppID, EOverlayToStoreFlag eFlag ) = 0;
+
+	// Mark a target user as 'played with'. This is a client-side only feature that requires that the calling user is 
+	// in game 
+	virtual void SetPlayedWith( CSteamID steamIDUserPlayedWith ) = 0;
+
+	// activates game overlay to open the invite dialog. Invitations will be sent for the provided lobby.
+	virtual void ActivateGameOverlayInviteDialog( CSteamID steamIDLobby ) = 0;
+
+	// gets the small (32x32) avatar of the current user, which is a handle to be used in IClientUtils::GetImageRGBA(), or 0 if none set
+	virtual int GetSmallFriendAvatar( CSteamID steamIDFriend ) = 0;
+
+	// gets the medium (64x64) avatar of the current user, which is a handle to be used in IClientUtils::GetImageRGBA(), or 0 if none set
+	virtual int GetMediumFriendAvatar( CSteamID steamIDFriend ) = 0;
+
+	// gets the large (184x184) avatar of the current user, which is a handle to be used in IClientUtils::GetImageRGBA(), or 0 if none set
+	// returns -1 if this image has yet to be loaded, in this case wait for a AvatarImageLoaded_t callback and then call this again
+	virtual int GetLargeFriendAvatar( CSteamID steamIDFriend ) = 0;
+
+	// requests information about a user - persona name & avatar
+	// if bRequireNameOnly is set, then the avatar of a user isn't downloaded 
+	// - it's a lot slower to download avatars and churns the local cache, so if you don't need avatars, don't request them
+	// if returns true, it means that data is being requested, and a PersonaStateChanged_t callback will be posted when it's retrieved
+	// if returns false, it means that we already have all the details about that user, and functions can be called immediately
+	virtual bool RequestUserInformation( CSteamID steamIDUser, bool bRequireNameOnly ) = 0;
+
+	// requests information about a clan officer list
+	// when complete, data is returned in ClanOfficerListResponse_t call result
+	// this makes available the calls below
+	// you can only ask about clans that a user is a member of
+	// note that this won't download avatars automatically; if you get an officer,
+	// and no avatar image is available, call RequestUserInformation( steamID, false ) to download the avatar
+	STEAM_CALL_RESULT( ClanOfficerListResponse_t )
+	virtual SteamAPICall_t RequestClanOfficerList( CSteamID steamIDClan ) = 0;
+
+	// iteration of clan officers - can only be done when a RequestClanOfficerList() call has completed
+	
+	// returns the steamID of the clan owner
+	virtual CSteamID GetClanOwner( CSteamID steamIDClan ) = 0;
+	// returns the number of officers in a clan (including the owner)
+	virtual int GetClanOfficerCount( CSteamID steamIDClan ) = 0;
+	// returns the steamID of a clan officer, by index, of range [0,GetClanOfficerCount)
+	virtual CSteamID GetClanOfficerByIndex( CSteamID steamIDClan, int iOfficer ) = 0;
+	// if current user is chat restricted, he can't send or receive any text/voice chat messages.
+	// the user can't see custom avatars. But the user can be online and send/recv game invites.
+	// a chat restricted user can't add friends or join any groups.
+	virtual uint32 GetUserRestrictions() = 0;
+
+	// Rich Presence data is automatically shared between friends who are in the same game
+	// Each user has a set of Key/Value pairs
+	// Note the following limits: k_cchMaxRichPresenceKeys, k_cchMaxRichPresenceKeyLength, k_cchMaxRichPresenceValueLength
+	// There are five magic keys:
+	//		"status"  - a UTF-8 string that will show up in the 'view game info' dialog in the Steam friends list
+	//		"connect" - a UTF-8 string that contains the command-line for how a friend can connect to a game
+	//		"steam_display"				- Names a rich presence localization token that will be displayed in the viewing user's selected language
+	//									  in the Steam client UI. For more info: https://partner.steamgames.com/doc/api/ISteamFriends#richpresencelocalization
+	//		"steam_player_group"		- When set, indicates to the Steam client that the player is a member of a particular group. Players in the same group
+	//									  may be organized together in various places in the Steam UI.
+	//		"steam_player_group_size"	- When set, indicates the total number of players in the steam_player_group. The Steam client may use this number to
+	//									  display additional information about a group when all of the members are not part of a user's friends list.
+	// GetFriendRichPresence() returns an empty string "" if no value is set
+	// SetRichPresence() to a NULL or an empty string deletes the key
+	// You can iterate the current set of keys for a friend with GetFriendRichPresenceKeyCount()
+	// and GetFriendRichPresenceKeyByIndex() (typically only used for debugging)
+	virtual bool SetRichPresence( const char *pchKey, const char *pchValue ) = 0;
+	virtual void ClearRichPresence() = 0;
+	virtual const char *GetFriendRichPresence( CSteamID steamIDFriend, const char *pchKey ) = 0;
+	virtual int GetFriendRichPresenceKeyCount( CSteamID steamIDFriend ) = 0;
+	virtual const char *GetFriendRichPresenceKeyByIndex( CSteamID steamIDFriend, int iKey ) = 0;
+	// Requests rich presence for a specific user.
+	virtual void RequestFriendRichPresence( CSteamID steamIDFriend ) = 0;
+
+	// Rich invite support.
+	// If the target accepts the invite, a GameRichPresenceJoinRequested_t callback is posted containing the connect string.
+	// (Or you can configure yout game so that it is passed on the command line instead.  This is a deprecated path; ask us if you really need this.)
+	virtual bool InviteUserToGame( CSteamID steamIDFriend, const char *pchConnectString ) = 0;
+
+	// recently-played-with friends iteration
+	// this iterates the entire list of users recently played with, across games
+	// GetFriendCoplayTime() returns as a unix time
+	virtual int GetCoplayFriendCount() = 0;
+	virtual CSteamID GetCoplayFriend( int iCoplayFriend ) = 0;
+	virtual int GetFriendCoplayTime( CSteamID steamIDFriend ) = 0;
+	virtual AppId_t GetFriendCoplayGame( CSteamID steamIDFriend ) = 0;
+
+	// chat interface for games
+	// this allows in-game access to group (clan) chats from in the game
+	// the behavior is somewhat sophisticated, because the user may or may not be already in the group chat from outside the game or in the overlay
+	// use ActivateGameOverlayToUser( "chat", steamIDClan ) to open the in-game overlay version of the chat
+	STEAM_CALL_RESULT( JoinClanChatRoomCompletionResult_t )
+	virtual SteamAPICall_t JoinClanChatRoom( CSteamID steamIDClan ) = 0;
+	virtual bool LeaveClanChatRoom( CSteamID steamIDClan ) = 0;
+	virtual int GetClanChatMemberCount( CSteamID steamIDClan ) = 0;
+	virtual CSteamID GetChatMemberByIndex( CSteamID steamIDClan, int iUser ) = 0;
+	virtual bool SendClanChatMessage( CSteamID steamIDClanChat, const char *pchText ) = 0;
+	virtual int GetClanChatMessage( CSteamID steamIDClanChat, int iMessage, void *prgchText, int cchTextMax, EChatEntryType *peChatEntryType, STEAM_OUT_STRUCT() CSteamID *psteamidChatter ) = 0;
+	virtual bool IsClanChatAdmin( CSteamID steamIDClanChat, CSteamID steamIDUser ) = 0;
+
+	// interact with the Steam (game overlay / desktop)
+	virtual bool IsClanChatWindowOpenInSteam( CSteamID steamIDClanChat ) = 0;
+	virtual bool OpenClanChatWindowInSteam( CSteamID steamIDClanChat ) = 0;
+	virtual bool CloseClanChatWindowInSteam( CSteamID steamIDClanChat ) = 0;
+
+	// peer-to-peer chat interception
+	// this is so you can show P2P chats inline in the game
+	virtual bool SetListenForFriendsMessages( bool bInterceptEnabled ) = 0;
+	virtual bool ReplyToFriendMessage( CSteamID steamIDFriend, const char *pchMsgToSend ) = 0;
+	virtual int GetFriendMessage( CSteamID steamIDFriend, int iMessageID, void *pvData, int cubData, EChatEntryType *peChatEntryType ) = 0;
+
+	// following apis
+	STEAM_CALL_RESULT( FriendsGetFollowerCount_t )
+	virtual SteamAPICall_t GetFollowerCount( CSteamID steamID ) = 0;
+	STEAM_CALL_RESULT( FriendsIsFollowing_t )
+	virtual SteamAPICall_t IsFollowing( CSteamID steamID ) = 0;
+	STEAM_CALL_RESULT( FriendsEnumerateFollowingList_t )
+	virtual SteamAPICall_t EnumerateFollowingList( uint32 unStartIndex ) = 0;
+
+	virtual bool IsClanPublic( CSteamID steamIDClan ) = 0;
+	virtual bool IsClanOfficialGameGroup( CSteamID steamIDClan ) = 0;
+
+	/// Return the number of chats (friends or chat rooms) with unread messages.
+	/// A "priority" message is one that would generate some sort of toast or
+	/// notification, and depends on user settings.
+	///
+	/// You can register for UnreadChatMessagesChanged_t callbacks to know when this
+	/// has potentially changed.
+	virtual int GetNumChatsWithUnreadPriorityMessages() = 0;
+
+	// activates game overlay to open the remote play together invite dialog. Invitations will be sent for remote play together
+	virtual void ActivateGameOverlayRemotePlayTogetherInviteDialog( CSteamID steamIDLobby ) = 0;
+};
+
+#define STEAMFRIENDS_INTERFACE_VERSION "SteamFriends017"
+
+// Global interface accessor
+inline ISteamFriends *SteamFriends();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamFriends *, SteamFriends, STEAMFRIENDS_INTERFACE_VERSION );
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+
+//-----------------------------------------------------------------------------
+// Purpose: called when a friends' status changes
+//-----------------------------------------------------------------------------
+struct PersonaStateChange_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 4 };
+	
+	uint64 m_ulSteamID;		// steamID of the friend who changed
+	int m_nChangeFlags;		// what's changed
+};
+
+
+// used in PersonaStateChange_t::m_nChangeFlags to describe what's changed about a user
+// these flags describe what the client has learned has changed recently, so on startup you'll see a name, avatar & relationship change for every friend
+enum EPersonaChange
+{
+	k_EPersonaChangeName		= 0x0001,
+	k_EPersonaChangeStatus		= 0x0002,
+	k_EPersonaChangeComeOnline	= 0x0004,
+	k_EPersonaChangeGoneOffline	= 0x0008,
+	k_EPersonaChangeGamePlayed	= 0x0010,
+	k_EPersonaChangeGameServer	= 0x0020,
+	k_EPersonaChangeAvatar		= 0x0040,
+	k_EPersonaChangeJoinedSource= 0x0080,
+	k_EPersonaChangeLeftSource	= 0x0100,
+	k_EPersonaChangeRelationshipChanged = 0x0200,
+	k_EPersonaChangeNameFirstSet = 0x0400,
+	k_EPersonaChangeBroadcast = 0x0800,
+	k_EPersonaChangeNickname =	0x1000,
+	k_EPersonaChangeSteamLevel = 0x2000,
+	k_EPersonaChangeRichPresence = 0x4000,
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: posted when game overlay activates or deactivates
+//			the game can use this to be pause or resume single player games
+//-----------------------------------------------------------------------------
+struct GameOverlayActivated_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 31 };
+	uint8 m_bActive;	// true if it's just been activated, false otherwise
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: called when the user tries to join a different game server from their friends list
+//			game client should attempt to connect to specified server when this is received
+//-----------------------------------------------------------------------------
+struct GameServerChangeRequested_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 32 };
+	char m_rgchServer[64];		// server address ("127.0.0.1:27015", "tf2.valvesoftware.com")
+	char m_rgchPassword[64];	// server password, if any
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: called when the user tries to join a lobby from their friends list
+//			game client should attempt to connect to specified lobby when this is received
+//-----------------------------------------------------------------------------
+struct GameLobbyJoinRequested_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 33 };
+	CSteamID m_steamIDLobby;
+
+	// The friend they did the join via (will be invalid if not directly via a friend)
+	//
+	// On PS3, the friend will be invalid if this was triggered by a PSN invite via the XMB, but
+	// the account type will be console user so you can tell at least that this was from a PSN friend
+	// rather than a Steam friend.
+	CSteamID m_steamIDFriend;		
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: called when an avatar is loaded in from a previous GetLargeFriendAvatar() call
+//			if the image wasn't already available
+//-----------------------------------------------------------------------------
+struct AvatarImageLoaded_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 34 };
+	CSteamID m_steamID; // steamid the avatar has been loaded for
+	int m_iImage; // the image index of the now loaded image
+	int m_iWide; // width of the loaded image
+	int m_iTall; // height of the loaded image
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: marks the return of a request officer list call
+//-----------------------------------------------------------------------------
+struct ClanOfficerListResponse_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 35 };
+	CSteamID m_steamIDClan;
+	int m_cOfficers;
+	uint8 m_bSuccess;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: callback indicating updated data about friends rich presence information
+//-----------------------------------------------------------------------------
+struct FriendRichPresenceUpdate_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 36 };
+	CSteamID m_steamIDFriend;	// friend who's rich presence has changed
+	AppId_t m_nAppID;			// the appID of the game (should always be the current game)
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: called when the user tries to join a game from their friends list
+//			rich presence will have been set with the "connect" key which is set here
+//-----------------------------------------------------------------------------
+struct GameRichPresenceJoinRequested_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 37 };
+	CSteamID m_steamIDFriend;		// the friend they did the join via (will be invalid if not directly via a friend)
+	char m_rgchConnect[k_cchMaxRichPresenceValueLength];
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: a chat message has been received for a clan chat the game has joined
+//-----------------------------------------------------------------------------
+struct GameConnectedClanChatMsg_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 38 };
+	CSteamID m_steamIDClanChat;
+	CSteamID m_steamIDUser;
+	int m_iMessageID;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: a user has joined a clan chat
+//-----------------------------------------------------------------------------
+struct GameConnectedChatJoin_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 39 };
+	CSteamID m_steamIDClanChat;
+	CSteamID m_steamIDUser;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: a user has left the chat we're in
+//-----------------------------------------------------------------------------
+struct GameConnectedChatLeave_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 40 };
+	CSteamID m_steamIDClanChat;
+	CSteamID m_steamIDUser;
+	bool m_bKicked;		// true if admin kicked
+	bool m_bDropped;	// true if Steam connection dropped
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: a DownloadClanActivityCounts() call has finished
+//-----------------------------------------------------------------------------
+struct DownloadClanActivityCountsResult_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 41 };
+	bool m_bSuccess;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: a JoinClanChatRoom() call has finished
+//-----------------------------------------------------------------------------
+struct JoinClanChatRoomCompletionResult_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 42 };
+	CSteamID m_steamIDClanChat;
+	EChatRoomEnterResponse m_eChatRoomEnterResponse;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: a chat message has been received from a user
+//-----------------------------------------------------------------------------
+struct GameConnectedFriendChatMsg_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 43 };
+	CSteamID m_steamIDUser;
+	int m_iMessageID;
+};
+
+
+struct FriendsGetFollowerCount_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 44 };
+	EResult m_eResult;
+	CSteamID m_steamID;
+	int m_nCount;
+};
+
+
+struct FriendsIsFollowing_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 45 };
+	EResult m_eResult;
+	CSteamID m_steamID;
+	bool m_bIsFollowing;
+};
+
+
+struct FriendsEnumerateFollowingList_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 46 };
+	EResult m_eResult;
+	CSteamID m_rgSteamID[ k_cEnumerateFollowersMax ];
+	int32 m_nResultsReturned;
+	int32 m_nTotalResultCount;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: reports the result of an attempt to change the user's persona name
+//-----------------------------------------------------------------------------
+struct SetPersonaNameResponse_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 47 };
+
+	bool m_bSuccess; // true if name change succeeded completely.
+	bool m_bLocalSuccess; // true if name change was retained locally.  (We might not have been able to communicate with Steam)
+	EResult m_result; // detailed result code
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: Invoked when the status of unread messages changes
+//-----------------------------------------------------------------------------
+struct UnreadChatMessagesChanged_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 48 };
+};
+
+#pragma pack( pop )
+
+#endif // ISTEAMFRIENDS_H

--- a/lsteamclient/steamworks_sdk_148a/isteamgamecoordinator.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamgamecoordinator.h
@@ -1,0 +1,74 @@
+//====== Copyright ©, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to the game coordinator for this application
+//
+//=============================================================================
+
+#ifndef ISTEAMGAMECOORDINATOR
+#define ISTEAMGAMECOORDINATOR
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+
+
+// list of possible return values from the ISteamGameCoordinator API
+enum EGCResults
+{
+	k_EGCResultOK = 0,
+	k_EGCResultNoMessage = 1,			// There is no message in the queue
+	k_EGCResultBufferTooSmall = 2,		// The buffer is too small for the requested message
+	k_EGCResultNotLoggedOn = 3,			// The client is not logged onto Steam
+	k_EGCResultInvalidMessage = 4,		// Something was wrong with the message being sent with SendMessage
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for sending and receiving messages from the Game Coordinator
+//			for this application
+//-----------------------------------------------------------------------------
+class ISteamGameCoordinator
+{
+public:
+
+	// sends a message to the Game Coordinator
+	virtual EGCResults SendMessage( uint32 unMsgType, const void *pubData, uint32 cubData ) = 0;
+
+	// returns true if there is a message waiting from the game coordinator
+	virtual bool IsMessageAvailable( uint32 *pcubMsgSize ) = 0; 
+
+	// fills the provided buffer with the first message in the queue and returns k_EGCResultOK or 
+	// returns k_EGCResultNoMessage if there is no message waiting. pcubMsgSize is filled with the message size.
+	// If the provided buffer is not large enough to fit the entire message, k_EGCResultBufferTooSmall is returned
+	// and the message remains at the head of the queue.
+	virtual EGCResults RetrieveMessage( uint32 *punMsgType, void *pubDest, uint32 cubDest, uint32 *pcubMsgSize ) = 0; 
+
+};
+#define STEAMGAMECOORDINATOR_INTERFACE_VERSION "SteamGameCoordinator001"
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+
+// callback notification - A new message is available for reading from the message queue
+struct GCMessageAvailable_t
+{
+	enum { k_iCallback = k_iSteamGameCoordinatorCallbacks + 1 };
+	uint32 m_nMessageSize;
+};
+
+// callback notification - A message failed to make it to the GC. It may be down temporarily
+struct GCMessageFailed_t
+{
+	enum { k_iCallback = k_iSteamGameCoordinatorCallbacks + 2 };
+};
+
+#pragma pack( pop )
+
+#endif // ISTEAMGAMECOORDINATOR

--- a/lsteamclient/steamworks_sdk_148a/isteamgameserver.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamgameserver.h
@@ -1,0 +1,391 @@
+//====== Copyright (c) 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to steam for game servers
+//
+//=============================================================================
+
+#ifndef ISTEAMGAMESERVER_H
+#define ISTEAMGAMESERVER_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+
+#define MASTERSERVERUPDATERPORT_USEGAMESOCKETSHARE	((uint16)-1)
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for authenticating users via Steam to play on a game server
+//-----------------------------------------------------------------------------
+class ISteamGameServer
+{
+public:
+
+//
+// Basic server data.  These properties, if set, must be set before before calling LogOn.  They
+// may not be changed after logged in.
+//
+
+	/// This is called by SteamGameServer_Init, and you will usually not need to call it directly
+	STEAM_PRIVATE_API( virtual bool InitGameServer( uint32 unIP, uint16 usGamePort, uint16 usQueryPort, uint32 unFlags, AppId_t nGameAppId, const char *pchVersionString ) = 0; )
+
+	/// Game product identifier.  This is currently used by the master server for version checking purposes.
+	/// It's a required field, but will eventually will go away, and the AppID will be used for this purpose.
+	virtual void SetProduct( const char *pszProduct ) = 0;
+
+	/// Description of the game.  This is a required field and is displayed in the steam server browser....for now.
+	/// This is a required field, but it will go away eventually, as the data should be determined from the AppID.
+	virtual void SetGameDescription( const char *pszGameDescription ) = 0;
+
+	/// If your game is a "mod," pass the string that identifies it.  The default is an empty string, meaning
+	/// this application is the original game, not a mod.
+	///
+	/// @see k_cbMaxGameServerGameDir
+	virtual void SetModDir( const char *pszModDir ) = 0;
+
+	/// Is this is a dedicated server?  The default value is false.
+	virtual void SetDedicatedServer( bool bDedicated ) = 0;
+
+//
+// Login
+//
+
+	/// Begin process to login to a persistent game server account
+	///
+	/// You need to register for callbacks to determine the result of this operation.
+	/// @see SteamServersConnected_t
+	/// @see SteamServerConnectFailure_t
+	/// @see SteamServersDisconnected_t
+	virtual void LogOn( const char *pszToken ) = 0;
+
+	/// Login to a generic, anonymous account.
+	///
+	/// Note: in previous versions of the SDK, this was automatically called within SteamGameServer_Init,
+	/// but this is no longer the case.
+	virtual void LogOnAnonymous() = 0;
+
+	/// Begin process of logging game server out of steam
+	virtual void LogOff() = 0;
+	
+	// status functions
+	virtual bool BLoggedOn() = 0;
+	virtual bool BSecure() = 0; 
+	virtual CSteamID GetSteamID() = 0;
+
+	/// Returns true if the master server has requested a restart.
+	/// Only returns true once per request.
+	virtual bool WasRestartRequested() = 0;
+
+//
+// Server state.  These properties may be changed at any time.
+//
+
+	/// Max player count that will be reported to server browser and client queries
+	virtual void SetMaxPlayerCount( int cPlayersMax ) = 0;
+
+	/// Number of bots.  Default value is zero
+	virtual void SetBotPlayerCount( int cBotplayers ) = 0;
+
+	/// Set the name of server as it will appear in the server browser
+	///
+	/// @see k_cbMaxGameServerName
+	virtual void SetServerName( const char *pszServerName ) = 0;
+
+	/// Set name of map to report in the server browser
+	///
+	/// @see k_cbMaxGameServerName
+	virtual void SetMapName( const char *pszMapName ) = 0;
+
+	/// Let people know if your server will require a password
+	virtual void SetPasswordProtected( bool bPasswordProtected ) = 0;
+
+	/// Spectator server.  The default value is zero, meaning the service
+	/// is not used.
+	virtual void SetSpectatorPort( uint16 unSpectatorPort ) = 0;
+
+	/// Name of the spectator server.  (Only used if spectator port is nonzero.)
+	///
+	/// @see k_cbMaxGameServerMapName
+	virtual void SetSpectatorServerName( const char *pszSpectatorServerName ) = 0;
+
+	/// Call this to clear the whole list of key/values that are sent in rules queries.
+	virtual void ClearAllKeyValues() = 0;
+	
+	/// Call this to add/update a key/value pair.
+	virtual void SetKeyValue( const char *pKey, const char *pValue ) = 0;
+
+	/// Sets a string defining the "gametags" for this server, this is optional, but if it is set
+	/// it allows users to filter in the matchmaking/server-browser interfaces based on the value
+	///
+	/// @see k_cbMaxGameServerTags
+	virtual void SetGameTags( const char *pchGameTags ) = 0;
+
+	/// Sets a string defining the "gamedata" for this server, this is optional, but if it is set
+	/// it allows users to filter in the matchmaking/server-browser interfaces based on the value
+	/// don't set this unless it actually changes, its only uploaded to the master once (when
+	/// acknowledged)
+	///
+	/// @see k_cbMaxGameServerGameData
+	virtual void SetGameData( const char *pchGameData ) = 0;
+
+	/// Region identifier.  This is an optional field, the default value is empty, meaning the "world" region
+	virtual void SetRegion( const char *pszRegion ) = 0;
+
+//
+// Player list management / authentication
+//
+
+	// Handles receiving a new connection from a Steam user.  This call will ask the Steam
+	// servers to validate the users identity, app ownership, and VAC status.  If the Steam servers 
+	// are off-line, then it will validate the cached ticket itself which will validate app ownership 
+	// and identity.  The AuthBlob here should be acquired on the game client using SteamUser()->InitiateGameConnection()
+	// and must then be sent up to the game server for authentication.
+	//
+	// Return Value: returns true if the users ticket passes basic checks. pSteamIDUser will contain the Steam ID of this user. pSteamIDUser must NOT be NULL
+	// If the call succeeds then you should expect a GSClientApprove_t or GSClientDeny_t callback which will tell you whether authentication
+	// for the user has succeeded or failed (the steamid in the callback will match the one returned by this call)
+	virtual bool SendUserConnectAndAuthenticate( uint32 unIPClient, const void *pvAuthBlob, uint32 cubAuthBlobSize, CSteamID *pSteamIDUser ) = 0;
+
+	// Creates a fake user (ie, a bot) which will be listed as playing on the server, but skips validation.  
+	// 
+	// Return Value: Returns a SteamID for the user to be tracked with, you should call HandleUserDisconnect()
+	// when this user leaves the server just like you would for a real user.
+	virtual CSteamID CreateUnauthenticatedUserConnection() = 0;
+
+	// Should be called whenever a user leaves our game server, this lets Steam internally
+	// track which users are currently on which servers for the purposes of preventing a single
+	// account being logged into multiple servers, showing who is currently on a server, etc.
+	virtual void SendUserDisconnect( CSteamID steamIDUser ) = 0;
+
+	// Update the data to be displayed in the server browser and matchmaking interfaces for a user
+	// currently connected to the server.  For regular users you must call this after you receive a
+	// GSUserValidationSuccess callback.
+	// 
+	// Return Value: true if successful, false if failure (ie, steamIDUser wasn't for an active player)
+	virtual bool BUpdateUserData( CSteamID steamIDUser, const char *pchPlayerName, uint32 uScore ) = 0;
+
+	// New auth system APIs - do not mix with the old auth system APIs.
+	// ----------------------------------------------------------------
+
+	// Retrieve ticket to be sent to the entity who wishes to authenticate you ( using BeginAuthSession API ). 
+	// pcbTicket retrieves the length of the actual ticket.
+	virtual HAuthTicket GetAuthSessionTicket( void *pTicket, int cbMaxTicket, uint32 *pcbTicket ) = 0;
+
+	// Authenticate ticket ( from GetAuthSessionTicket ) from entity steamID to be sure it is valid and isnt reused
+	// Registers for callbacks if the entity goes offline or cancels the ticket ( see ValidateAuthTicketResponse_t callback and EAuthSessionResponse )
+	virtual EBeginAuthSessionResult BeginAuthSession( const void *pAuthTicket, int cbAuthTicket, CSteamID steamID ) = 0;
+
+	// Stop tracking started by BeginAuthSession - called when no longer playing game with this entity
+	virtual void EndAuthSession( CSteamID steamID ) = 0;
+
+	// Cancel auth ticket from GetAuthSessionTicket, called when no longer playing game with the entity you gave the ticket to
+	virtual void CancelAuthTicket( HAuthTicket hAuthTicket ) = 0;
+
+	// After receiving a user's authentication data, and passing it to SendUserConnectAndAuthenticate, use this function
+	// to determine if the user owns downloadable content specified by the provided AppID.
+	virtual EUserHasLicenseForAppResult UserHasLicenseForApp( CSteamID steamID, AppId_t appID ) = 0;
+
+	// Ask if a user in in the specified group, results returns async by GSUserGroupStatus_t
+	// returns false if we're not connected to the steam servers and thus cannot ask
+	virtual bool RequestUserGroupStatus( CSteamID steamIDUser, CSteamID steamIDGroup ) = 0;
+
+
+	// these two functions s are deprecated, and will not return results
+	// they will be removed in a future version of the SDK
+	virtual void GetGameplayStats( ) = 0;
+	STEAM_CALL_RESULT( GSReputation_t )
+	virtual SteamAPICall_t GetServerReputation() = 0;
+
+	// Returns the public IP of the server according to Steam, useful when the server is 
+	// behind NAT and you want to advertise its IP in a lobby for other clients to directly
+	// connect to
+	virtual SteamIPAddress_t GetPublicIP() = 0;
+
+// These are in GameSocketShare mode, where instead of ISteamGameServer creating its own
+// socket to talk to the master server on, it lets the game use its socket to forward messages
+// back and forth. This prevents us from requiring server ops to open up yet another port
+// in their firewalls.
+//
+// the IP address and port should be in host order, i.e 127.0.0.1 == 0x7f000001
+	
+	// These are used when you've elected to multiplex the game server's UDP socket
+	// rather than having the master server updater use its own sockets.
+	// 
+	// Source games use this to simplify the job of the server admins, so they 
+	// don't have to open up more ports on their firewalls.
+	
+	// Call this when a packet that starts with 0xFFFFFFFF comes in. That means
+	// it's for us.
+	virtual bool HandleIncomingPacket( const void *pData, int cbData, uint32 srcIP, uint16 srcPort ) = 0;
+
+	// AFTER calling HandleIncomingPacket for any packets that came in that frame, call this.
+	// This gets a packet that the master server updater needs to send out on UDP.
+	// It returns the length of the packet it wants to send, or 0 if there are no more packets to send.
+	// Call this each frame until it returns 0.
+	virtual int GetNextOutgoingPacket( void *pOut, int cbMaxOut, uint32 *pNetAdr, uint16 *pPort ) = 0;
+
+//
+// Control heartbeats / advertisement with master server
+//
+
+	// Call this as often as you like to tell the master server updater whether or not
+	// you want it to be active (default: off).
+	virtual void EnableHeartbeats( bool bActive ) = 0;
+
+	// You usually don't need to modify this.
+	// Pass -1 to use the default value for iHeartbeatInterval.
+	// Some mods change this.
+	virtual void SetHeartbeatInterval( int iHeartbeatInterval ) = 0;
+
+	// Force a heartbeat to steam at the next opportunity
+	virtual void ForceHeartbeat() = 0;
+
+	// associate this game server with this clan for the purposes of computing player compat
+	STEAM_CALL_RESULT( AssociateWithClanResult_t )
+	virtual SteamAPICall_t AssociateWithClan( CSteamID steamIDClan ) = 0;
+	
+	// ask if any of the current players dont want to play with this new player - or vice versa
+	STEAM_CALL_RESULT( ComputeNewPlayerCompatibilityResult_t )
+	virtual SteamAPICall_t ComputeNewPlayerCompatibility( CSteamID steamIDNewPlayer ) = 0;
+
+};
+
+#define STEAMGAMESERVER_INTERFACE_VERSION "SteamGameServer013"
+
+// Global accessor
+inline ISteamGameServer *SteamGameServer();
+STEAM_DEFINE_GAMESERVER_INTERFACE_ACCESSOR( ISteamGameServer *, SteamGameServer, STEAMGAMESERVER_INTERFACE_VERSION );
+
+// game server flags
+const uint32 k_unServerFlagNone			= 0x00;
+const uint32 k_unServerFlagActive		= 0x01;		// server has users playing
+const uint32 k_unServerFlagSecure		= 0x02;		// server wants to be secure
+const uint32 k_unServerFlagDedicated	= 0x04;		// server is dedicated
+const uint32 k_unServerFlagLinux		= 0x08;		// linux build
+const uint32 k_unServerFlagPassworded	= 0x10;		// password protected
+const uint32 k_unServerFlagPrivate		= 0x20;		// server shouldn't list on master server and
+													// won't enforce authentication of users that connect to the server.
+													// Useful when you run a server where the clients may not
+													// be connected to the internet but you want them to play (i.e LANs)
+
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+
+
+// client has been approved to connect to this game server
+struct GSClientApprove_t
+{
+	enum { k_iCallback = k_iSteamGameServerCallbacks + 1 };
+	CSteamID m_SteamID;			// SteamID of approved player
+	CSteamID m_OwnerSteamID;	// SteamID of original owner for game license
+};
+
+
+// client has been denied to connection to this game server
+struct GSClientDeny_t
+{
+	enum { k_iCallback = k_iSteamGameServerCallbacks + 2 };
+	CSteamID m_SteamID;
+	EDenyReason m_eDenyReason;
+	char m_rgchOptionalText[128];
+};
+
+
+// request the game server should kick the user
+struct GSClientKick_t
+{
+	enum { k_iCallback = k_iSteamGameServerCallbacks + 3 };
+	CSteamID m_SteamID;
+	EDenyReason m_eDenyReason;
+};
+
+// NOTE: callback values 4 and 5 are skipped because they are used for old deprecated callbacks, 
+// do not reuse them here.
+
+
+// client achievement info
+struct GSClientAchievementStatus_t
+{
+	enum { k_iCallback = k_iSteamGameServerCallbacks + 6 };
+	uint64 m_SteamID;
+	char m_pchAchievement[128];
+	bool m_bUnlocked;
+};
+
+// received when the game server requests to be displayed as secure (VAC protected)
+// m_bSecure is true if the game server should display itself as secure to users, false otherwise
+struct GSPolicyResponse_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 15 };
+	uint8 m_bSecure;
+};
+
+// GS gameplay stats info
+struct GSGameplayStats_t
+{
+	enum { k_iCallback = k_iSteamGameServerCallbacks + 7 };
+	EResult m_eResult;					// Result of the call
+	int32	m_nRank;					// Overall rank of the server (0-based)
+	uint32	m_unTotalConnects;			// Total number of clients who have ever connected to the server
+	uint32	m_unTotalMinutesPlayed;		// Total number of minutes ever played on the server
+};
+
+// send as a reply to RequestUserGroupStatus()
+struct GSClientGroupStatus_t
+{
+	enum { k_iCallback = k_iSteamGameServerCallbacks + 8 };
+	CSteamID m_SteamIDUser;
+	CSteamID m_SteamIDGroup;
+	bool m_bMember;
+	bool m_bOfficer;
+};
+
+// Sent as a reply to GetServerReputation()
+struct GSReputation_t
+{
+	enum { k_iCallback = k_iSteamGameServerCallbacks + 9 };
+	EResult	m_eResult;				// Result of the call;
+	uint32	m_unReputationScore;	// The reputation score for the game server
+	bool	m_bBanned;				// True if the server is banned from the Steam
+									// master servers
+
+	// The following members are only filled out if m_bBanned is true. They will all 
+	// be set to zero otherwise. Master server bans are by IP so it is possible to be
+	// banned even when the score is good high if there is a bad server on another port.
+	// This information can be used to determine which server is bad.
+
+	uint32	m_unBannedIP;		// The IP of the banned server
+	uint16	m_usBannedPort;		// The port of the banned server
+	uint64	m_ulBannedGameID;	// The game ID the banned server is serving
+	uint32	m_unBanExpires;		// Time the ban expires, expressed in the Unix epoch (seconds since 1/1/1970)
+};
+
+// Sent as a reply to AssociateWithClan()
+struct AssociateWithClanResult_t
+{
+	enum { k_iCallback = k_iSteamGameServerCallbacks + 10 };
+	EResult	m_eResult;				// Result of the call;
+};
+
+// Sent as a reply to ComputeNewPlayerCompatibility()
+struct ComputeNewPlayerCompatibilityResult_t
+{
+	enum { k_iCallback = k_iSteamGameServerCallbacks + 11 };
+	EResult	m_eResult;				// Result of the call;
+	int m_cPlayersThatDontLikeCandidate;
+	int m_cPlayersThatCandidateDoesntLike;
+	int m_cClanPlayersThatDontLikeCandidate;
+	CSteamID m_SteamIDCandidate;
+};
+
+
+#pragma pack( pop )
+
+#endif // ISTEAMGAMESERVER_H

--- a/lsteamclient/steamworks_sdk_148a/isteamgameserverstats.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamgameserverstats.h
@@ -1,0 +1,114 @@
+//====== Copyright © Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface for game servers to steam stats and achievements
+//
+//=============================================================================
+
+#ifndef ISTEAMGAMESERVERSTATS_H
+#define ISTEAMGAMESERVERSTATS_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for authenticating users via Steam to play on a game server
+//-----------------------------------------------------------------------------
+class ISteamGameServerStats
+{
+public:
+	// downloads stats for the user
+	// returns a GSStatsReceived_t callback when completed
+	// if the user has no stats, GSStatsReceived_t.m_eResult will be set to k_EResultFail
+	// these stats will only be auto-updated for clients playing on the server. For other
+	// users you'll need to call RequestUserStats() again to refresh any data
+	STEAM_CALL_RESULT( GSStatsReceived_t )
+	virtual SteamAPICall_t RequestUserStats( CSteamID steamIDUser ) = 0;
+
+	// requests stat information for a user, usable after a successful call to RequestUserStats()
+	STEAM_FLAT_NAME( GetUserStatInt32 )
+	virtual bool GetUserStat( CSteamID steamIDUser, const char *pchName, int32 *pData ) = 0;
+
+	STEAM_FLAT_NAME( GetUserStatFloat )
+	virtual bool GetUserStat( CSteamID steamIDUser, const char *pchName, float *pData ) = 0;
+
+	virtual bool GetUserAchievement( CSteamID steamIDUser, const char *pchName, bool *pbAchieved ) = 0;
+
+	// Set / update stats and achievements. 
+	// Note: These updates will work only on stats game servers are allowed to edit and only for 
+	// game servers that have been declared as officially controlled by the game creators. 
+	// Set the IP range of your official servers on the Steamworks page
+
+	STEAM_FLAT_NAME( SetUserStatInt32 )
+	virtual bool SetUserStat( CSteamID steamIDUser, const char *pchName, int32 nData ) = 0;
+
+	STEAM_FLAT_NAME( SetUserStatFloat )
+	virtual bool SetUserStat( CSteamID steamIDUser, const char *pchName, float fData ) = 0;
+
+	virtual bool UpdateUserAvgRateStat( CSteamID steamIDUser, const char *pchName, float flCountThisSession, double dSessionLength ) = 0;
+
+	virtual bool SetUserAchievement( CSteamID steamIDUser, const char *pchName ) = 0;
+	virtual bool ClearUserAchievement( CSteamID steamIDUser, const char *pchName ) = 0;
+
+	// Store the current data on the server, will get a GSStatsStored_t callback when set.
+	//
+	// If the callback has a result of k_EResultInvalidParam, one or more stats 
+	// uploaded has been rejected, either because they broke constraints
+	// or were out of date. In this case the server sends back updated values.
+	// The stats should be re-iterated to keep in sync.
+	STEAM_CALL_RESULT( GSStatsStored_t )
+	virtual SteamAPICall_t StoreUserStats( CSteamID steamIDUser ) = 0;
+};
+#define STEAMGAMESERVERSTATS_INTERFACE_VERSION "SteamGameServerStats001"
+
+// Global accessor
+inline ISteamGameServerStats *SteamGameServerStats();
+STEAM_DEFINE_GAMESERVER_INTERFACE_ACCESSOR( ISteamGameServerStats *, SteamGameServerStats, STEAMGAMESERVERSTATS_INTERFACE_VERSION );
+
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+
+//-----------------------------------------------------------------------------
+// Purpose: called when the latests stats and achievements have been received
+//			from the server
+//-----------------------------------------------------------------------------
+struct GSStatsReceived_t
+{
+	enum { k_iCallback = k_iSteamGameServerStatsCallbacks };
+	EResult		m_eResult;		// Success / error fetching the stats
+	CSteamID	m_steamIDUser;	// The user for whom the stats are retrieved for
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: result of a request to store the user stats for a game
+//-----------------------------------------------------------------------------
+struct GSStatsStored_t
+{
+	enum { k_iCallback = k_iSteamGameServerStatsCallbacks + 1 };
+	EResult		m_eResult;		// success / error
+	CSteamID	m_steamIDUser;	// The user for whom the stats were stored
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback indicating that a user's stats have been unloaded.
+//  Call RequestUserStats again to access stats for this user
+//-----------------------------------------------------------------------------
+struct GSStatsUnloaded_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 8 };
+	CSteamID	m_steamIDUser;	// User whose stats have been unloaded
+};
+
+#pragma pack( pop )
+
+
+#endif // ISTEAMGAMESERVERSTATS_H

--- a/lsteamclient/steamworks_sdk_148a/isteamhtmlsurface.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamhtmlsurface.h
@@ -1,0 +1,480 @@
+//====== Copyright 1996-2013, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to display html pages in a texture
+//
+//=============================================================================
+
+#ifndef ISTEAMHTMLSURFACE_H
+#define ISTEAMHTMLSURFACE_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+
+typedef uint32 HHTMLBrowser;
+const uint32 INVALID_HTMLBROWSER = 0;
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for displaying HTML pages and interacting with them
+//-----------------------------------------------------------------------------
+class ISteamHTMLSurface
+{
+public:
+	virtual ~ISteamHTMLSurface() {}
+
+	// Must call init and shutdown when starting/ending use of the interface
+	virtual bool Init() = 0;
+	virtual bool Shutdown() = 0;
+
+	// Create a browser object for display of a html page, when creation is complete the call handle
+	// will return a HTML_BrowserReady_t callback for the HHTMLBrowser of your new browser.
+	//   The user agent string is a substring to be added to the general user agent string so you can
+	// identify your client on web servers.
+	//   The userCSS string lets you apply a CSS style sheet to every displayed page, leave null if
+	// you do not require this functionality.
+	//
+	// YOU MUST HAVE IMPLEMENTED HANDLERS FOR HTML_BrowserReady_t, HTML_StartRequest_t,
+	// HTML_JSAlert_t, HTML_JSConfirm_t, and HTML_FileOpenDialog_t! See the CALLBACKS
+	// section of this interface (AllowStartRequest, etc) for more details. If you do
+	// not implement these callback handlers, the browser may appear to hang instead of
+	// navigating to new pages or triggering javascript popups.
+	//
+	STEAM_CALL_RESULT( HTML_BrowserReady_t )
+	virtual SteamAPICall_t CreateBrowser( const char *pchUserAgent, const char *pchUserCSS ) = 0;
+
+	// Call this when you are done with a html surface, this lets us free the resources being used by it
+	virtual void RemoveBrowser( HHTMLBrowser unBrowserHandle ) = 0;
+
+	// Navigate to this URL, results in a HTML_StartRequest_t as the request commences 
+	virtual void LoadURL( HHTMLBrowser unBrowserHandle, const char *pchURL, const char *pchPostData ) = 0;
+
+	// Tells the surface the size in pixels to display the surface
+	virtual void SetSize( HHTMLBrowser unBrowserHandle, uint32 unWidth, uint32 unHeight ) = 0;
+
+	// Stop the load of the current html page
+	virtual void StopLoad( HHTMLBrowser unBrowserHandle ) = 0;
+	// Reload (most likely from local cache) the current page
+	virtual void Reload( HHTMLBrowser unBrowserHandle ) = 0;
+	// navigate back in the page history
+	virtual void GoBack( HHTMLBrowser unBrowserHandle ) = 0;
+	// navigate forward in the page history
+	virtual void GoForward( HHTMLBrowser unBrowserHandle ) = 0;
+
+	// add this header to any url requests from this browser
+	virtual void AddHeader( HHTMLBrowser unBrowserHandle, const char *pchKey, const char *pchValue ) = 0;
+	// run this javascript script in the currently loaded page
+	virtual void ExecuteJavascript( HHTMLBrowser unBrowserHandle, const char *pchScript ) = 0;
+
+	enum EHTMLMouseButton
+	{
+		eHTMLMouseButton_Left = 0,
+		eHTMLMouseButton_Right = 1,
+		eHTMLMouseButton_Middle = 2,
+	};
+
+	// Mouse click and mouse movement commands
+	virtual void MouseUp( HHTMLBrowser unBrowserHandle, EHTMLMouseButton eMouseButton ) = 0;
+	virtual void MouseDown( HHTMLBrowser unBrowserHandle, EHTMLMouseButton eMouseButton ) = 0;
+	virtual void MouseDoubleClick( HHTMLBrowser unBrowserHandle, EHTMLMouseButton eMouseButton ) = 0;
+	// x and y are relative to the HTML bounds
+	virtual void MouseMove( HHTMLBrowser unBrowserHandle, int x, int y ) = 0;
+	// nDelta is pixels of scroll
+	virtual void MouseWheel( HHTMLBrowser unBrowserHandle, int32 nDelta ) = 0;
+
+	enum EMouseCursor
+	{
+		dc_user = 0,
+		dc_none,
+		dc_arrow,
+		dc_ibeam,
+		dc_hourglass,
+		dc_waitarrow,
+		dc_crosshair,
+		dc_up,
+		dc_sizenw,
+		dc_sizese,
+		dc_sizene,
+		dc_sizesw,
+		dc_sizew,
+		dc_sizee,
+		dc_sizen,
+		dc_sizes,
+		dc_sizewe,
+		dc_sizens,
+		dc_sizeall,
+		dc_no,
+		dc_hand,
+		dc_blank, // don't show any custom cursor, just use your default
+		dc_middle_pan,
+		dc_north_pan,
+		dc_north_east_pan,
+		dc_east_pan,
+		dc_south_east_pan,
+		dc_south_pan,
+		dc_south_west_pan,
+		dc_west_pan,
+		dc_north_west_pan,
+		dc_alias,
+		dc_cell,
+		dc_colresize,
+		dc_copycur,
+		dc_verticaltext,
+		dc_rowresize,
+		dc_zoomin,
+		dc_zoomout,
+		dc_help,
+		dc_custom,
+
+		dc_last, // custom cursors start from this value and up
+	};
+
+	enum EHTMLKeyModifiers
+	{
+		k_eHTMLKeyModifier_None = 0,
+		k_eHTMLKeyModifier_AltDown = 1 << 0,
+		k_eHTMLKeyModifier_CtrlDown = 1 << 1,
+		k_eHTMLKeyModifier_ShiftDown = 1 << 2,
+	};
+
+	// keyboard interactions, native keycode is the virtual key code value from your OS, system key flags the key to not
+	// be sent as a typed character as well as a key down
+	virtual void KeyDown( HHTMLBrowser unBrowserHandle, uint32 nNativeKeyCode, EHTMLKeyModifiers eHTMLKeyModifiers, bool bIsSystemKey = false ) = 0;
+	virtual void KeyUp( HHTMLBrowser unBrowserHandle, uint32 nNativeKeyCode, EHTMLKeyModifiers eHTMLKeyModifiers ) = 0;
+	// cUnicodeChar is the unicode character point for this keypress (and potentially multiple chars per press)
+	virtual void KeyChar( HHTMLBrowser unBrowserHandle, uint32 cUnicodeChar, EHTMLKeyModifiers eHTMLKeyModifiers ) = 0;
+
+	// programmatically scroll this many pixels on the page
+	virtual void SetHorizontalScroll( HHTMLBrowser unBrowserHandle, uint32 nAbsolutePixelScroll ) = 0;
+	virtual void SetVerticalScroll( HHTMLBrowser unBrowserHandle, uint32 nAbsolutePixelScroll ) = 0;
+
+	// tell the html control if it has key focus currently, controls showing the I-beam cursor in text controls amongst other things
+	virtual void SetKeyFocus( HHTMLBrowser unBrowserHandle, bool bHasKeyFocus ) = 0;
+
+	// open the current pages html code in the local editor of choice, used for debugging
+	virtual void ViewSource( HHTMLBrowser unBrowserHandle ) = 0;
+	// copy the currently selected text on the html page to the local clipboard
+	virtual void CopyToClipboard( HHTMLBrowser unBrowserHandle ) = 0;
+	// paste from the local clipboard to the current html page
+	virtual void PasteFromClipboard( HHTMLBrowser unBrowserHandle ) = 0;
+
+	// find this string in the browser, if bCurrentlyInFind is true then instead cycle to the next matching element
+	virtual void Find( HHTMLBrowser unBrowserHandle, const char *pchSearchStr, bool bCurrentlyInFind, bool bReverse ) = 0;
+	// cancel a currently running find
+	virtual void StopFind( HHTMLBrowser unBrowserHandle ) = 0;
+
+	// return details about the link at position x,y on the current page
+	virtual void GetLinkAtPosition(  HHTMLBrowser unBrowserHandle, int x, int y ) = 0;
+
+	// set a webcookie for the hostname in question
+	virtual void SetCookie( const char *pchHostname, const char *pchKey, const char *pchValue, const char *pchPath = "/", RTime32 nExpires = 0, bool bSecure = false, bool bHTTPOnly = false ) = 0;
+
+	// Zoom the current page by flZoom ( from 0.0 to 2.0, so to zoom to 120% use 1.2 ), zooming around point X,Y in the page (use 0,0 if you don't care)
+	virtual void SetPageScaleFactor( HHTMLBrowser unBrowserHandle, float flZoom, int nPointX, int nPointY ) = 0;
+
+	// Enable/disable low-resource background mode, where javascript and repaint timers are throttled, resources are
+	// more aggressively purged from memory, and audio/video elements are paused. When background mode is enabled,
+	// all HTML5 video and audio objects will execute ".pause()" and gain the property "._steam_background_paused = 1".
+	// When background mode is disabled, any video or audio objects with that property will resume with ".play()".
+	virtual void SetBackgroundMode( HHTMLBrowser unBrowserHandle, bool bBackgroundMode ) = 0;
+
+	// Scale the output display space by this factor, this is useful when displaying content on high dpi devices.
+	// Specifies the ratio between physical and logical pixels.
+	virtual void SetDPIScalingFactor( HHTMLBrowser unBrowserHandle, float flDPIScaling ) = 0;
+
+	// Open HTML/JS developer tools
+	virtual void OpenDeveloperTools( HHTMLBrowser unBrowserHandle ) = 0;
+
+	// CALLBACKS
+	//
+	//  These set of functions are used as responses to callback requests
+	//
+
+	// You MUST call this in response to a HTML_StartRequest_t callback
+	//  Set bAllowed to true to allow this navigation, false to cancel it and stay 
+	// on the current page. You can use this feature to limit the valid pages
+	// allowed in your HTML surface.
+	virtual void AllowStartRequest( HHTMLBrowser unBrowserHandle, bool bAllowed ) = 0;
+
+	// You MUST call this in response to a HTML_JSAlert_t or HTML_JSConfirm_t callback
+	//  Set bResult to true for the OK option of a confirm, use false otherwise
+	virtual void JSDialogResponse( HHTMLBrowser unBrowserHandle, bool bResult ) = 0;
+
+	// You MUST call this in response to a HTML_FileOpenDialog_t callback
+	STEAM_IGNOREATTR()
+	virtual void FileLoadDialogResponse( HHTMLBrowser unBrowserHandle, const char **pchSelectedFiles ) = 0;
+};
+
+#define STEAMHTMLSURFACE_INTERFACE_VERSION "STEAMHTMLSURFACE_INTERFACE_VERSION_005"
+
+// Global interface accessor
+inline ISteamHTMLSurface *SteamHTMLSurface();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamHTMLSurface *, SteamHTMLSurface, STEAMHTMLSURFACE_INTERFACE_VERSION );
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The browser is ready for use
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( HTML_BrowserReady_t, k_iSteamHTMLSurfaceCallbacks + 1 )
+STEAM_CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // this browser is now fully created and ready to navigate to pages
+STEAM_CALLBACK_END(1)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: the browser has a pending paint
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN(HTML_NeedsPaint_t, k_iSteamHTMLSurfaceCallbacks + 2)
+STEAM_CALLBACK_MEMBER(0, HHTMLBrowser, unBrowserHandle) // the browser that needs the paint
+STEAM_CALLBACK_MEMBER(1, const char *, pBGRA ) // a pointer to the B8G8R8A8 data for this surface, valid until SteamAPI_RunCallbacks is next called
+STEAM_CALLBACK_MEMBER(2, uint32, unWide) // the total width of the pBGRA texture
+STEAM_CALLBACK_MEMBER(3, uint32, unTall) // the total height of the pBGRA texture
+STEAM_CALLBACK_MEMBER(4, uint32, unUpdateX) // the offset in X for the damage rect for this update
+STEAM_CALLBACK_MEMBER(5, uint32, unUpdateY) // the offset in Y for the damage rect for this update
+STEAM_CALLBACK_MEMBER(6, uint32, unUpdateWide) // the width of the damage rect for this update
+STEAM_CALLBACK_MEMBER(7, uint32, unUpdateTall) // the height of the damage rect for this update
+STEAM_CALLBACK_MEMBER(8, uint32, unScrollX) // the page scroll the browser was at when this texture was rendered
+STEAM_CALLBACK_MEMBER(9, uint32, unScrollY) // the page scroll the browser was at when this texture was rendered
+STEAM_CALLBACK_MEMBER(10, float, flPageScale) // the page scale factor on this page when rendered
+STEAM_CALLBACK_MEMBER(11, uint32, unPageSerial) // incremented on each new page load, you can use this to reject draws while navigating to new pages
+STEAM_CALLBACK_END(12)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The browser wanted to navigate to a new page
+//   NOTE - you MUST call AllowStartRequest in response to this callback
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN(HTML_StartRequest_t, k_iSteamHTMLSurfaceCallbacks + 3)
+STEAM_CALLBACK_MEMBER(0, HHTMLBrowser, unBrowserHandle) // the handle of the surface navigating
+STEAM_CALLBACK_MEMBER(1, const char *, pchURL) // the url they wish to navigate to 
+STEAM_CALLBACK_MEMBER(2, const char *, pchTarget) // the html link target type  (i.e _blank, _self, _parent, _top )
+STEAM_CALLBACK_MEMBER(3, const char *, pchPostData ) // any posted data for the request
+STEAM_CALLBACK_MEMBER(4, bool, bIsRedirect) // true if this was a http/html redirect from the last load request
+STEAM_CALLBACK_END(5)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The browser has been requested to close due to user interaction (usually from a javascript window.close() call)
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN(HTML_CloseBrowser_t, k_iSteamHTMLSurfaceCallbacks + 4)
+STEAM_CALLBACK_MEMBER(0, HHTMLBrowser, unBrowserHandle) // the handle of the surface 
+STEAM_CALLBACK_END(1)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: the browser is navigating to a new url
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( HTML_URLChanged_t, k_iSteamHTMLSurfaceCallbacks + 5 )
+STEAM_CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface navigating
+STEAM_CALLBACK_MEMBER( 1, const char *, pchURL ) // the url they wish to navigate to 
+STEAM_CALLBACK_MEMBER( 2, const char *, pchPostData ) // any posted data for the request
+STEAM_CALLBACK_MEMBER( 3, bool, bIsRedirect ) // true if this was a http/html redirect from the last load request
+STEAM_CALLBACK_MEMBER( 4, const char *, pchPageTitle ) // the title of the page
+STEAM_CALLBACK_MEMBER( 5, bool, bNewNavigation ) // true if this was from a fresh tab and not a click on an existing page
+STEAM_CALLBACK_END(6)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: A page is finished loading
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( HTML_FinishedRequest_t, k_iSteamHTMLSurfaceCallbacks + 6 )
+STEAM_CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+STEAM_CALLBACK_MEMBER( 1, const char *, pchURL ) // 
+STEAM_CALLBACK_MEMBER( 2, const char *, pchPageTitle ) // 
+STEAM_CALLBACK_END(3)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: a request to load this url in a new tab
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( HTML_OpenLinkInNewTab_t, k_iSteamHTMLSurfaceCallbacks + 7 )
+STEAM_CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+STEAM_CALLBACK_MEMBER( 1, const char *, pchURL ) // 
+STEAM_CALLBACK_END(2)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: the page has a new title now
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( HTML_ChangedTitle_t, k_iSteamHTMLSurfaceCallbacks + 8 )
+STEAM_CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+STEAM_CALLBACK_MEMBER( 1, const char *, pchTitle ) // 
+STEAM_CALLBACK_END(2)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: results from a search
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( HTML_SearchResults_t, k_iSteamHTMLSurfaceCallbacks + 9 )
+STEAM_CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+STEAM_CALLBACK_MEMBER( 1, uint32, unResults ) // 
+STEAM_CALLBACK_MEMBER( 2, uint32, unCurrentMatch ) // 
+STEAM_CALLBACK_END(3)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: page history status changed on the ability to go backwards and forward
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( HTML_CanGoBackAndForward_t, k_iSteamHTMLSurfaceCallbacks + 10 )
+STEAM_CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+STEAM_CALLBACK_MEMBER( 1, bool, bCanGoBack ) // 
+STEAM_CALLBACK_MEMBER( 2, bool, bCanGoForward ) // 
+STEAM_CALLBACK_END(3)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: details on the visibility and size of the horizontal scrollbar
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( HTML_HorizontalScroll_t, k_iSteamHTMLSurfaceCallbacks + 11 )
+STEAM_CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+STEAM_CALLBACK_MEMBER( 1, uint32, unScrollMax ) // 
+STEAM_CALLBACK_MEMBER( 2, uint32, unScrollCurrent ) // 
+STEAM_CALLBACK_MEMBER( 3, float, flPageScale ) // 
+STEAM_CALLBACK_MEMBER( 4, bool , bVisible ) // 
+STEAM_CALLBACK_MEMBER( 5, uint32, unPageSize ) // 
+STEAM_CALLBACK_END(6)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: details on the visibility and size of the vertical scrollbar
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( HTML_VerticalScroll_t, k_iSteamHTMLSurfaceCallbacks + 12 )
+STEAM_CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+STEAM_CALLBACK_MEMBER( 1, uint32, unScrollMax ) // 
+STEAM_CALLBACK_MEMBER( 2, uint32, unScrollCurrent ) // 
+STEAM_CALLBACK_MEMBER( 3, float, flPageScale ) // 
+STEAM_CALLBACK_MEMBER( 4, bool, bVisible ) // 
+STEAM_CALLBACK_MEMBER( 5, uint32, unPageSize ) // 
+STEAM_CALLBACK_END(6)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: response to GetLinkAtPosition call 
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( HTML_LinkAtPosition_t, k_iSteamHTMLSurfaceCallbacks + 13 )
+STEAM_CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+STEAM_CALLBACK_MEMBER( 1, uint32, x ) // NOTE - Not currently set
+STEAM_CALLBACK_MEMBER( 2, uint32, y ) // NOTE - Not currently set
+STEAM_CALLBACK_MEMBER( 3, const char *, pchURL ) // 
+STEAM_CALLBACK_MEMBER( 4, bool, bInput ) // 
+STEAM_CALLBACK_MEMBER( 5, bool, bLiveLink ) // 
+STEAM_CALLBACK_END(6)
+
+
+
+//-----------------------------------------------------------------------------
+// Purpose: show a Javascript alert dialog, call JSDialogResponse 
+//   when the user dismisses this dialog (or right away to ignore it)
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( HTML_JSAlert_t, k_iSteamHTMLSurfaceCallbacks + 14 )
+STEAM_CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+STEAM_CALLBACK_MEMBER( 1, const char *, pchMessage ) // 
+STEAM_CALLBACK_END(2)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: show a Javascript confirmation dialog, call JSDialogResponse 
+//   when the user dismisses this dialog (or right away to ignore it)
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( HTML_JSConfirm_t, k_iSteamHTMLSurfaceCallbacks + 15 )
+STEAM_CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+STEAM_CALLBACK_MEMBER( 1, const char *, pchMessage ) // 
+STEAM_CALLBACK_END(2)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: when received show a file open dialog
+//   then call FileLoadDialogResponse with the file(s) the user selected.
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( HTML_FileOpenDialog_t, k_iSteamHTMLSurfaceCallbacks + 16 )
+STEAM_CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+STEAM_CALLBACK_MEMBER( 1, const char *, pchTitle ) // 
+STEAM_CALLBACK_MEMBER( 2, const char *, pchInitialFile ) // 
+STEAM_CALLBACK_END(3)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: a new html window is being created.
+//
+// IMPORTANT NOTE: at this time, the API does not allow you to acknowledge or
+// render the contents of this new window, so the new window is always destroyed
+// immediately. The URL and other parameters of the new window are passed here
+// to give your application the opportunity to call CreateBrowser and set up
+// a new browser in response to the attempted popup, if you wish to do so.
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( HTML_NewWindow_t, k_iSteamHTMLSurfaceCallbacks + 21 )
+STEAM_CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the current surface 
+STEAM_CALLBACK_MEMBER( 1, const char *, pchURL ) // the page to load
+STEAM_CALLBACK_MEMBER( 2, uint32, unX ) // the x pos into the page to display the popup
+STEAM_CALLBACK_MEMBER( 3, uint32, unY ) // the y pos into the page to display the popup
+STEAM_CALLBACK_MEMBER( 4, uint32, unWide ) // the total width of the pBGRA texture
+STEAM_CALLBACK_MEMBER( 5, uint32, unTall ) // the total height of the pBGRA texture
+STEAM_CALLBACK_MEMBER( 6, HHTMLBrowser, unNewWindow_BrowserHandle_IGNORE )
+STEAM_CALLBACK_END(7)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: change the cursor to display
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( HTML_SetCursor_t, k_iSteamHTMLSurfaceCallbacks + 22 )
+STEAM_CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+STEAM_CALLBACK_MEMBER( 1, uint32, eMouseCursor ) // the EMouseCursor to display
+STEAM_CALLBACK_END(2)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: informational message from the browser
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( HTML_StatusText_t, k_iSteamHTMLSurfaceCallbacks + 23 )
+STEAM_CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+STEAM_CALLBACK_MEMBER( 1, const char *, pchMsg ) // the EMouseCursor to display
+STEAM_CALLBACK_END(2)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: show a tooltip
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( HTML_ShowToolTip_t, k_iSteamHTMLSurfaceCallbacks + 24 )
+STEAM_CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+STEAM_CALLBACK_MEMBER( 1, const char *, pchMsg ) // the EMouseCursor to display
+STEAM_CALLBACK_END(2)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: update the text of an existing tooltip
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( HTML_UpdateToolTip_t, k_iSteamHTMLSurfaceCallbacks + 25 )
+STEAM_CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+STEAM_CALLBACK_MEMBER( 1, const char *, pchMsg ) // the EMouseCursor to display
+STEAM_CALLBACK_END(2)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: hide the tooltip you are showing
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( HTML_HideToolTip_t, k_iSteamHTMLSurfaceCallbacks + 26 )
+STEAM_CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+STEAM_CALLBACK_END(1)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The browser has restarted due to an internal failure, use this new handle value
+//-----------------------------------------------------------------------------
+STEAM_CALLBACK_BEGIN( HTML_BrowserRestarted_t, k_iSteamHTMLSurfaceCallbacks + 27 )
+STEAM_CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // this is the new browser handle after the restart
+STEAM_CALLBACK_MEMBER( 1, HHTMLBrowser, unOldBrowserHandle ) // the handle for the browser before the restart, if your handle was this then switch to using unBrowserHandle for API calls
+STEAM_CALLBACK_END(2)
+
+
+#pragma pack( pop )
+
+
+#endif // ISTEAMHTMLSURFACE_H

--- a/lsteamclient/steamworks_sdk_148a/isteamhttp.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamhttp.h
@@ -1,0 +1,219 @@
+//====== Copyright © 1996-2009, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to http client 
+//
+//=============================================================================
+
+#ifndef ISTEAMHTTP_H
+#define ISTEAMHTTP_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+#include "steamhttpenums.h"
+
+// Handle to a HTTP Request handle
+typedef uint32 HTTPRequestHandle;
+#define INVALID_HTTPREQUEST_HANDLE		0
+
+typedef uint32 HTTPCookieContainerHandle;
+#define INVALID_HTTPCOOKIE_HANDLE		0
+
+//-----------------------------------------------------------------------------
+// Purpose: interface to http client
+//-----------------------------------------------------------------------------
+class ISteamHTTP
+{
+public:
+
+	// Initializes a new HTTP request, returning a handle to use in further operations on it.  Requires
+	// the method (GET or POST) and the absolute URL for the request.  Both http and https are supported,
+	// so this string must start with http:// or https:// and should look like http://store.steampowered.com/app/250/ 
+	// or such.
+	virtual HTTPRequestHandle CreateHTTPRequest( EHTTPMethod eHTTPRequestMethod, const char *pchAbsoluteURL ) = 0;
+
+	// Set a context value for the request, which will be returned in the HTTPRequestCompleted_t callback after
+	// sending the request.  This is just so the caller can easily keep track of which callbacks go with which request data.
+	virtual bool SetHTTPRequestContextValue( HTTPRequestHandle hRequest, uint64 ulContextValue ) = 0;
+
+	// Set a timeout in seconds for the HTTP request, must be called prior to sending the request.  Default
+	// timeout is 60 seconds if you don't call this.  Returns false if the handle is invalid, or the request
+	// has already been sent.
+	virtual bool SetHTTPRequestNetworkActivityTimeout( HTTPRequestHandle hRequest, uint32 unTimeoutSeconds ) = 0;
+
+	// Set a request header value for the request, must be called prior to sending the request.  Will 
+	// return false if the handle is invalid or the request is already sent.
+	virtual bool SetHTTPRequestHeaderValue( HTTPRequestHandle hRequest, const char *pchHeaderName, const char *pchHeaderValue ) = 0;
+
+	// Set a GET or POST parameter value on the request, which is set will depend on the EHTTPMethod specified
+	// when creating the request.  Must be called prior to sending the request.  Will return false if the 
+	// handle is invalid or the request is already sent.
+	virtual bool SetHTTPRequestGetOrPostParameter( HTTPRequestHandle hRequest, const char *pchParamName, const char *pchParamValue ) = 0;
+
+	// Sends the HTTP request, will return false on a bad handle, otherwise use SteamCallHandle to wait on
+	// asynchronous response via callback.
+	//
+	// Note: If the user is in offline mode in Steam, then this will add a only-if-cached cache-control 
+	// header and only do a local cache lookup rather than sending any actual remote request.
+	virtual bool SendHTTPRequest( HTTPRequestHandle hRequest, SteamAPICall_t *pCallHandle ) = 0;
+
+	// Sends the HTTP request, will return false on a bad handle, otherwise use SteamCallHandle to wait on
+	// asynchronous response via callback for completion, and listen for HTTPRequestHeadersReceived_t and 
+	// HTTPRequestDataReceived_t callbacks while streaming.
+	virtual bool SendHTTPRequestAndStreamResponse( HTTPRequestHandle hRequest, SteamAPICall_t *pCallHandle ) = 0;
+
+	// Defers a request you have sent, the actual HTTP client code may have many requests queued, and this will move
+	// the specified request to the tail of the queue.  Returns false on invalid handle, or if the request is not yet sent.
+	virtual bool DeferHTTPRequest( HTTPRequestHandle hRequest ) = 0;
+
+	// Prioritizes a request you have sent, the actual HTTP client code may have many requests queued, and this will move
+	// the specified request to the head of the queue.  Returns false on invalid handle, or if the request is not yet sent.
+	virtual bool PrioritizeHTTPRequest( HTTPRequestHandle hRequest ) = 0;
+
+	// Checks if a response header is present in a HTTP response given a handle from HTTPRequestCompleted_t, also 
+	// returns the size of the header value if present so the caller and allocate a correctly sized buffer for
+	// GetHTTPResponseHeaderValue.
+	virtual bool GetHTTPResponseHeaderSize( HTTPRequestHandle hRequest, const char *pchHeaderName, uint32 *unResponseHeaderSize ) = 0;
+
+	// Gets header values from a HTTP response given a handle from HTTPRequestCompleted_t, will return false if the
+	// header is not present or if your buffer is too small to contain it's value.  You should first call 
+	// BGetHTTPResponseHeaderSize to check for the presence of the header and to find out the size buffer needed.
+	virtual bool GetHTTPResponseHeaderValue( HTTPRequestHandle hRequest, const char *pchHeaderName, uint8 *pHeaderValueBuffer, uint32 unBufferSize ) = 0;
+
+	// Gets the size of the body data from a HTTP response given a handle from HTTPRequestCompleted_t, will return false if the 
+	// handle is invalid.
+	virtual bool GetHTTPResponseBodySize( HTTPRequestHandle hRequest, uint32 *unBodySize ) = 0;
+
+	// Gets the body data from a HTTP response given a handle from HTTPRequestCompleted_t, will return false if the 
+	// handle is invalid or is to a streaming response, or if the provided buffer is not the correct size.  Use BGetHTTPResponseBodySize first to find out
+	// the correct buffer size to use.
+	virtual bool GetHTTPResponseBodyData( HTTPRequestHandle hRequest, uint8 *pBodyDataBuffer, uint32 unBufferSize ) = 0;
+
+	// Gets the body data from a streaming HTTP response given a handle from HTTPRequestDataReceived_t. Will return false if the 
+	// handle is invalid or is to a non-streaming response (meaning it wasn't sent with SendHTTPRequestAndStreamResponse), or if the buffer size and offset 
+	// do not match the size and offset sent in HTTPRequestDataReceived_t.
+	virtual bool GetHTTPStreamingResponseBodyData( HTTPRequestHandle hRequest, uint32 cOffset, uint8 *pBodyDataBuffer, uint32 unBufferSize ) = 0;
+
+	// Releases an HTTP response handle, should always be called to free resources after receiving a HTTPRequestCompleted_t
+	// callback and finishing using the response.
+	virtual bool ReleaseHTTPRequest( HTTPRequestHandle hRequest ) = 0;
+
+	// Gets progress on downloading the body for the request.  This will be zero unless a response header has already been
+	// received which included a content-length field.  For responses that contain no content-length it will report
+	// zero for the duration of the request as the size is unknown until the connection closes.
+	virtual bool GetHTTPDownloadProgressPct( HTTPRequestHandle hRequest, float *pflPercentOut ) = 0;
+
+	// Sets the body for an HTTP Post request.  Will fail and return false on a GET request, and will fail if POST params
+	// have already been set for the request.  Setting this raw body makes it the only contents for the post, the pchContentType
+	// parameter will set the content-type header for the request so the server may know how to interpret the body.
+	virtual bool SetHTTPRequestRawPostBody( HTTPRequestHandle hRequest, const char *pchContentType, uint8 *pubBody, uint32 unBodyLen ) = 0;
+
+	// Creates a cookie container handle which you must later free with ReleaseCookieContainer().  If bAllowResponsesToModify=true
+	// than any response to your requests using this cookie container may add new cookies which may be transmitted with
+	// future requests.  If bAllowResponsesToModify=false than only cookies you explicitly set will be sent.  This API is just for
+	// during process lifetime, after steam restarts no cookies are persisted and you have no way to access the cookie container across
+	// repeat executions of your process.
+	virtual HTTPCookieContainerHandle CreateCookieContainer( bool bAllowResponsesToModify ) = 0;
+
+	// Release a cookie container you are finished using, freeing it's memory
+	virtual bool ReleaseCookieContainer( HTTPCookieContainerHandle hCookieContainer ) = 0;
+
+	// Adds a cookie to the specified cookie container that will be used with future requests.
+	virtual bool SetCookie( HTTPCookieContainerHandle hCookieContainer, const char *pchHost, const char *pchUrl, const char *pchCookie ) = 0;
+
+	// Set the cookie container to use for a HTTP request
+	virtual bool SetHTTPRequestCookieContainer( HTTPRequestHandle hRequest, HTTPCookieContainerHandle hCookieContainer ) = 0;
+
+	// Set the extra user agent info for a request, this doesn't clobber the normal user agent, it just adds the extra info on the end
+	virtual bool SetHTTPRequestUserAgentInfo( HTTPRequestHandle hRequest, const char *pchUserAgentInfo ) = 0;
+
+	// Disable or re-enable verification of SSL/TLS certificates.
+	// By default, certificates are checked for all HTTPS requests.
+	virtual bool SetHTTPRequestRequiresVerifiedCertificate( HTTPRequestHandle hRequest, bool bRequireVerifiedCertificate ) = 0;
+
+	// Set an absolute timeout on the HTTP request, this is just a total time timeout different than the network activity timeout
+	// which can bump everytime we get more data
+	virtual bool SetHTTPRequestAbsoluteTimeoutMS( HTTPRequestHandle hRequest, uint32 unMilliseconds ) = 0;
+
+	// Check if the reason the request failed was because we timed it out (rather than some harder failure)
+	virtual bool GetHTTPRequestWasTimedOut( HTTPRequestHandle hRequest, bool *pbWasTimedOut ) = 0;
+};
+
+#define STEAMHTTP_INTERFACE_VERSION "STEAMHTTP_INTERFACE_VERSION003"
+
+// Global interface accessor
+inline ISteamHTTP *SteamHTTP();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamHTTP *, SteamHTTP, STEAMHTTP_INTERFACE_VERSION );
+
+// Global accessor for the gameserver client
+inline ISteamHTTP *SteamGameServerHTTP();
+STEAM_DEFINE_GAMESERVER_INTERFACE_ACCESSOR( ISteamHTTP *, SteamGameServerHTTP, STEAMHTTP_INTERFACE_VERSION );
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+
+struct HTTPRequestCompleted_t
+{
+	enum { k_iCallback = k_iClientHTTPCallbacks + 1 };
+
+	// Handle value for the request that has completed.
+	HTTPRequestHandle m_hRequest;
+
+	// Context value that the user defined on the request that this callback is associated with, 0 if
+	// no context value was set.
+	uint64 m_ulContextValue;
+
+	// This will be true if we actually got any sort of response from the server (even an error).  
+	// It will be false if we failed due to an internal error or client side network failure.
+	bool m_bRequestSuccessful;
+
+	// Will be the HTTP status code value returned by the server, k_EHTTPStatusCode200OK is the normal
+	// OK response, if you get something else you probably need to treat it as a failure.
+	EHTTPStatusCode m_eStatusCode;
+
+	uint32 m_unBodySize; // Same as GetHTTPResponseBodySize()
+};
+
+
+struct HTTPRequestHeadersReceived_t
+{
+	enum { k_iCallback = k_iClientHTTPCallbacks + 2 };
+
+	// Handle value for the request that has received headers.
+	HTTPRequestHandle m_hRequest;
+
+	// Context value that the user defined on the request that this callback is associated with, 0 if
+	// no context value was set.
+	uint64 m_ulContextValue;
+};
+
+struct HTTPRequestDataReceived_t
+{
+	enum { k_iCallback = k_iClientHTTPCallbacks + 3 };
+
+	// Handle value for the request that has received data.
+	HTTPRequestHandle m_hRequest;
+
+	// Context value that the user defined on the request that this callback is associated with, 0 if
+	// no context value was set.
+	uint64 m_ulContextValue;
+
+
+	// Offset to provide to GetHTTPStreamingResponseBodyData to get this chunk of data
+	uint32 m_cOffset;
+
+	// Size to provide to GetHTTPStreamingResponseBodyData to get this chunk of data
+	uint32 m_cBytesReceived;
+};
+
+
+#pragma pack( pop )
+
+#endif // ISTEAMHTTP_H

--- a/lsteamclient/steamworks_sdk_148a/isteaminput.h
+++ b/lsteamclient/steamworks_sdk_148a/isteaminput.h
@@ -1,0 +1,609 @@
+//====== Copyright 1996-2018, Valve Corporation, All rights reserved. =======
+//
+// Purpose: Steam Input is a flexible input API that supports over three hundred devices including all 
+//          common variants of Xbox, Playstation, Nintendo Switch Pro, and Steam Controllers.
+//			For more info including a getting started guide for developers 
+//			please visit: https://partner.steamgames.com/doc/features/steam_controller
+//
+//=============================================================================
+
+#ifndef ISTEAMINPUT_H
+#define ISTEAMINPUT_H
+#ifdef _WIN32
+#pragma once	
+#endif
+
+#include "steam_api_common.h"
+
+#define STEAM_INPUT_MAX_COUNT 16
+
+#define STEAM_INPUT_MAX_ANALOG_ACTIONS 16
+
+#define STEAM_INPUT_MAX_DIGITAL_ACTIONS 128
+
+#define STEAM_INPUT_MAX_ORIGINS 8
+
+#define STEAM_INPUT_MAX_ACTIVE_LAYERS 16
+
+// When sending an option to a specific controller handle, you can send to all devices via this command
+#define STEAM_INPUT_HANDLE_ALL_CONTROLLERS UINT64_MAX
+
+#define STEAM_INPUT_MIN_ANALOG_ACTION_DATA -1.0f
+#define STEAM_INPUT_MAX_ANALOG_ACTION_DATA 1.0f
+
+enum EInputSourceMode
+{
+	k_EInputSourceMode_None,
+	k_EInputSourceMode_Dpad,
+	k_EInputSourceMode_Buttons,
+	k_EInputSourceMode_FourButtons,
+	k_EInputSourceMode_AbsoluteMouse,
+	k_EInputSourceMode_RelativeMouse,
+	k_EInputSourceMode_JoystickMove,
+	k_EInputSourceMode_JoystickMouse,
+	k_EInputSourceMode_JoystickCamera,
+	k_EInputSourceMode_ScrollWheel,
+	k_EInputSourceMode_Trigger,
+	k_EInputSourceMode_TouchMenu,
+	k_EInputSourceMode_MouseJoystick,
+	k_EInputSourceMode_MouseRegion,
+	k_EInputSourceMode_RadialMenu,
+	k_EInputSourceMode_SingleButton,
+	k_EInputSourceMode_Switches
+};
+
+// Note: Please do not use action origins as a way to identify controller types. There is no
+// guarantee that they will be added in a contiguous manner - use GetInputTypeForHandle instead.
+// Versions of Steam that add new controller types in the future will extend this enum so if you're
+// using a lookup table please check the bounds of any origins returned by Steam.
+enum EInputActionOrigin
+{
+	// Steam Controller
+	k_EInputActionOrigin_None,
+	k_EInputActionOrigin_SteamController_A,
+	k_EInputActionOrigin_SteamController_B,
+	k_EInputActionOrigin_SteamController_X,
+	k_EInputActionOrigin_SteamController_Y,
+	k_EInputActionOrigin_SteamController_LeftBumper,
+	k_EInputActionOrigin_SteamController_RightBumper,
+	k_EInputActionOrigin_SteamController_LeftGrip,
+	k_EInputActionOrigin_SteamController_RightGrip,
+	k_EInputActionOrigin_SteamController_Start,
+	k_EInputActionOrigin_SteamController_Back,
+	k_EInputActionOrigin_SteamController_LeftPad_Touch,
+	k_EInputActionOrigin_SteamController_LeftPad_Swipe,
+	k_EInputActionOrigin_SteamController_LeftPad_Click,
+	k_EInputActionOrigin_SteamController_LeftPad_DPadNorth,
+	k_EInputActionOrigin_SteamController_LeftPad_DPadSouth,
+	k_EInputActionOrigin_SteamController_LeftPad_DPadWest,
+	k_EInputActionOrigin_SteamController_LeftPad_DPadEast,
+	k_EInputActionOrigin_SteamController_RightPad_Touch,
+	k_EInputActionOrigin_SteamController_RightPad_Swipe,
+	k_EInputActionOrigin_SteamController_RightPad_Click,
+	k_EInputActionOrigin_SteamController_RightPad_DPadNorth,
+	k_EInputActionOrigin_SteamController_RightPad_DPadSouth,
+	k_EInputActionOrigin_SteamController_RightPad_DPadWest,
+	k_EInputActionOrigin_SteamController_RightPad_DPadEast,
+	k_EInputActionOrigin_SteamController_LeftTrigger_Pull,
+	k_EInputActionOrigin_SteamController_LeftTrigger_Click,
+	k_EInputActionOrigin_SteamController_RightTrigger_Pull,
+	k_EInputActionOrigin_SteamController_RightTrigger_Click,
+	k_EInputActionOrigin_SteamController_LeftStick_Move,
+	k_EInputActionOrigin_SteamController_LeftStick_Click,
+	k_EInputActionOrigin_SteamController_LeftStick_DPadNorth,
+	k_EInputActionOrigin_SteamController_LeftStick_DPadSouth,
+	k_EInputActionOrigin_SteamController_LeftStick_DPadWest,
+	k_EInputActionOrigin_SteamController_LeftStick_DPadEast,
+	k_EInputActionOrigin_SteamController_Gyro_Move,
+	k_EInputActionOrigin_SteamController_Gyro_Pitch,
+	k_EInputActionOrigin_SteamController_Gyro_Yaw,
+	k_EInputActionOrigin_SteamController_Gyro_Roll,
+	k_EInputActionOrigin_SteamController_Reserved0,
+	k_EInputActionOrigin_SteamController_Reserved1,
+	k_EInputActionOrigin_SteamController_Reserved2,
+	k_EInputActionOrigin_SteamController_Reserved3,
+	k_EInputActionOrigin_SteamController_Reserved4,
+	k_EInputActionOrigin_SteamController_Reserved5,
+	k_EInputActionOrigin_SteamController_Reserved6,
+	k_EInputActionOrigin_SteamController_Reserved7,
+	k_EInputActionOrigin_SteamController_Reserved8,
+	k_EInputActionOrigin_SteamController_Reserved9,
+	k_EInputActionOrigin_SteamController_Reserved10,
+	
+	// PS4 Dual Shock
+	k_EInputActionOrigin_PS4_X,
+	k_EInputActionOrigin_PS4_Circle,
+	k_EInputActionOrigin_PS4_Triangle,
+	k_EInputActionOrigin_PS4_Square,
+	k_EInputActionOrigin_PS4_LeftBumper,
+	k_EInputActionOrigin_PS4_RightBumper,
+	k_EInputActionOrigin_PS4_Options,	//Start
+	k_EInputActionOrigin_PS4_Share,		//Back
+	k_EInputActionOrigin_PS4_LeftPad_Touch,
+	k_EInputActionOrigin_PS4_LeftPad_Swipe,
+	k_EInputActionOrigin_PS4_LeftPad_Click,
+	k_EInputActionOrigin_PS4_LeftPad_DPadNorth,
+	k_EInputActionOrigin_PS4_LeftPad_DPadSouth,
+	k_EInputActionOrigin_PS4_LeftPad_DPadWest,
+	k_EInputActionOrigin_PS4_LeftPad_DPadEast,
+	k_EInputActionOrigin_PS4_RightPad_Touch,
+	k_EInputActionOrigin_PS4_RightPad_Swipe,
+	k_EInputActionOrigin_PS4_RightPad_Click,
+	k_EInputActionOrigin_PS4_RightPad_DPadNorth,
+	k_EInputActionOrigin_PS4_RightPad_DPadSouth,
+	k_EInputActionOrigin_PS4_RightPad_DPadWest,
+	k_EInputActionOrigin_PS4_RightPad_DPadEast,
+	k_EInputActionOrigin_PS4_CenterPad_Touch,
+	k_EInputActionOrigin_PS4_CenterPad_Swipe,
+	k_EInputActionOrigin_PS4_CenterPad_Click,
+	k_EInputActionOrigin_PS4_CenterPad_DPadNorth,
+	k_EInputActionOrigin_PS4_CenterPad_DPadSouth,
+	k_EInputActionOrigin_PS4_CenterPad_DPadWest,
+	k_EInputActionOrigin_PS4_CenterPad_DPadEast,
+	k_EInputActionOrigin_PS4_LeftTrigger_Pull,
+	k_EInputActionOrigin_PS4_LeftTrigger_Click,
+	k_EInputActionOrigin_PS4_RightTrigger_Pull,
+	k_EInputActionOrigin_PS4_RightTrigger_Click,
+	k_EInputActionOrigin_PS4_LeftStick_Move,
+	k_EInputActionOrigin_PS4_LeftStick_Click,
+	k_EInputActionOrigin_PS4_LeftStick_DPadNorth,
+	k_EInputActionOrigin_PS4_LeftStick_DPadSouth,
+	k_EInputActionOrigin_PS4_LeftStick_DPadWest,
+	k_EInputActionOrigin_PS4_LeftStick_DPadEast,
+	k_EInputActionOrigin_PS4_RightStick_Move,
+	k_EInputActionOrigin_PS4_RightStick_Click,
+	k_EInputActionOrigin_PS4_RightStick_DPadNorth,
+	k_EInputActionOrigin_PS4_RightStick_DPadSouth,
+	k_EInputActionOrigin_PS4_RightStick_DPadWest,
+	k_EInputActionOrigin_PS4_RightStick_DPadEast,
+	k_EInputActionOrigin_PS4_DPad_North,
+	k_EInputActionOrigin_PS4_DPad_South,
+	k_EInputActionOrigin_PS4_DPad_West,
+	k_EInputActionOrigin_PS4_DPad_East,
+	k_EInputActionOrigin_PS4_Gyro_Move,
+	k_EInputActionOrigin_PS4_Gyro_Pitch,
+	k_EInputActionOrigin_PS4_Gyro_Yaw,
+	k_EInputActionOrigin_PS4_Gyro_Roll,
+	k_EInputActionOrigin_PS4_DPad_Move,
+	k_EInputActionOrigin_PS4_Reserved1,
+	k_EInputActionOrigin_PS4_Reserved2,
+	k_EInputActionOrigin_PS4_Reserved3,
+	k_EInputActionOrigin_PS4_Reserved4,
+	k_EInputActionOrigin_PS4_Reserved5,
+	k_EInputActionOrigin_PS4_Reserved6,
+	k_EInputActionOrigin_PS4_Reserved7,
+	k_EInputActionOrigin_PS4_Reserved8,
+	k_EInputActionOrigin_PS4_Reserved9,
+	k_EInputActionOrigin_PS4_Reserved10,
+
+	// XBox One
+	k_EInputActionOrigin_XBoxOne_A,
+	k_EInputActionOrigin_XBoxOne_B,
+	k_EInputActionOrigin_XBoxOne_X,
+	k_EInputActionOrigin_XBoxOne_Y,
+	k_EInputActionOrigin_XBoxOne_LeftBumper,
+	k_EInputActionOrigin_XBoxOne_RightBumper,
+	k_EInputActionOrigin_XBoxOne_Menu,  //Start
+	k_EInputActionOrigin_XBoxOne_View,  //Back
+	k_EInputActionOrigin_XBoxOne_LeftTrigger_Pull,
+	k_EInputActionOrigin_XBoxOne_LeftTrigger_Click,
+	k_EInputActionOrigin_XBoxOne_RightTrigger_Pull,
+	k_EInputActionOrigin_XBoxOne_RightTrigger_Click,
+	k_EInputActionOrigin_XBoxOne_LeftStick_Move,
+	k_EInputActionOrigin_XBoxOne_LeftStick_Click,
+	k_EInputActionOrigin_XBoxOne_LeftStick_DPadNorth,
+	k_EInputActionOrigin_XBoxOne_LeftStick_DPadSouth,
+	k_EInputActionOrigin_XBoxOne_LeftStick_DPadWest,
+	k_EInputActionOrigin_XBoxOne_LeftStick_DPadEast,
+	k_EInputActionOrigin_XBoxOne_RightStick_Move,
+	k_EInputActionOrigin_XBoxOne_RightStick_Click,
+	k_EInputActionOrigin_XBoxOne_RightStick_DPadNorth,
+	k_EInputActionOrigin_XBoxOne_RightStick_DPadSouth,
+	k_EInputActionOrigin_XBoxOne_RightStick_DPadWest,
+	k_EInputActionOrigin_XBoxOne_RightStick_DPadEast,
+	k_EInputActionOrigin_XBoxOne_DPad_North,
+	k_EInputActionOrigin_XBoxOne_DPad_South,
+	k_EInputActionOrigin_XBoxOne_DPad_West,
+	k_EInputActionOrigin_XBoxOne_DPad_East,
+	k_EInputActionOrigin_XBoxOne_DPad_Move,
+	k_EInputActionOrigin_XBoxOne_Reserved1,
+	k_EInputActionOrigin_XBoxOne_Reserved2,
+	k_EInputActionOrigin_XBoxOne_Reserved3,
+	k_EInputActionOrigin_XBoxOne_Reserved4,
+	k_EInputActionOrigin_XBoxOne_Reserved5,
+	k_EInputActionOrigin_XBoxOne_Reserved6,
+	k_EInputActionOrigin_XBoxOne_Reserved7,
+	k_EInputActionOrigin_XBoxOne_Reserved8,
+	k_EInputActionOrigin_XBoxOne_Reserved9,
+	k_EInputActionOrigin_XBoxOne_Reserved10,
+
+	// XBox 360
+	k_EInputActionOrigin_XBox360_A,
+	k_EInputActionOrigin_XBox360_B,
+	k_EInputActionOrigin_XBox360_X,
+	k_EInputActionOrigin_XBox360_Y,
+	k_EInputActionOrigin_XBox360_LeftBumper,
+	k_EInputActionOrigin_XBox360_RightBumper,
+	k_EInputActionOrigin_XBox360_Start,		//Start
+	k_EInputActionOrigin_XBox360_Back,		//Back
+	k_EInputActionOrigin_XBox360_LeftTrigger_Pull,
+	k_EInputActionOrigin_XBox360_LeftTrigger_Click,
+	k_EInputActionOrigin_XBox360_RightTrigger_Pull,
+	k_EInputActionOrigin_XBox360_RightTrigger_Click,
+	k_EInputActionOrigin_XBox360_LeftStick_Move,
+	k_EInputActionOrigin_XBox360_LeftStick_Click,
+	k_EInputActionOrigin_XBox360_LeftStick_DPadNorth,
+	k_EInputActionOrigin_XBox360_LeftStick_DPadSouth,
+	k_EInputActionOrigin_XBox360_LeftStick_DPadWest,
+	k_EInputActionOrigin_XBox360_LeftStick_DPadEast,
+	k_EInputActionOrigin_XBox360_RightStick_Move,
+	k_EInputActionOrigin_XBox360_RightStick_Click,
+	k_EInputActionOrigin_XBox360_RightStick_DPadNorth,
+	k_EInputActionOrigin_XBox360_RightStick_DPadSouth,
+	k_EInputActionOrigin_XBox360_RightStick_DPadWest,
+	k_EInputActionOrigin_XBox360_RightStick_DPadEast,
+	k_EInputActionOrigin_XBox360_DPad_North,
+	k_EInputActionOrigin_XBox360_DPad_South,
+	k_EInputActionOrigin_XBox360_DPad_West,
+	k_EInputActionOrigin_XBox360_DPad_East,	
+	k_EInputActionOrigin_XBox360_DPad_Move,
+	k_EInputActionOrigin_XBox360_Reserved1,
+	k_EInputActionOrigin_XBox360_Reserved2,
+	k_EInputActionOrigin_XBox360_Reserved3,
+	k_EInputActionOrigin_XBox360_Reserved4,
+	k_EInputActionOrigin_XBox360_Reserved5,
+	k_EInputActionOrigin_XBox360_Reserved6,
+	k_EInputActionOrigin_XBox360_Reserved7,
+	k_EInputActionOrigin_XBox360_Reserved8,
+	k_EInputActionOrigin_XBox360_Reserved9,
+	k_EInputActionOrigin_XBox360_Reserved10,
+
+
+	// Switch - Pro or Joycons used as a single input device.
+	// This does not apply to a single joycon
+	k_EInputActionOrigin_Switch_A,
+	k_EInputActionOrigin_Switch_B,
+	k_EInputActionOrigin_Switch_X,
+	k_EInputActionOrigin_Switch_Y,
+	k_EInputActionOrigin_Switch_LeftBumper,
+	k_EInputActionOrigin_Switch_RightBumper,
+	k_EInputActionOrigin_Switch_Plus,	//Start
+	k_EInputActionOrigin_Switch_Minus,	//Back
+	k_EInputActionOrigin_Switch_Capture,
+	k_EInputActionOrigin_Switch_LeftTrigger_Pull,
+	k_EInputActionOrigin_Switch_LeftTrigger_Click,
+	k_EInputActionOrigin_Switch_RightTrigger_Pull,
+	k_EInputActionOrigin_Switch_RightTrigger_Click,
+	k_EInputActionOrigin_Switch_LeftStick_Move,
+	k_EInputActionOrigin_Switch_LeftStick_Click,
+	k_EInputActionOrigin_Switch_LeftStick_DPadNorth,
+	k_EInputActionOrigin_Switch_LeftStick_DPadSouth,
+	k_EInputActionOrigin_Switch_LeftStick_DPadWest,
+	k_EInputActionOrigin_Switch_LeftStick_DPadEast,
+	k_EInputActionOrigin_Switch_RightStick_Move,
+	k_EInputActionOrigin_Switch_RightStick_Click,
+	k_EInputActionOrigin_Switch_RightStick_DPadNorth,
+	k_EInputActionOrigin_Switch_RightStick_DPadSouth,
+	k_EInputActionOrigin_Switch_RightStick_DPadWest,
+	k_EInputActionOrigin_Switch_RightStick_DPadEast,
+	k_EInputActionOrigin_Switch_DPad_North,
+	k_EInputActionOrigin_Switch_DPad_South,
+	k_EInputActionOrigin_Switch_DPad_West,
+	k_EInputActionOrigin_Switch_DPad_East,
+	k_EInputActionOrigin_Switch_ProGyro_Move,  // Primary Gyro in Pro Controller, or Right JoyCon
+	k_EInputActionOrigin_Switch_ProGyro_Pitch,  // Primary Gyro in Pro Controller, or Right JoyCon
+	k_EInputActionOrigin_Switch_ProGyro_Yaw,  // Primary Gyro in Pro Controller, or Right JoyCon
+	k_EInputActionOrigin_Switch_ProGyro_Roll,  // Primary Gyro in Pro Controller, or Right JoyCon
+	k_EInputActionOrigin_Switch_DPad_Move,
+	k_EInputActionOrigin_Switch_Reserved1,
+	k_EInputActionOrigin_Switch_Reserved2,
+	k_EInputActionOrigin_Switch_Reserved3,
+	k_EInputActionOrigin_Switch_Reserved4,
+	k_EInputActionOrigin_Switch_Reserved5,
+	k_EInputActionOrigin_Switch_Reserved6,
+	k_EInputActionOrigin_Switch_Reserved7,
+	k_EInputActionOrigin_Switch_Reserved8,
+	k_EInputActionOrigin_Switch_Reserved9,
+	k_EInputActionOrigin_Switch_Reserved10,
+
+	// Switch JoyCon Specific
+	k_EInputActionOrigin_Switch_RightGyro_Move,  // Right JoyCon Gyro generally should correspond to Pro's single gyro
+	k_EInputActionOrigin_Switch_RightGyro_Pitch,  // Right JoyCon Gyro generally should correspond to Pro's single gyro
+	k_EInputActionOrigin_Switch_RightGyro_Yaw,  // Right JoyCon Gyro generally should correspond to Pro's single gyro
+	k_EInputActionOrigin_Switch_RightGyro_Roll,  // Right JoyCon Gyro generally should correspond to Pro's single gyro
+	k_EInputActionOrigin_Switch_LeftGyro_Move,
+	k_EInputActionOrigin_Switch_LeftGyro_Pitch,
+	k_EInputActionOrigin_Switch_LeftGyro_Yaw,
+	k_EInputActionOrigin_Switch_LeftGyro_Roll,
+	k_EInputActionOrigin_Switch_LeftGrip_Lower, // Left JoyCon SR Button
+	k_EInputActionOrigin_Switch_LeftGrip_Upper, // Left JoyCon SL Button
+	k_EInputActionOrigin_Switch_RightGrip_Lower,  // Right JoyCon SL Button
+	k_EInputActionOrigin_Switch_RightGrip_Upper,  // Right JoyCon SR Button
+	k_EInputActionOrigin_Switch_Reserved11,
+	k_EInputActionOrigin_Switch_Reserved12,
+	k_EInputActionOrigin_Switch_Reserved13,
+	k_EInputActionOrigin_Switch_Reserved14,
+	k_EInputActionOrigin_Switch_Reserved15,
+	k_EInputActionOrigin_Switch_Reserved16,
+	k_EInputActionOrigin_Switch_Reserved17,
+	k_EInputActionOrigin_Switch_Reserved18,
+	k_EInputActionOrigin_Switch_Reserved19,
+	k_EInputActionOrigin_Switch_Reserved20,
+
+	k_EInputActionOrigin_Count, // If Steam has added support for new controllers origins will go here.
+	k_EInputActionOrigin_MaximumPossibleValue = 32767, // Origins are currently a maximum of 16 bits.
+};
+
+enum EXboxOrigin
+{
+	k_EXboxOrigin_A,
+	k_EXboxOrigin_B,
+	k_EXboxOrigin_X,
+	k_EXboxOrigin_Y,
+	k_EXboxOrigin_LeftBumper,
+	k_EXboxOrigin_RightBumper,
+	k_EXboxOrigin_Menu,  //Start
+	k_EXboxOrigin_View,  //Back
+	k_EXboxOrigin_LeftTrigger_Pull,
+	k_EXboxOrigin_LeftTrigger_Click,
+	k_EXboxOrigin_RightTrigger_Pull,
+	k_EXboxOrigin_RightTrigger_Click,
+	k_EXboxOrigin_LeftStick_Move,
+	k_EXboxOrigin_LeftStick_Click,
+	k_EXboxOrigin_LeftStick_DPadNorth,
+	k_EXboxOrigin_LeftStick_DPadSouth,
+	k_EXboxOrigin_LeftStick_DPadWest,
+	k_EXboxOrigin_LeftStick_DPadEast,
+	k_EXboxOrigin_RightStick_Move,
+	k_EXboxOrigin_RightStick_Click,
+	k_EXboxOrigin_RightStick_DPadNorth,
+	k_EXboxOrigin_RightStick_DPadSouth,
+	k_EXboxOrigin_RightStick_DPadWest,
+	k_EXboxOrigin_RightStick_DPadEast,
+	k_EXboxOrigin_DPad_North,
+	k_EXboxOrigin_DPad_South,
+	k_EXboxOrigin_DPad_West,
+	k_EXboxOrigin_DPad_East,
+	k_EXboxOrigin_Count,
+};
+
+enum ESteamControllerPad
+{
+	k_ESteamControllerPad_Left,
+	k_ESteamControllerPad_Right
+};
+
+enum ESteamInputType
+{
+	k_ESteamInputType_Unknown,
+	k_ESteamInputType_SteamController,
+	k_ESteamInputType_XBox360Controller,
+	k_ESteamInputType_XBoxOneController,
+	k_ESteamInputType_GenericGamepad,		// DirectInput controllers
+	k_ESteamInputType_PS4Controller,
+	k_ESteamInputType_AppleMFiController,	// Unused
+	k_ESteamInputType_AndroidController,	// Unused
+	k_ESteamInputType_SwitchJoyConPair,		// Unused
+	k_ESteamInputType_SwitchJoyConSingle,	// Unused
+	k_ESteamInputType_SwitchProController,
+	k_ESteamInputType_MobileTouch,			// Steam Link App On-screen Virtual Controller
+	k_ESteamInputType_PS3Controller,		// Currently uses PS4 Origins
+	k_ESteamInputType_Count,
+	k_ESteamInputType_MaximumPossibleValue = 255,
+};
+
+// These values are passed into SetLEDColor
+enum ESteamInputLEDFlag
+{
+	k_ESteamInputLEDFlag_SetColor,
+	// Restore the LED color to the user's preference setting as set in the controller personalization menu.
+	// This also happens automatically on exit of your game.  
+	k_ESteamInputLEDFlag_RestoreUserDefault 
+};
+
+// InputHandle_t is used to refer to a specific controller.
+// This handle will consistently identify a controller, even if it is disconnected and re-connected
+typedef uint64 InputHandle_t;
+
+
+// These handles are used to refer to a specific in-game action or action set
+// All action handles should be queried during initialization for performance reasons
+typedef uint64 InputActionSetHandle_t;
+typedef uint64 InputDigitalActionHandle_t;
+typedef uint64 InputAnalogActionHandle_t;
+
+#pragma pack( push, 1 )
+
+struct InputAnalogActionData_t
+{
+	// Type of data coming from this action, this will match what got specified in the action set
+	EInputSourceMode eMode;
+	
+	// The current state of this action; will be delta updates for mouse actions
+	float x, y;
+	
+	// Whether or not this action is currently available to be bound in the active action set
+	bool bActive;
+};
+
+struct InputDigitalActionData_t
+{
+	// The current state of this action; will be true if currently pressed
+	bool bState;
+	
+	// Whether or not this action is currently available to be bound in the active action set
+	bool bActive;
+};
+
+struct InputMotionData_t
+{
+	// Sensor-fused absolute rotation; will drift in heading
+	float rotQuatX;
+	float rotQuatY;
+	float rotQuatZ;
+	float rotQuatW;
+	
+	// Positional acceleration
+	float posAccelX;
+	float posAccelY;
+	float posAccelZ;
+
+	// Angular velocity
+	float rotVelX;
+	float rotVelY;
+	float rotVelZ;
+};
+
+#pragma pack( pop )
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Steam Input API
+//-----------------------------------------------------------------------------
+class ISteamInput
+{
+public:
+	
+	// Init and Shutdown must be called when starting/ending use of this interface
+	virtual bool Init() = 0;
+	virtual bool Shutdown() = 0;
+	
+	// Synchronize API state with the latest Steam Controller inputs available. This
+	// is performed automatically by SteamAPI_RunCallbacks, but for the absolute lowest
+	// possible latency, you call this directly before reading controller state. This must
+	// be called from somewhere before GetConnectedControllers will return any handles
+	virtual void RunFrame() = 0;
+
+	// Enumerate currently connected Steam Input enabled devices - developers can opt in controller by type (ex: Xbox/Playstation/etc) via
+	// the Steam Input settings in the Steamworks site or users can opt-in in their controller settings in Steam.
+	// handlesOut should point to a STEAM_INPUT_MAX_COUNT sized array of InputHandle_t handles
+	// Returns the number of handles written to handlesOut
+	virtual int GetConnectedControllers( STEAM_OUT_ARRAY_COUNT( STEAM_INPUT_MAX_COUNT, Receives list of connected controllers ) InputHandle_t *handlesOut ) = 0;
+	
+	//-----------------------------------------------------------------------------
+	// ACTION SETS
+	//-----------------------------------------------------------------------------
+
+	// Lookup the handle for an Action Set. Best to do this once on startup, and store the handles for all future API calls.
+	virtual InputActionSetHandle_t GetActionSetHandle( const char *pszActionSetName ) = 0;
+	
+	// Reconfigure the controller to use the specified action set (ie 'Menu', 'Walk' or 'Drive')
+	// This is cheap, and can be safely called repeatedly. It's often easier to repeatedly call it in
+	// your state loops, instead of trying to place it in all of your state transitions.
+	virtual void ActivateActionSet( InputHandle_t inputHandle, InputActionSetHandle_t actionSetHandle ) = 0;
+	virtual InputActionSetHandle_t GetCurrentActionSet( InputHandle_t inputHandle ) = 0;
+
+	// ACTION SET LAYERS
+	virtual void ActivateActionSetLayer( InputHandle_t inputHandle, InputActionSetHandle_t actionSetLayerHandle ) = 0;
+	virtual void DeactivateActionSetLayer( InputHandle_t inputHandle, InputActionSetHandle_t actionSetLayerHandle ) = 0;
+	virtual void DeactivateAllActionSetLayers( InputHandle_t inputHandle ) = 0;
+	// Enumerate currently active layers.
+	// handlesOut should point to a STEAM_INPUT_MAX_ACTIVE_LAYERS sized array of ControllerActionSetHandle_t handles
+	// Returns the number of handles written to handlesOut
+	virtual int GetActiveActionSetLayers( InputHandle_t inputHandle, STEAM_OUT_ARRAY_COUNT( STEAM_INPUT_MAX_ACTIVE_LAYERS, Receives list of active layers ) InputActionSetHandle_t *handlesOut ) = 0;
+
+	//-----------------------------------------------------------------------------
+	// ACTIONS
+	//-----------------------------------------------------------------------------
+
+	// Lookup the handle for a digital action. Best to do this once on startup, and store the handles for all future API calls.
+	virtual InputDigitalActionHandle_t GetDigitalActionHandle( const char *pszActionName ) = 0;
+	
+	// Returns the current state of the supplied digital game action
+	virtual InputDigitalActionData_t GetDigitalActionData( InputHandle_t inputHandle, InputDigitalActionHandle_t digitalActionHandle ) = 0;
+	
+	// Get the origin(s) for a digital action within an action set. Returns the number of origins supplied in originsOut. Use this to display the appropriate on-screen prompt for the action.
+	// originsOut should point to a STEAM_INPUT_MAX_ORIGINS sized array of EInputActionOrigin handles. The EInputActionOrigin enum will get extended as support for new controller controllers gets added to
+	// the Steam client and will exceed the values from this header, please check bounds if you are using a look up table.
+	virtual int GetDigitalActionOrigins( InputHandle_t inputHandle, InputActionSetHandle_t actionSetHandle, InputDigitalActionHandle_t digitalActionHandle, STEAM_OUT_ARRAY_COUNT( STEAM_INPUT_MAX_ORIGINS, Receives list of action origins ) EInputActionOrigin *originsOut ) = 0;
+	
+	// Lookup the handle for an analog action. Best to do this once on startup, and store the handles for all future API calls.
+	virtual InputAnalogActionHandle_t GetAnalogActionHandle( const char *pszActionName ) = 0;
+	
+	// Returns the current state of these supplied analog game action
+	virtual InputAnalogActionData_t GetAnalogActionData( InputHandle_t inputHandle, InputAnalogActionHandle_t analogActionHandle ) = 0;
+
+	// Get the origin(s) for an analog action within an action set. Returns the number of origins supplied in originsOut. Use this to display the appropriate on-screen prompt for the action.
+	// originsOut should point to a STEAM_INPUT_MAX_ORIGINS sized array of EInputActionOrigin handles. The EInputActionOrigin enum will get extended as support for new controller controllers gets added to
+	// the Steam client and will exceed the values from this header, please check bounds if you are using a look up table.
+	virtual int GetAnalogActionOrigins( InputHandle_t inputHandle, InputActionSetHandle_t actionSetHandle, InputAnalogActionHandle_t analogActionHandle, STEAM_OUT_ARRAY_COUNT( STEAM_INPUT_MAX_ORIGINS, Receives list of action origins ) EInputActionOrigin *originsOut ) = 0;
+	
+	// Get a local path to art for on-screen glyph for a particular origin
+	virtual const char *GetGlyphForActionOrigin( EInputActionOrigin eOrigin ) = 0;
+	
+	// Returns a localized string (from Steam's language setting) for the specified origin.
+	virtual const char *GetStringForActionOrigin( EInputActionOrigin eOrigin ) = 0;
+
+	// Stop analog momentum for the action if it is a mouse action in trackball mode
+	virtual void StopAnalogActionMomentum( InputHandle_t inputHandle, InputAnalogActionHandle_t eAction ) = 0;
+
+	// Returns raw motion data from the specified device
+	virtual InputMotionData_t GetMotionData( InputHandle_t inputHandle ) = 0;
+
+	//-----------------------------------------------------------------------------
+	// OUTPUTS
+	//-----------------------------------------------------------------------------
+
+	// Trigger a vibration event on supported controllers - Steam will translate these commands into haptic pulses for Steam Controllers
+	virtual void TriggerVibration( InputHandle_t inputHandle, unsigned short usLeftSpeed, unsigned short usRightSpeed ) = 0;
+
+	// Set the controller LED color on supported controllers. nFlags is a bitmask of values from ESteamInputLEDFlag - 0 will default to setting a color. Steam will handle
+	// the behavior on exit of your program so you don't need to try restore the default as you are shutting down
+	virtual void SetLEDColor( InputHandle_t inputHandle, uint8 nColorR, uint8 nColorG, uint8 nColorB, unsigned int nFlags ) = 0;
+
+	// Trigger a haptic pulse on a Steam Controller - if you are approximating rumble you may want to use TriggerVibration instead.
+	// Good uses for Haptic pulses include chimes, noises, or directional gameplay feedback (taking damage, footstep locations, etc).
+	virtual void TriggerHapticPulse( InputHandle_t inputHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec ) = 0;
+
+	// Trigger a haptic pulse with a duty cycle of usDurationMicroSec / usOffMicroSec, unRepeat times. If you are approximating rumble you may want to use TriggerVibration instead.
+	// nFlags is currently unused and reserved for future use.
+	virtual void TriggerRepeatedHapticPulse( InputHandle_t inputHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec, unsigned short usOffMicroSec, unsigned short unRepeat, unsigned int nFlags ) = 0;
+
+	//-----------------------------------------------------------------------------
+	// Utility functions availible without using the rest of Steam Input API
+	//-----------------------------------------------------------------------------
+
+	// Invokes the Steam overlay and brings up the binding screen if the user is using Big Picture Mode
+	// If the user is not in Big Picture Mode it will open up the binding in a new window
+	virtual bool ShowBindingPanel( InputHandle_t inputHandle ) = 0;
+
+	// Returns the input type for a particular handle
+	virtual ESteamInputType GetInputTypeForHandle( InputHandle_t inputHandle ) = 0;
+
+	// Returns the associated controller handle for the specified emulated gamepad - can be used with the above 2 functions
+	// to identify controllers presented to your game over Xinput. Returns 0 if the Xinput index isn't associated with Steam Input
+	virtual InputHandle_t GetControllerForGamepadIndex( int nIndex ) = 0;
+
+	// Returns the associated gamepad index for the specified controller, if emulating a gamepad or -1 if not associated with an Xinput index
+	virtual int GetGamepadIndexForController( InputHandle_t ulinputHandle ) = 0;
+	
+	// Returns a localized string (from Steam's language setting) for the specified Xbox controller origin.
+	virtual const char *GetStringForXboxOrigin( EXboxOrigin eOrigin ) = 0;
+
+	// Get a local path to art for on-screen glyph for a particular Xbox controller origin
+	virtual const char *GetGlyphForXboxOrigin( EXboxOrigin eOrigin ) = 0;
+
+	// Get the equivalent ActionOrigin for a given Xbox controller origin this can be chained with GetGlyphForActionOrigin to provide future proof glyphs for
+	// non-Steam Input API action games. Note - this only translates the buttons directly and doesn't take into account any remapping a user has made in their configuration
+	virtual EInputActionOrigin GetActionOriginFromXboxOrigin( InputHandle_t inputHandle, EXboxOrigin eOrigin ) = 0;
+
+	// Convert an origin to another controller type - for inputs not present on the other controller type this will return k_EInputActionOrigin_None
+	// When a new input type is added you will be able to pass in k_ESteamInputType_Unknown and the closest origin that your version of the SDK recognized will be returned
+	// ex: if a Playstation 5 controller was released this function would return Playstation 4 origins.
+	virtual EInputActionOrigin TranslateActionOrigin( ESteamInputType eDestinationInputType, EInputActionOrigin eSourceOrigin ) = 0;
+
+	// Get the binding revision for a given device. Returns false if the handle was not valid or if a mapping is not yet loaded for the device
+	virtual bool GetDeviceBindingRevision( InputHandle_t inputHandle, int *pMajor, int *pMinor ) = 0;
+
+	// Get the Steam Remote Play session ID associated with a device, or 0 if there is no session associated with it
+	// See isteamremoteplay.h for more information on Steam Remote Play sessions
+	virtual uint32 GetRemotePlaySessionID( InputHandle_t inputHandle ) = 0;
+};
+
+#define STEAMINPUT_INTERFACE_VERSION "SteamInput001"
+
+// Global interface accessor
+inline ISteamInput *SteamInput();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamInput *, SteamInput, STEAMINPUT_INTERFACE_VERSION );
+
+#endif // ISTEAMINPUT_H

--- a/lsteamclient/steamworks_sdk_148a/isteaminventory.h
+++ b/lsteamclient/steamworks_sdk_148a/isteaminventory.h
@@ -1,0 +1,446 @@
+//====== Copyright © 1996-2014 Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to Steam Inventory
+//
+//=============================================================================
+
+#ifndef ISTEAMINVENTORY_H
+#define ISTEAMINVENTORY_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif
+
+
+// Every individual instance of an item has a globally-unique ItemInstanceID.
+// This ID is unique to the combination of (player, specific item instance)
+// and will not be transferred to another player or re-used for another item.
+typedef uint64 SteamItemInstanceID_t;
+
+static const SteamItemInstanceID_t k_SteamItemInstanceIDInvalid = (SteamItemInstanceID_t)~0;
+
+// Types of items in your game are identified by a 32-bit "item definition number".
+// Valid definition numbers are between 1 and 999999999; numbers less than or equal to
+// zero are invalid, and numbers greater than or equal to one billion (1x10^9) are
+// reserved for internal Steam use.
+typedef int32 SteamItemDef_t;
+
+
+enum ESteamItemFlags
+{
+	// Item status flags - these flags are permanently attached to specific item instances
+	k_ESteamItemNoTrade = 1 << 0, // This item is account-locked and cannot be traded or given away.
+
+	// Action confirmation flags - these flags are set one time only, as part of a result set
+	k_ESteamItemRemoved = 1 << 8,	// The item has been destroyed, traded away, expired, or otherwise invalidated
+	k_ESteamItemConsumed = 1 << 9,	// The item quantity has been decreased by 1 via ConsumeItem API.
+
+	// All other flag bits are currently reserved for internal Steam use at this time.
+	// Do not assume anything about the state of other flags which are not defined here.
+};
+
+struct SteamItemDetails_t
+{
+	SteamItemInstanceID_t m_itemId;
+	SteamItemDef_t m_iDefinition;
+	uint16 m_unQuantity;
+	uint16 m_unFlags; // see ESteamItemFlags
+};
+
+typedef int32 SteamInventoryResult_t;
+
+static const SteamInventoryResult_t k_SteamInventoryResultInvalid = -1;
+
+typedef uint64 SteamInventoryUpdateHandle_t;
+const SteamInventoryUpdateHandle_t k_SteamInventoryUpdateHandleInvalid = 0xffffffffffffffffull;
+
+//-----------------------------------------------------------------------------
+// Purpose: Steam Inventory query and manipulation API
+//-----------------------------------------------------------------------------
+class ISteamInventory
+{
+public:
+
+	// INVENTORY ASYNC RESULT MANAGEMENT
+	//
+	// Asynchronous inventory queries always output a result handle which can be used with
+	// GetResultStatus, GetResultItems, etc. A SteamInventoryResultReady_t callback will
+	// be triggered when the asynchronous result becomes ready (or fails).
+	//
+
+	// Find out the status of an asynchronous inventory result handle. Possible values:
+	//  k_EResultPending - still in progress
+	//  k_EResultOK - done, result ready
+	//  k_EResultExpired - done, result ready, maybe out of date (see DeserializeResult)
+	//  k_EResultInvalidParam - ERROR: invalid API call parameters
+	//  k_EResultServiceUnavailable - ERROR: service temporarily down, you may retry later
+	//  k_EResultLimitExceeded - ERROR: operation would exceed per-user inventory limits
+	//  k_EResultFail - ERROR: unknown / generic error
+	STEAM_METHOD_DESC(Find out the status of an asynchronous inventory result handle.)
+	virtual EResult GetResultStatus( SteamInventoryResult_t resultHandle ) = 0;
+
+	// Copies the contents of a result set into a flat array. The specific
+	// contents of the result set depend on which query which was used.
+	STEAM_METHOD_DESC(Copies the contents of a result set into a flat array. The specific contents of the result set depend on which query which was used.)
+	virtual bool GetResultItems( SteamInventoryResult_t resultHandle,
+								STEAM_OUT_ARRAY_COUNT( punOutItemsArraySize,Output array) SteamItemDetails_t *pOutItemsArray,
+								uint32 *punOutItemsArraySize ) = 0;
+
+	// In combination with GetResultItems, you can use GetResultItemProperty to retrieve
+	// dynamic string properties for a given item returned in the result set.
+	// 
+	// Property names are always composed of ASCII letters, numbers, and/or underscores.
+	//
+	// Pass a NULL pointer for pchPropertyName to get a comma - separated list of available
+	// property names.
+	//
+	// If pchValueBuffer is NULL, *punValueBufferSize will contain the 
+	// suggested buffer size. Otherwise it will be the number of bytes actually copied
+	// to pchValueBuffer. If the results do not fit in the given buffer, partial 
+	// results may be copied.
+	virtual bool GetResultItemProperty( SteamInventoryResult_t resultHandle, 
+										uint32 unItemIndex, 
+										const char *pchPropertyName,
+										STEAM_OUT_STRING_COUNT( punValueBufferSizeOut ) char *pchValueBuffer, uint32 *punValueBufferSizeOut ) = 0;
+
+	// Returns the server time at which the result was generated. Compare against
+	// the value of IClientUtils::GetServerRealTime() to determine age.
+	STEAM_METHOD_DESC(Returns the server time at which the result was generated. Compare against the value of IClientUtils::GetServerRealTime() to determine age.)
+	virtual uint32 GetResultTimestamp( SteamInventoryResult_t resultHandle ) = 0;
+
+	// Returns true if the result belongs to the target steam ID, false if the
+	// result does not. This is important when using DeserializeResult, to verify
+	// that a remote player is not pretending to have a different user's inventory.
+	STEAM_METHOD_DESC(Returns true if the result belongs to the target steam ID or false if the result does not. This is important when using DeserializeResult to verify that a remote player is not pretending to have a different users inventory.)
+	virtual bool CheckResultSteamID( SteamInventoryResult_t resultHandle, CSteamID steamIDExpected ) = 0;
+
+	// Destroys a result handle and frees all associated memory.
+	STEAM_METHOD_DESC(Destroys a result handle and frees all associated memory.)
+	virtual void DestroyResult( SteamInventoryResult_t resultHandle ) = 0;
+
+
+	// INVENTORY ASYNC QUERY
+	//
+
+	// Captures the entire state of the current user's Steam inventory.
+	// You must call DestroyResult on this handle when you are done with it.
+	// Returns false and sets *pResultHandle to zero if inventory is unavailable.
+	// Note: calls to this function are subject to rate limits and may return
+	// cached results if called too frequently. It is suggested that you call
+	// this function only when you are about to display the user's full inventory,
+	// or if you expect that the inventory may have changed.
+	STEAM_METHOD_DESC(Captures the entire state of the current users Steam inventory.)
+	virtual bool GetAllItems( SteamInventoryResult_t *pResultHandle ) = 0;
+
+
+	// Captures the state of a subset of the current user's Steam inventory,
+	// identified by an array of item instance IDs. The results from this call
+	// can be serialized and passed to other players to "prove" that the current
+	// user owns specific items, without exposing the user's entire inventory.
+	// For example, you could call GetItemsByID with the IDs of the user's
+	// currently equipped cosmetic items and serialize this to a buffer, and
+	// then transmit this buffer to other players upon joining a game.
+	STEAM_METHOD_DESC(Captures the state of a subset of the current users Steam inventory identified by an array of item instance IDs.)
+	virtual bool GetItemsByID( SteamInventoryResult_t *pResultHandle, STEAM_ARRAY_COUNT( unCountInstanceIDs ) const SteamItemInstanceID_t *pInstanceIDs, uint32 unCountInstanceIDs ) = 0;
+
+
+	// RESULT SERIALIZATION AND AUTHENTICATION
+	//
+	// Serialized result sets contain a short signature which can't be forged
+	// or replayed across different game sessions. A result set can be serialized
+	// on the local client, transmitted to other players via your game networking,
+	// and deserialized by the remote players. This is a secure way of preventing
+	// hackers from lying about posessing rare/high-value items.
+
+	// Serializes a result set with signature bytes to an output buffer. Pass
+	// NULL as an output buffer to get the required size via punOutBufferSize.
+	// The size of a serialized result depends on the number items which are being
+	// serialized. When securely transmitting items to other players, it is
+	// recommended to use "GetItemsByID" first to create a minimal result set.
+	// Results have a built-in timestamp which will be considered "expired" after
+	// an hour has elapsed. See DeserializeResult for expiration handling.
+	virtual bool SerializeResult( SteamInventoryResult_t resultHandle, STEAM_OUT_BUFFER_COUNT(punOutBufferSize) void *pOutBuffer, uint32 *punOutBufferSize ) = 0;
+
+	// Deserializes a result set and verifies the signature bytes. Returns false
+	// if bRequireFullOnlineVerify is set but Steam is running in Offline mode.
+	// Otherwise returns true and then delivers error codes via GetResultStatus.
+	//
+	// The bRESERVED_MUST_BE_FALSE flag is reserved for future use and should not
+	// be set to true by your game at this time.
+	//
+	// DeserializeResult has a potential soft-failure mode where the handle status
+	// is set to k_EResultExpired. GetResultItems() still succeeds in this mode.
+	// The "expired" result could indicate that the data may be out of date - not
+	// just due to timed expiration (one hour), but also because one of the items
+	// in the result set may have been traded or consumed since the result set was
+	// generated. You could compare the timestamp from GetResultTimestamp() to
+	// ISteamUtils::GetServerRealTime() to determine how old the data is. You could
+	// simply ignore the "expired" result code and continue as normal, or you
+	// could challenge the player with expired data to send an updated result set.
+	virtual bool DeserializeResult( SteamInventoryResult_t *pOutResultHandle, STEAM_BUFFER_COUNT(punOutBufferSize) const void *pBuffer, uint32 unBufferSize, bool bRESERVED_MUST_BE_FALSE = false ) = 0;
+
+	
+	// INVENTORY ASYNC MODIFICATION
+	//
+	
+	// GenerateItems() creates one or more items and then generates a SteamInventoryCallback_t
+	// notification with a matching nCallbackContext parameter. This API is only intended
+	// for prototyping - it is only usable by Steam accounts that belong to the publisher group 
+	// for your game.
+	// If punArrayQuantity is not NULL, it should be the same length as pArrayItems and should
+	// describe the quantity of each item to generate.
+	virtual bool GenerateItems( SteamInventoryResult_t *pResultHandle, STEAM_ARRAY_COUNT(unArrayLength) const SteamItemDef_t *pArrayItemDefs, STEAM_ARRAY_COUNT(unArrayLength) const uint32 *punArrayQuantity, uint32 unArrayLength ) = 0;
+
+	// GrantPromoItems() checks the list of promotional items for which the user may be eligible
+	// and grants the items (one time only).  On success, the result set will include items which
+	// were granted, if any. If no items were granted because the user isn't eligible for any
+	// promotions, this is still considered a success.
+	STEAM_METHOD_DESC(GrantPromoItems() checks the list of promotional items for which the user may be eligible and grants the items (one time only).)
+	virtual bool GrantPromoItems( SteamInventoryResult_t *pResultHandle ) = 0;
+
+	// AddPromoItem() / AddPromoItems() are restricted versions of GrantPromoItems(). Instead of
+	// scanning for all eligible promotional items, the check is restricted to a single item
+	// definition or set of item definitions. This can be useful if your game has custom UI for
+	// showing a specific promo item to the user.
+	virtual bool AddPromoItem( SteamInventoryResult_t *pResultHandle, SteamItemDef_t itemDef ) = 0;
+	virtual bool AddPromoItems( SteamInventoryResult_t *pResultHandle, STEAM_ARRAY_COUNT(unArrayLength) const SteamItemDef_t *pArrayItemDefs, uint32 unArrayLength ) = 0;
+
+	// ConsumeItem() removes items from the inventory, permanently. They cannot be recovered.
+	// Not for the faint of heart - if your game implements item removal at all, a high-friction
+	// UI confirmation process is highly recommended.
+	STEAM_METHOD_DESC(ConsumeItem() removes items from the inventory permanently.)
+	virtual bool ConsumeItem( SteamInventoryResult_t *pResultHandle, SteamItemInstanceID_t itemConsume, uint32 unQuantity ) = 0;
+
+	// ExchangeItems() is an atomic combination of item generation and consumption. 
+	// It can be used to implement crafting recipes or transmutations, or items which unpack 
+	// themselves into other items (e.g., a chest). 
+	// Exchange recipes are defined in the ItemDef, and explicitly list the required item 
+	// types and resulting generated type. 
+	// Exchange recipes are evaluated atomically by the Inventory Service; if the supplied
+	// components do not match the recipe, or do not contain sufficient quantity, the 
+	// exchange will fail.
+	virtual bool ExchangeItems( SteamInventoryResult_t *pResultHandle,
+								STEAM_ARRAY_COUNT(unArrayGenerateLength) const SteamItemDef_t *pArrayGenerate, STEAM_ARRAY_COUNT(unArrayGenerateLength) const uint32 *punArrayGenerateQuantity, uint32 unArrayGenerateLength,
+								STEAM_ARRAY_COUNT(unArrayDestroyLength) const SteamItemInstanceID_t *pArrayDestroy, STEAM_ARRAY_COUNT(unArrayDestroyLength) const uint32 *punArrayDestroyQuantity, uint32 unArrayDestroyLength ) = 0;
+	
+
+	// TransferItemQuantity() is intended for use with items which are "stackable" (can have
+	// quantity greater than one). It can be used to split a stack into two, or to transfer
+	// quantity from one stack into another stack of identical items. To split one stack into
+	// two, pass k_SteamItemInstanceIDInvalid for itemIdDest and a new item will be generated.
+	virtual bool TransferItemQuantity( SteamInventoryResult_t *pResultHandle, SteamItemInstanceID_t itemIdSource, uint32 unQuantity, SteamItemInstanceID_t itemIdDest ) = 0;
+
+
+	// TIMED DROPS AND PLAYTIME CREDIT
+	//
+
+	// Deprecated. Calling this method is not required for proper playtime accounting.
+	STEAM_METHOD_DESC( Deprecated method. Playtime accounting is performed on the Steam servers. )
+	virtual void SendItemDropHeartbeat() = 0;
+
+	// Playtime credit must be consumed and turned into item drops by your game. Only item
+	// definitions which are marked as "playtime item generators" can be spawned. The call
+	// will return an empty result set if there is not enough playtime credit for a drop.
+	// Your game should call TriggerItemDrop at an appropriate time for the user to receive
+	// new items, such as between rounds or while the player is dead. Note that players who
+	// hack their clients could modify the value of "dropListDefinition", so do not use it
+	// to directly control rarity.
+	// See your Steamworks configuration to set playtime drop rates for individual itemdefs.
+	// The client library will suppress too-frequent calls to this method.
+	STEAM_METHOD_DESC(Playtime credit must be consumed and turned into item drops by your game.)
+	virtual bool TriggerItemDrop( SteamInventoryResult_t *pResultHandle, SteamItemDef_t dropListDefinition ) = 0;
+
+
+	// Deprecated. This method is not supported.
+	virtual bool TradeItems( SteamInventoryResult_t *pResultHandle, CSteamID steamIDTradePartner,
+							 STEAM_ARRAY_COUNT(nArrayGiveLength) const SteamItemInstanceID_t *pArrayGive, STEAM_ARRAY_COUNT(nArrayGiveLength) const uint32 *pArrayGiveQuantity, uint32 nArrayGiveLength,
+							 STEAM_ARRAY_COUNT(nArrayGetLength) const SteamItemInstanceID_t *pArrayGet, STEAM_ARRAY_COUNT(nArrayGetLength) const uint32 *pArrayGetQuantity, uint32 nArrayGetLength ) = 0;
+
+
+	// ITEM DEFINITIONS
+	//
+	// Item definitions are a mapping of "definition IDs" (integers between 1 and 1000000)
+	// to a set of string properties. Some of these properties are required to display items
+	// on the Steam community web site. Other properties can be defined by applications.
+	// Use of these functions is optional; there is no reason to call LoadItemDefinitions
+	// if your game hardcodes the numeric definition IDs (eg, purple face mask = 20, blue
+	// weapon mod = 55) and does not allow for adding new item types without a client patch.
+	//
+
+	// LoadItemDefinitions triggers the automatic load and refresh of item definitions.
+	// Every time new item definitions are available (eg, from the dynamic addition of new
+	// item types while players are still in-game), a SteamInventoryDefinitionUpdate_t
+	// callback will be fired.
+	STEAM_METHOD_DESC(LoadItemDefinitions triggers the automatic load and refresh of item definitions.)
+	virtual bool LoadItemDefinitions() = 0;
+
+	// GetItemDefinitionIDs returns the set of all defined item definition IDs (which are
+	// defined via Steamworks configuration, and not necessarily contiguous integers).
+	// If pItemDefIDs is null, the call will return true and *punItemDefIDsArraySize will
+	// contain the total size necessary for a subsequent call. Otherwise, the call will
+	// return false if and only if there is not enough space in the output array.
+	virtual bool GetItemDefinitionIDs(
+				STEAM_OUT_ARRAY_COUNT(punItemDefIDsArraySize,List of item definition IDs) SteamItemDef_t *pItemDefIDs,
+				STEAM_DESC(Size of array is passed in and actual size used is returned in this param) uint32 *punItemDefIDsArraySize ) = 0;
+
+	// GetItemDefinitionProperty returns a string property from a given item definition.
+	// Note that some properties (for example, "name") may be localized and will depend
+	// on the current Steam language settings (see ISteamApps::GetCurrentGameLanguage).
+	// Property names are always composed of ASCII letters, numbers, and/or underscores.
+	// Pass a NULL pointer for pchPropertyName to get a comma - separated list of available
+	// property names. If pchValueBuffer is NULL, *punValueBufferSize will contain the 
+	// suggested buffer size. Otherwise it will be the number of bytes actually copied
+	// to pchValueBuffer. If the results do not fit in the given buffer, partial 
+	// results may be copied.
+	virtual bool GetItemDefinitionProperty( SteamItemDef_t iDefinition, const char *pchPropertyName,
+		STEAM_OUT_STRING_COUNT(punValueBufferSizeOut) char *pchValueBuffer, uint32 *punValueBufferSizeOut ) = 0;
+
+	// Request the list of "eligible" promo items that can be manually granted to the given
+	// user.  These are promo items of type "manual" that won't be granted automatically.
+	// An example usage of this is an item that becomes available every week.
+	STEAM_CALL_RESULT( SteamInventoryEligiblePromoItemDefIDs_t )
+	virtual SteamAPICall_t RequestEligiblePromoItemDefinitionsIDs( CSteamID steamID ) = 0;
+
+	// After handling a SteamInventoryEligiblePromoItemDefIDs_t call result, use this
+	// function to pull out the list of item definition ids that the user can be
+	// manually granted via the AddPromoItems() call.
+	virtual bool GetEligiblePromoItemDefinitionIDs(
+		CSteamID steamID,
+		STEAM_OUT_ARRAY_COUNT(punItemDefIDsArraySize,List of item definition IDs) SteamItemDef_t *pItemDefIDs,
+		STEAM_DESC(Size of array is passed in and actual size used is returned in this param) uint32 *punItemDefIDsArraySize ) = 0;
+
+	// Starts the purchase process for the given item definitions.  The callback SteamInventoryStartPurchaseResult_t
+	// will be posted if Steam was able to initialize the transaction.
+	// 
+	// Once the purchase has been authorized and completed by the user, the callback SteamInventoryResultReady_t 
+	// will be posted.
+	STEAM_CALL_RESULT( SteamInventoryStartPurchaseResult_t )
+	virtual SteamAPICall_t StartPurchase( STEAM_ARRAY_COUNT(unArrayLength) const SteamItemDef_t *pArrayItemDefs, STEAM_ARRAY_COUNT(unArrayLength) const uint32 *punArrayQuantity, uint32 unArrayLength ) = 0;
+
+	// Request current prices for all applicable item definitions
+	STEAM_CALL_RESULT( SteamInventoryRequestPricesResult_t )
+	virtual SteamAPICall_t RequestPrices() = 0;
+
+	// Returns the number of items with prices.  Need to call RequestPrices() first.
+	virtual uint32 GetNumItemsWithPrices() = 0;
+	
+	// Returns item definition ids and their prices in the user's local currency.
+	// Need to call RequestPrices() first.
+	virtual bool GetItemsWithPrices( STEAM_ARRAY_COUNT(unArrayLength) STEAM_OUT_ARRAY_COUNT(pArrayItemDefs, Items with prices) SteamItemDef_t *pArrayItemDefs,
+									 STEAM_ARRAY_COUNT(unArrayLength) STEAM_OUT_ARRAY_COUNT(pPrices, List of prices for the given item defs) uint64 *pCurrentPrices,
+									 STEAM_ARRAY_COUNT(unArrayLength) STEAM_OUT_ARRAY_COUNT(pPrices, List of prices for the given item defs) uint64 *pBasePrices,
+									 uint32 unArrayLength ) = 0;
+
+	// Retrieves the price for the item definition id
+	// Returns false if there is no price stored for the item definition.
+	virtual bool GetItemPrice( SteamItemDef_t iDefinition, uint64 *pCurrentPrice, uint64 *pBasePrice ) = 0;
+
+	// Create a request to update properties on items
+	virtual SteamInventoryUpdateHandle_t StartUpdateProperties() = 0;
+	// Remove the property on the item
+	virtual bool RemoveProperty( SteamInventoryUpdateHandle_t handle, SteamItemInstanceID_t nItemID, const char *pchPropertyName ) = 0;
+	// Accessor methods to set properties on items
+
+	STEAM_FLAT_NAME( SetPropertyString )
+	virtual bool SetProperty( SteamInventoryUpdateHandle_t handle, SteamItemInstanceID_t nItemID, const char *pchPropertyName, const char *pchPropertyValue ) = 0;
+
+	STEAM_FLAT_NAME( SetPropertyBool )
+	virtual bool SetProperty( SteamInventoryUpdateHandle_t handle, SteamItemInstanceID_t nItemID, const char *pchPropertyName, bool bValue ) = 0;
+
+	STEAM_FLAT_NAME( SetPropertyInt64 )
+	virtual bool SetProperty( SteamInventoryUpdateHandle_t handle, SteamItemInstanceID_t nItemID, const char *pchPropertyName, int64 nValue ) = 0;
+
+	STEAM_FLAT_NAME( SetPropertyFloat )
+	virtual bool SetProperty( SteamInventoryUpdateHandle_t handle, SteamItemInstanceID_t nItemID, const char *pchPropertyName, float flValue ) = 0;
+
+	// Submit the update request by handle
+	virtual bool SubmitUpdateProperties( SteamInventoryUpdateHandle_t handle, SteamInventoryResult_t * pResultHandle ) = 0;
+	
+};
+
+#define STEAMINVENTORY_INTERFACE_VERSION "STEAMINVENTORY_INTERFACE_V003"
+
+// Global interface accessor
+inline ISteamInventory *SteamInventory();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamInventory *, SteamInventory, STEAMINVENTORY_INTERFACE_VERSION );
+
+// Global accessor for the gameserver client
+inline ISteamInventory *SteamGameServerInventory();
+STEAM_DEFINE_GAMESERVER_INTERFACE_ACCESSOR( ISteamInventory *, SteamGameServerInventory, STEAMINVENTORY_INTERFACE_VERSION );
+
+// SteamInventoryResultReady_t callbacks are fired whenever asynchronous
+// results transition from "Pending" to "OK" or an error state. There will
+// always be exactly one callback per handle.
+struct SteamInventoryResultReady_t
+{
+	enum { k_iCallback = k_iClientInventoryCallbacks + 0 };
+	SteamInventoryResult_t m_handle;
+	EResult m_result;
+};
+
+
+// SteamInventoryFullUpdate_t callbacks are triggered when GetAllItems
+// successfully returns a result which is newer / fresher than the last
+// known result. (It will not trigger if the inventory hasn't changed,
+// or if results from two overlapping calls are reversed in flight and
+// the earlier result is already known to be stale/out-of-date.)
+// The normal ResultReady callback will still be triggered immediately
+// afterwards; this is an additional notification for your convenience.
+struct SteamInventoryFullUpdate_t
+{
+	enum { k_iCallback = k_iClientInventoryCallbacks + 1 };
+	SteamInventoryResult_t m_handle;
+};
+
+
+// A SteamInventoryDefinitionUpdate_t callback is triggered whenever
+// item definitions have been updated, which could be in response to 
+// LoadItemDefinitions() or any other async request which required
+// a definition update in order to process results from the server.
+struct SteamInventoryDefinitionUpdate_t
+{
+	enum { k_iCallback = k_iClientInventoryCallbacks + 2 };
+};
+
+// Returned 
+struct SteamInventoryEligiblePromoItemDefIDs_t
+{
+	enum { k_iCallback = k_iClientInventoryCallbacks + 3 };
+	EResult m_result;
+	CSteamID m_steamID;
+	int m_numEligiblePromoItemDefs;
+	bool m_bCachedData;	// indicates that the data was retrieved from the cache and not the server
+};
+
+// Triggered from StartPurchase call
+struct SteamInventoryStartPurchaseResult_t
+{
+	enum { k_iCallback = k_iClientInventoryCallbacks + 4 };
+	EResult m_result;
+	uint64 m_ulOrderID;
+	uint64 m_ulTransID;
+};
+
+
+// Triggered from RequestPrices
+struct SteamInventoryRequestPricesResult_t
+{
+	enum { k_iCallback = k_iClientInventoryCallbacks + 5 };
+	EResult m_result;
+	char m_rgchCurrency[4];
+};
+
+#pragma pack( pop )
+
+
+#endif // ISTEAMCONTROLLER_H

--- a/lsteamclient/steamworks_sdk_148a/isteammasterserverupdater.h
+++ b/lsteamclient/steamworks_sdk_148a/isteammasterserverupdater.h
@@ -1,0 +1,1 @@
+#error "This file isn't used any more"

--- a/lsteamclient/steamworks_sdk_148a/isteammatchmaking.h
+++ b/lsteamclient/steamworks_sdk_148a/isteammatchmaking.h
@@ -1,0 +1,1087 @@
+//====== Copyright © 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to steam managing game server/client match making
+//
+//=============================================================================
+
+#ifndef ISTEAMMATCHMAKING
+#define ISTEAMMATCHMAKING
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+#include "matchmakingtypes.h" 
+#include "isteamfriends.h"
+
+// lobby type description
+enum ELobbyType
+{
+	k_ELobbyTypePrivate = 0,		// only way to join the lobby is to invite to someone else
+	k_ELobbyTypeFriendsOnly = 1,	// shows for friends or invitees, but not in lobby list
+	k_ELobbyTypePublic = 2,			// visible for friends and in lobby list
+	k_ELobbyTypeInvisible = 3,		// returned by search, but not visible to other friends 
+									//    useful if you want a user in two lobbies, for example matching groups together
+									//	  a user can be in only one regular lobby, and up to two invisible lobbies
+	k_ELobbyTypePrivateUnique = 4,	// private, unique and does not delete when empty - only one of these may exist per unique keypair set
+									// can only create from webapi
+};
+
+// lobby search filter tools
+enum ELobbyComparison
+{
+	k_ELobbyComparisonEqualToOrLessThan = -2,
+	k_ELobbyComparisonLessThan = -1,
+	k_ELobbyComparisonEqual = 0,
+	k_ELobbyComparisonGreaterThan = 1,
+	k_ELobbyComparisonEqualToOrGreaterThan = 2,
+	k_ELobbyComparisonNotEqual = 3,
+};
+
+// lobby search distance. Lobby results are sorted from closest to farthest.
+enum ELobbyDistanceFilter
+{
+	k_ELobbyDistanceFilterClose,		// only lobbies in the same immediate region will be returned
+	k_ELobbyDistanceFilterDefault,		// only lobbies in the same region or near by regions
+	k_ELobbyDistanceFilterFar,			// for games that don't have many latency requirements, will return lobbies about half-way around the globe
+	k_ELobbyDistanceFilterWorldwide,	// no filtering, will match lobbies as far as India to NY (not recommended, expect multiple seconds of latency between the clients)
+};
+
+// maximum number of characters a lobby metadata key can be
+#define k_nMaxLobbyKeyLength 255
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for match making services for clients to get to favorites
+//			and to operate on game lobbies.
+//-----------------------------------------------------------------------------
+class ISteamMatchmaking
+{
+public:
+	// game server favorites storage
+	// saves basic details about a multiplayer game server locally
+
+	// returns the number of favorites servers the user has stored
+	virtual int GetFavoriteGameCount() = 0;
+	
+	// returns the details of the game server
+	// iGame is of range [0,GetFavoriteGameCount())
+	// *pnIP, *pnConnPort are filled in the with IP:port of the game server
+	// *punFlags specify whether the game server was stored as an explicit favorite or in the history of connections
+	// *pRTime32LastPlayedOnServer is filled in the with the Unix time the favorite was added
+	virtual bool GetFavoriteGame( int iGame, AppId_t *pnAppID, uint32 *pnIP, uint16 *pnConnPort, uint16 *pnQueryPort, uint32 *punFlags, uint32 *pRTime32LastPlayedOnServer ) = 0;
+
+	// adds the game server to the local list; updates the time played of the server if it already exists in the list
+	virtual int AddFavoriteGame( AppId_t nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags, uint32 rTime32LastPlayedOnServer ) = 0;
+	
+	// removes the game server from the local storage; returns true if one was removed
+	virtual bool RemoveFavoriteGame( AppId_t nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags ) = 0;
+
+	///////
+	// Game lobby functions
+
+	// Get a list of relevant lobbies
+	// this is an asynchronous request
+	// results will be returned by LobbyMatchList_t callback & call result, with the number of lobbies found
+	// this will never return lobbies that are full
+	// to add more filter, the filter calls below need to be call before each and every RequestLobbyList() call
+	// use the CCallResult<> object in steam_api.h to match the SteamAPICall_t call result to a function in an object, e.g.
+	/*
+		class CMyLobbyListManager
+		{
+			CCallResult<CMyLobbyListManager, LobbyMatchList_t> m_CallResultLobbyMatchList;
+			void FindLobbies()
+			{
+				// SteamMatchmaking()->AddRequestLobbyListFilter*() functions would be called here, before RequestLobbyList()
+				SteamAPICall_t hSteamAPICall = SteamMatchmaking()->RequestLobbyList();
+				m_CallResultLobbyMatchList.Set( hSteamAPICall, this, &CMyLobbyListManager::OnLobbyMatchList );
+			}
+
+			void OnLobbyMatchList( LobbyMatchList_t *pLobbyMatchList, bool bIOFailure )
+			{
+				// lobby list has be retrieved from Steam back-end, use results
+			}
+		}
+	*/
+	// 
+	STEAM_CALL_RESULT( LobbyMatchList_t )
+	virtual SteamAPICall_t RequestLobbyList() = 0;
+	// filters for lobbies
+	// this needs to be called before RequestLobbyList() to take effect
+	// these are cleared on each call to RequestLobbyList()
+	virtual void AddRequestLobbyListStringFilter( const char *pchKeyToMatch, const char *pchValueToMatch, ELobbyComparison eComparisonType ) = 0;
+	// numerical comparison
+	virtual void AddRequestLobbyListNumericalFilter( const char *pchKeyToMatch, int nValueToMatch, ELobbyComparison eComparisonType ) = 0;
+	// returns results closest to the specified value. Multiple near filters can be added, with early filters taking precedence
+	virtual void AddRequestLobbyListNearValueFilter( const char *pchKeyToMatch, int nValueToBeCloseTo ) = 0;
+	// returns only lobbies with the specified number of slots available
+	virtual void AddRequestLobbyListFilterSlotsAvailable( int nSlotsAvailable ) = 0;
+	// sets the distance for which we should search for lobbies (based on users IP address to location map on the Steam backed)
+	virtual void AddRequestLobbyListDistanceFilter( ELobbyDistanceFilter eLobbyDistanceFilter ) = 0;
+	// sets how many results to return, the lower the count the faster it is to download the lobby results & details to the client
+	virtual void AddRequestLobbyListResultCountFilter( int cMaxResults ) = 0;
+
+	virtual void AddRequestLobbyListCompatibleMembersFilter( CSteamID steamIDLobby ) = 0;
+
+	// returns the CSteamID of a lobby, as retrieved by a RequestLobbyList call
+	// should only be called after a LobbyMatchList_t callback is received
+	// iLobby is of the range [0, LobbyMatchList_t::m_nLobbiesMatching)
+	// the returned CSteamID::IsValid() will be false if iLobby is out of range
+	virtual CSteamID GetLobbyByIndex( int iLobby ) = 0;
+
+	// Create a lobby on the Steam servers.
+	// If private, then the lobby will not be returned by any RequestLobbyList() call; the CSteamID
+	// of the lobby will need to be communicated via game channels or via InviteUserToLobby()
+	// this is an asynchronous request
+	// results will be returned by LobbyCreated_t callback and call result; lobby is joined & ready to use at this point
+	// a LobbyEnter_t callback will also be received (since the local user is joining their own lobby)
+	STEAM_CALL_RESULT( LobbyCreated_t )
+	virtual SteamAPICall_t CreateLobby( ELobbyType eLobbyType, int cMaxMembers ) = 0;
+
+	// Joins an existing lobby
+	// this is an asynchronous request
+	// results will be returned by LobbyEnter_t callback & call result, check m_EChatRoomEnterResponse to see if was successful
+	// lobby metadata is available to use immediately on this call completing
+	STEAM_CALL_RESULT( LobbyEnter_t )
+	virtual SteamAPICall_t JoinLobby( CSteamID steamIDLobby ) = 0;
+
+	// Leave a lobby; this will take effect immediately on the client side
+	// other users in the lobby will be notified by a LobbyChatUpdate_t callback
+	virtual void LeaveLobby( CSteamID steamIDLobby ) = 0;
+
+	// Invite another user to the lobby
+	// the target user will receive a LobbyInvite_t callback
+	// will return true if the invite is successfully sent, whether or not the target responds
+	// returns false if the local user is not connected to the Steam servers
+	// if the other user clicks the join link, a GameLobbyJoinRequested_t will be posted if the user is in-game,
+	// or if the game isn't running yet the game will be launched with the parameter +connect_lobby <64-bit lobby id>
+	virtual bool InviteUserToLobby( CSteamID steamIDLobby, CSteamID steamIDInvitee ) = 0;
+
+	// Lobby iteration, for viewing details of users in a lobby
+	// only accessible if the lobby user is a member of the specified lobby
+	// persona information for other lobby members (name, avatar, etc.) will be asynchronously received
+	// and accessible via ISteamFriends interface
+	
+	// returns the number of users in the specified lobby
+	virtual int GetNumLobbyMembers( CSteamID steamIDLobby ) = 0;
+	// returns the CSteamID of a user in the lobby
+	// iMember is of range [0,GetNumLobbyMembers())
+	// note that the current user must be in a lobby to retrieve CSteamIDs of other users in that lobby
+	virtual CSteamID GetLobbyMemberByIndex( CSteamID steamIDLobby, int iMember ) = 0;
+
+	// Get data associated with this lobby
+	// takes a simple key, and returns the string associated with it
+	// "" will be returned if no value is set, or if steamIDLobby is invalid
+	virtual const char *GetLobbyData( CSteamID steamIDLobby, const char *pchKey ) = 0;
+	// Sets a key/value pair in the lobby metadata
+	// each user in the lobby will be broadcast this new value, and any new users joining will receive any existing data
+	// this can be used to set lobby names, map, etc.
+	// to reset a key, just set it to ""
+	// other users in the lobby will receive notification of the lobby data change via a LobbyDataUpdate_t callback
+	virtual bool SetLobbyData( CSteamID steamIDLobby, const char *pchKey, const char *pchValue ) = 0;
+
+	// returns the number of metadata keys set on the specified lobby
+	virtual int GetLobbyDataCount( CSteamID steamIDLobby ) = 0;
+
+	// returns a lobby metadata key/values pair by index, of range [0, GetLobbyDataCount())
+	virtual bool GetLobbyDataByIndex( CSteamID steamIDLobby, int iLobbyData, char *pchKey, int cchKeyBufferSize, char *pchValue, int cchValueBufferSize ) = 0;
+
+	// removes a metadata key from the lobby
+	virtual bool DeleteLobbyData( CSteamID steamIDLobby, const char *pchKey ) = 0;
+
+	// Gets per-user metadata for someone in this lobby
+	virtual const char *GetLobbyMemberData( CSteamID steamIDLobby, CSteamID steamIDUser, const char *pchKey ) = 0;
+	// Sets per-user metadata (for the local user implicitly)
+	virtual void SetLobbyMemberData( CSteamID steamIDLobby, const char *pchKey, const char *pchValue ) = 0;
+	
+	// Broadcasts a chat message to the all the users in the lobby
+	// users in the lobby (including the local user) will receive a LobbyChatMsg_t callback
+	// returns true if the message is successfully sent
+	// pvMsgBody can be binary or text data, up to 4k
+	// if pvMsgBody is text, cubMsgBody should be strlen( text ) + 1, to include the null terminator
+	virtual bool SendLobbyChatMsg( CSteamID steamIDLobby, const void *pvMsgBody, int cubMsgBody ) = 0;
+	// Get a chat message as specified in a LobbyChatMsg_t callback
+	// iChatID is the LobbyChatMsg_t::m_iChatID value in the callback
+	// *pSteamIDUser is filled in with the CSteamID of the member
+	// *pvData is filled in with the message itself
+	// return value is the number of bytes written into the buffer
+	virtual int GetLobbyChatEntry( CSteamID steamIDLobby, int iChatID, STEAM_OUT_STRUCT() CSteamID *pSteamIDUser, void *pvData, int cubData, EChatEntryType *peChatEntryType ) = 0;
+
+	// Refreshes metadata for a lobby you're not necessarily in right now
+	// you never do this for lobbies you're a member of, only if your
+	// this will send down all the metadata associated with a lobby
+	// this is an asynchronous call
+	// returns false if the local user is not connected to the Steam servers
+	// results will be returned by a LobbyDataUpdate_t callback
+	// if the specified lobby doesn't exist, LobbyDataUpdate_t::m_bSuccess will be set to false
+	virtual bool RequestLobbyData( CSteamID steamIDLobby ) = 0;
+	
+	// sets the game server associated with the lobby
+	// usually at this point, the users will join the specified game server
+	// either the IP/Port or the steamID of the game server has to be valid, depending on how you want the clients to be able to connect
+	virtual void SetLobbyGameServer( CSteamID steamIDLobby, uint32 unGameServerIP, uint16 unGameServerPort, CSteamID steamIDGameServer ) = 0;
+	// returns the details of a game server set in a lobby - returns false if there is no game server set, or that lobby doesn't exist
+	virtual bool GetLobbyGameServer( CSteamID steamIDLobby, uint32 *punGameServerIP, uint16 *punGameServerPort, STEAM_OUT_STRUCT() CSteamID *psteamIDGameServer ) = 0;
+
+	// set the limit on the # of users who can join the lobby
+	virtual bool SetLobbyMemberLimit( CSteamID steamIDLobby, int cMaxMembers ) = 0;
+	// returns the current limit on the # of users who can join the lobby; returns 0 if no limit is defined
+	virtual int GetLobbyMemberLimit( CSteamID steamIDLobby ) = 0;
+
+	// updates which type of lobby it is
+	// only lobbies that are k_ELobbyTypePublic or k_ELobbyTypeInvisible, and are set to joinable, will be returned by RequestLobbyList() calls
+	virtual bool SetLobbyType( CSteamID steamIDLobby, ELobbyType eLobbyType ) = 0;
+
+	// sets whether or not a lobby is joinable - defaults to true for a new lobby
+	// if set to false, no user can join, even if they are a friend or have been invited
+	virtual bool SetLobbyJoinable( CSteamID steamIDLobby, bool bLobbyJoinable ) = 0;
+
+	// returns the current lobby owner
+	// you must be a member of the lobby to access this
+	// there always one lobby owner - if the current owner leaves, another user will become the owner
+	// it is possible (bur rare) to join a lobby just as the owner is leaving, thus entering a lobby with self as the owner
+	virtual CSteamID GetLobbyOwner( CSteamID steamIDLobby ) = 0;
+
+	// changes who the lobby owner is
+	// you must be the lobby owner for this to succeed, and steamIDNewOwner must be in the lobby
+	// after completion, the local user will no longer be the owner
+	virtual bool SetLobbyOwner( CSteamID steamIDLobby, CSteamID steamIDNewOwner ) = 0;
+
+	// link two lobbies for the purposes of checking player compatibility
+	// you must be the lobby owner of both lobbies
+	virtual bool SetLinkedLobby( CSteamID steamIDLobby, CSteamID steamIDLobbyDependent ) = 0;
+
+#ifdef _PS3
+	// changes who the lobby owner is
+	// you must be the lobby owner for this to succeed, and steamIDNewOwner must be in the lobby
+	// after completion, the local user will no longer be the owner
+	virtual void CheckForPSNGameBootInvite( unsigned int iGameBootAttributes  ) = 0;
+#endif
+};
+#define STEAMMATCHMAKING_INTERFACE_VERSION "SteamMatchMaking009"
+
+// Global interface accessor
+inline ISteamMatchmaking *SteamMatchmaking();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamMatchmaking *, SteamMatchmaking, STEAMMATCHMAKING_INTERFACE_VERSION );
+
+//-----------------------------------------------------------------------------
+// Callback interfaces for server list functions (see ISteamMatchmakingServers below)
+//
+// The idea here is that your game code implements objects that implement these
+// interfaces to receive callback notifications after calling asynchronous functions
+// inside the ISteamMatchmakingServers() interface below.
+//
+// This is different than normal Steam callback handling due to the potentially
+// large size of server lists.
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+// Typedef for handle type you will receive when requesting server list.
+//-----------------------------------------------------------------------------
+typedef void* HServerListRequest;
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback interface for receiving responses after a server list refresh
+// or an individual server update.
+//
+// Since you get these callbacks after requesting full list refreshes you will
+// usually implement this interface inside an object like CServerBrowser.  If that
+// object is getting destructed you should use ISteamMatchMakingServers()->CancelQuery()
+// to cancel any in-progress queries so you don't get a callback into the destructed
+// object and crash.
+//-----------------------------------------------------------------------------
+class ISteamMatchmakingServerListResponse
+{
+public:
+	// Server has responded ok with updated data
+	virtual void ServerResponded( HServerListRequest hRequest, int iServer ) = 0; 
+
+	// Server has failed to respond
+	virtual void ServerFailedToRespond( HServerListRequest hRequest, int iServer ) = 0; 
+
+	// A list refresh you had initiated is now 100% completed
+	virtual void RefreshComplete( HServerListRequest hRequest, EMatchMakingServerResponse response ) = 0; 
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback interface for receiving responses after pinging an individual server 
+//
+// These callbacks all occur in response to querying an individual server
+// via the ISteamMatchmakingServers()->PingServer() call below.  If you are 
+// destructing an object that implements this interface then you should call 
+// ISteamMatchmakingServers()->CancelServerQuery() passing in the handle to the query
+// which is in progress.  Failure to cancel in progress queries when destructing
+// a callback handler may result in a crash when a callback later occurs.
+//-----------------------------------------------------------------------------
+class ISteamMatchmakingPingResponse
+{
+public:
+	// Server has responded successfully and has updated data
+	virtual void ServerResponded( gameserveritem_t &server ) = 0;
+
+	// Server failed to respond to the ping request
+	virtual void ServerFailedToRespond() = 0;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback interface for receiving responses after requesting details on
+// who is playing on a particular server.
+//
+// These callbacks all occur in response to querying an individual server
+// via the ISteamMatchmakingServers()->PlayerDetails() call below.  If you are 
+// destructing an object that implements this interface then you should call 
+// ISteamMatchmakingServers()->CancelServerQuery() passing in the handle to the query
+// which is in progress.  Failure to cancel in progress queries when destructing
+// a callback handler may result in a crash when a callback later occurs.
+//-----------------------------------------------------------------------------
+class ISteamMatchmakingPlayersResponse
+{
+public:
+	// Got data on a new player on the server -- you'll get this callback once per player
+	// on the server which you have requested player data on.
+	virtual void AddPlayerToList( const char *pchName, int nScore, float flTimePlayed ) = 0;
+
+	// The server failed to respond to the request for player details
+	virtual void PlayersFailedToRespond() = 0;
+
+	// The server has finished responding to the player details request 
+	// (ie, you won't get anymore AddPlayerToList callbacks)
+	virtual void PlayersRefreshComplete() = 0;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback interface for receiving responses after requesting rules
+// details on a particular server.
+//
+// These callbacks all occur in response to querying an individual server
+// via the ISteamMatchmakingServers()->ServerRules() call below.  If you are 
+// destructing an object that implements this interface then you should call 
+// ISteamMatchmakingServers()->CancelServerQuery() passing in the handle to the query
+// which is in progress.  Failure to cancel in progress queries when destructing
+// a callback handler may result in a crash when a callback later occurs.
+//-----------------------------------------------------------------------------
+class ISteamMatchmakingRulesResponse
+{
+public:
+	// Got data on a rule on the server -- you'll get one of these per rule defined on
+	// the server you are querying
+	virtual void RulesResponded( const char *pchRule, const char *pchValue ) = 0;
+
+	// The server failed to respond to the request for rule details
+	virtual void RulesFailedToRespond() = 0;
+
+	// The server has finished responding to the rule details request 
+	// (ie, you won't get anymore RulesResponded callbacks)
+	virtual void RulesRefreshComplete() = 0;
+};
+
+
+//-----------------------------------------------------------------------------
+// Typedef for handle type you will receive when querying details on an individual server.
+//-----------------------------------------------------------------------------
+typedef int HServerQuery;
+const int HSERVERQUERY_INVALID = 0xffffffff;
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for match making services for clients to get to game lists and details
+//-----------------------------------------------------------------------------
+class ISteamMatchmakingServers
+{
+public:
+	// Request a new list of servers of a particular type.  These calls each correspond to one of the EMatchMakingType values.
+	// Each call allocates a new asynchronous request object.
+	// Request object must be released by calling ReleaseRequest( hServerListRequest )
+	virtual HServerListRequest RequestInternetServerList( AppId_t iApp, STEAM_ARRAY_COUNT(nFilters) MatchMakingKeyValuePair_t **ppchFilters, uint32 nFilters, ISteamMatchmakingServerListResponse *pRequestServersResponse ) = 0;
+	virtual HServerListRequest RequestLANServerList( AppId_t iApp, ISteamMatchmakingServerListResponse *pRequestServersResponse ) = 0;
+	virtual HServerListRequest RequestFriendsServerList( AppId_t iApp, STEAM_ARRAY_COUNT(nFilters) MatchMakingKeyValuePair_t **ppchFilters, uint32 nFilters, ISteamMatchmakingServerListResponse *pRequestServersResponse ) = 0;
+	virtual HServerListRequest RequestFavoritesServerList( AppId_t iApp, STEAM_ARRAY_COUNT(nFilters) MatchMakingKeyValuePair_t **ppchFilters, uint32 nFilters, ISteamMatchmakingServerListResponse *pRequestServersResponse ) = 0;
+	virtual HServerListRequest RequestHistoryServerList( AppId_t iApp, STEAM_ARRAY_COUNT(nFilters) MatchMakingKeyValuePair_t **ppchFilters, uint32 nFilters, ISteamMatchmakingServerListResponse *pRequestServersResponse ) = 0;
+	virtual HServerListRequest RequestSpectatorServerList( AppId_t iApp, STEAM_ARRAY_COUNT(nFilters) MatchMakingKeyValuePair_t **ppchFilters, uint32 nFilters, ISteamMatchmakingServerListResponse *pRequestServersResponse ) = 0;
+
+	// Releases the asynchronous request object and cancels any pending query on it if there's a pending query in progress.
+	// RefreshComplete callback is not posted when request is released.
+	virtual void ReleaseRequest( HServerListRequest hServerListRequest ) = 0;
+
+	/* the filter operation codes that go in the key part of MatchMakingKeyValuePair_t should be one of these:
+
+		"map"
+			- Server passes the filter if the server is playing the specified map.
+		"gamedataand"
+			- Server passes the filter if the server's game data (ISteamGameServer::SetGameData) contains all of the
+			specified strings.  The value field is a comma-delimited list of strings to match.
+		"gamedataor"
+			- Server passes the filter if the server's game data (ISteamGameServer::SetGameData) contains at least one of the
+			specified strings.  The value field is a comma-delimited list of strings to match.
+		"gamedatanor"
+			- Server passes the filter if the server's game data (ISteamGameServer::SetGameData) does not contain any
+			of the specified strings.  The value field is a comma-delimited list of strings to check.
+		"gametagsand"
+			- Server passes the filter if the server's game tags (ISteamGameServer::SetGameTags) contains all
+			of the specified strings.  The value field is a comma-delimited list of strings to check.
+		"gametagsnor"
+			- Server passes the filter if the server's game tags (ISteamGameServer::SetGameTags) does not contain any
+			of the specified strings.  The value field is a comma-delimited list of strings to check.
+		"and" (x1 && x2 && ... && xn)
+		"or" (x1 || x2 || ... || xn)
+		"nand" !(x1 && x2 && ... && xn)
+		"nor" !(x1 || x2 || ... || xn)
+			- Performs Boolean operation on the following filters.  The operand to this filter specifies
+			the "size" of the Boolean inputs to the operation, in Key/value pairs.  (The keyvalue
+			pairs must immediately follow, i.e. this is a prefix logical operator notation.)
+			In the simplest case where Boolean expressions are not nested, this is simply
+			the number of operands.
+
+			For example, to match servers on a particular map or with a particular tag, would would
+			use these filters.
+
+				( server.map == "cp_dustbowl" || server.gametags.contains("payload") )
+				"or", "2"
+				"map", "cp_dustbowl"
+				"gametagsand", "payload"
+
+			If logical inputs are nested, then the operand specifies the size of the entire
+			"length" of its operands, not the number of immediate children.
+
+				( server.map == "cp_dustbowl" || ( server.gametags.contains("payload") && !server.gametags.contains("payloadrace") ) )
+				"or", "4"
+				"map", "cp_dustbowl"
+				"and", "2"
+				"gametagsand", "payload"
+				"gametagsnor", "payloadrace"
+
+			Unary NOT can be achieved using either "nand" or "nor" with a single operand.
+
+		"addr"
+			- Server passes the filter if the server's query address matches the specified IP or IP:port.
+		"gameaddr"
+			- Server passes the filter if the server's game address matches the specified IP or IP:port.
+
+		The following filter operations ignore the "value" part of MatchMakingKeyValuePair_t
+
+		"dedicated"
+			- Server passes the filter if it passed true to SetDedicatedServer.
+		"secure"
+			- Server passes the filter if the server is VAC-enabled.
+		"notfull"
+			- Server passes the filter if the player count is less than the reported max player count.
+		"hasplayers"
+			- Server passes the filter if the player count is greater than zero.
+		"noplayers"
+			- Server passes the filter if it doesn't have any players.
+		"linux"
+			- Server passes the filter if it's a linux server
+	*/
+
+	// Get details on a given server in the list, you can get the valid range of index
+	// values by calling GetServerCount().  You will also receive index values in 
+	// ISteamMatchmakingServerListResponse::ServerResponded() callbacks
+	virtual gameserveritem_t *GetServerDetails( HServerListRequest hRequest, int iServer ) = 0; 
+
+	// Cancel an request which is operation on the given list type.  You should call this to cancel
+	// any in-progress requests before destructing a callback object that may have been passed 
+	// to one of the above list request calls.  Not doing so may result in a crash when a callback
+	// occurs on the destructed object.
+	// Canceling a query does not release the allocated request handle.
+	// The request handle must be released using ReleaseRequest( hRequest )
+	virtual void CancelQuery( HServerListRequest hRequest ) = 0; 
+
+	// Ping every server in your list again but don't update the list of servers
+	// Query callback installed when the server list was requested will be used
+	// again to post notifications and RefreshComplete, so the callback must remain
+	// valid until another RefreshComplete is called on it or the request
+	// is released with ReleaseRequest( hRequest )
+	virtual void RefreshQuery( HServerListRequest hRequest ) = 0; 
+
+	// Returns true if the list is currently refreshing its server list
+	virtual bool IsRefreshing( HServerListRequest hRequest ) = 0; 
+
+	// How many servers in the given list, GetServerDetails above takes 0... GetServerCount() - 1
+	virtual int GetServerCount( HServerListRequest hRequest ) = 0; 
+
+	// Refresh a single server inside of a query (rather than all the servers )
+	virtual void RefreshServer( HServerListRequest hRequest, int iServer ) = 0; 
+
+
+	//-----------------------------------------------------------------------------
+	// Queries to individual servers directly via IP/Port
+	//-----------------------------------------------------------------------------
+
+	// Request updated ping time and other details from a single server
+	virtual HServerQuery PingServer( uint32 unIP, uint16 usPort, ISteamMatchmakingPingResponse *pRequestServersResponse ) = 0; 
+
+	// Request the list of players currently playing on a server
+	virtual HServerQuery PlayerDetails( uint32 unIP, uint16 usPort, ISteamMatchmakingPlayersResponse *pRequestServersResponse ) = 0;
+
+	// Request the list of rules that the server is running (See ISteamGameServer::SetKeyValue() to set the rules server side)
+	virtual HServerQuery ServerRules( uint32 unIP, uint16 usPort, ISteamMatchmakingRulesResponse *pRequestServersResponse ) = 0; 
+
+	// Cancel an outstanding Ping/Players/Rules query from above.  You should call this to cancel
+	// any in-progress requests before destructing a callback object that may have been passed 
+	// to one of the above calls to avoid crashing when callbacks occur.
+	virtual void CancelServerQuery( HServerQuery hServerQuery ) = 0; 
+};
+#define STEAMMATCHMAKINGSERVERS_INTERFACE_VERSION "SteamMatchMakingServers002"
+
+// Global interface accessor
+inline ISteamMatchmakingServers *SteamMatchmakingServers();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamMatchmakingServers *, SteamMatchmakingServers, STEAMMATCHMAKINGSERVERS_INTERFACE_VERSION );
+
+// game server flags
+const uint32 k_unFavoriteFlagNone			= 0x00;
+const uint32 k_unFavoriteFlagFavorite		= 0x01; // this game favorite entry is for the favorites list
+const uint32 k_unFavoriteFlagHistory		= 0x02; // this game favorite entry is for the history list
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Used in ChatInfo messages - fields specific to a chat member - must fit in a uint32
+//-----------------------------------------------------------------------------
+enum EChatMemberStateChange
+{
+	// Specific to joining / leaving the chatroom
+	k_EChatMemberStateChangeEntered			= 0x0001,		// This user has joined or is joining the chat room
+	k_EChatMemberStateChangeLeft			= 0x0002,		// This user has left or is leaving the chat room
+	k_EChatMemberStateChangeDisconnected	= 0x0004,		// User disconnected without leaving the chat first
+	k_EChatMemberStateChangeKicked			= 0x0008,		// User kicked
+	k_EChatMemberStateChangeBanned			= 0x0010,		// User kicked and banned
+};
+
+// returns true of the flags indicate that a user has been removed from the chat
+#define BChatMemberStateChangeRemoved( rgfChatMemberStateChangeFlags ) ( rgfChatMemberStateChangeFlags & ( k_EChatMemberStateChangeDisconnected | k_EChatMemberStateChangeLeft | k_EChatMemberStateChangeKicked | k_EChatMemberStateChangeBanned ) )
+
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for match making services for clients to get to favorites
+//			and to operate on game lobbies.
+//-----------------------------------------------------------------------------
+class ISteamGameSearch
+{
+public:
+	// =============================================================================================
+	// Game Player APIs
+
+	// a keyname and a list of comma separated values: one of which is must be found in order for the match to qualify
+	// fails if a search is currently in progress
+	virtual EGameSearchErrorCode_t AddGameSearchParams( const char *pchKeyToFind, const char *pchValuesToFind ) = 0;
+
+	// all players in lobby enter the queue and await a SearchForGameNotificationCallback_t callback. fails if another search is currently in progress
+	// if not the owner of the lobby or search already in progress this call fails
+	// periodic callbacks will be sent as queue time estimates change
+	virtual EGameSearchErrorCode_t SearchForGameWithLobby( CSteamID steamIDLobby, int nPlayerMin, int nPlayerMax ) = 0;
+
+	// user enter the queue and await a SearchForGameNotificationCallback_t callback. fails if another search is currently in progress
+	// periodic callbacks will be sent as queue time estimates change
+	virtual EGameSearchErrorCode_t SearchForGameSolo( int nPlayerMin, int nPlayerMax ) = 0;
+
+	// after receiving SearchForGameResultCallback_t, accept or decline the game
+	// multiple SearchForGameResultCallback_t will follow as players accept game until the host starts or cancels the game
+	virtual EGameSearchErrorCode_t AcceptGame() = 0;
+	virtual EGameSearchErrorCode_t DeclineGame() = 0;
+
+	// after receiving GameStartedByHostCallback_t get connection details to server
+	virtual EGameSearchErrorCode_t RetrieveConnectionDetails( CSteamID steamIDHost, char *pchConnectionDetails, int cubConnectionDetails ) = 0;
+
+	// leaves queue if still waiting
+	virtual EGameSearchErrorCode_t EndGameSearch() = 0;
+
+	// =============================================================================================
+	// Game Host APIs
+
+	// a keyname and a list of comma separated values: all the values you allow
+	virtual EGameSearchErrorCode_t SetGameHostParams( const char *pchKey, const char *pchValue ) = 0;
+
+	// set connection details for players once game is found so they can connect to this server
+	virtual EGameSearchErrorCode_t SetConnectionDetails( const char *pchConnectionDetails, int cubConnectionDetails ) = 0;
+
+	// mark server as available for more players with nPlayerMin,nPlayerMax desired
+	// accept no lobbies with playercount greater than nMaxTeamSize
+	// the set of lobbies returned must be partitionable into teams of no more than nMaxTeamSize
+	// RequestPlayersForGameNotificationCallback_t callback will be sent when the search has started
+	// multple RequestPlayersForGameResultCallback_t callbacks will follow when players are found
+	virtual EGameSearchErrorCode_t RequestPlayersForGame( int nPlayerMin, int nPlayerMax, int nMaxTeamSize ) = 0;
+
+	// accept the player list and release connection details to players
+	// players will only be given connection details and host steamid when this is called
+	// ( allows host to accept after all players confirm, some confirm, or none confirm. decision is entirely up to the host )
+	virtual EGameSearchErrorCode_t HostConfirmGameStart( uint64 ullUniqueGameID ) = 0;
+
+	// cancel request and leave the pool of game hosts looking for players
+	// if a set of players has already been sent to host, all players will receive SearchForGameHostFailedToConfirm_t
+	virtual EGameSearchErrorCode_t CancelRequestPlayersForGame() = 0;
+
+	// submit a result for one player. does not end the game. ullUniqueGameID continues to describe this game
+	virtual EGameSearchErrorCode_t SubmitPlayerResult( uint64 ullUniqueGameID, CSteamID steamIDPlayer, EPlayerResult_t EPlayerResult ) = 0;
+
+	// ends the game. no further SubmitPlayerResults for ullUniqueGameID will be accepted
+	// any future requests will provide a new ullUniqueGameID
+	virtual EGameSearchErrorCode_t EndGame( uint64 ullUniqueGameID ) = 0;
+
+};
+#define STEAMGAMESEARCH_INTERFACE_VERSION "SteamMatchGameSearch001"
+
+// Global interface accessor
+inline ISteamGameSearch *SteamGameSearch();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamGameSearch *, SteamGameSearch, STEAMGAMESEARCH_INTERFACE_VERSION );
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for quickly creating a Party with friends or acquaintances,
+//			EG from chat rooms.
+//-----------------------------------------------------------------------------
+enum ESteamPartyBeaconLocationType
+{
+	k_ESteamPartyBeaconLocationType_Invalid = 0,
+	k_ESteamPartyBeaconLocationType_ChatGroup = 1,
+
+	k_ESteamPartyBeaconLocationType_Max,
+};
+
+
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+
+
+struct SteamPartyBeaconLocation_t
+{
+	ESteamPartyBeaconLocationType m_eType;
+	uint64 m_ulLocationID;
+};
+
+enum ESteamPartyBeaconLocationData
+{
+	k_ESteamPartyBeaconLocationDataInvalid = 0,
+	k_ESteamPartyBeaconLocationDataName = 1,
+	k_ESteamPartyBeaconLocationDataIconURLSmall = 2,
+	k_ESteamPartyBeaconLocationDataIconURLMedium = 3,
+	k_ESteamPartyBeaconLocationDataIconURLLarge = 4,
+};
+
+class ISteamParties
+{
+public:
+
+	// =============================================================================================
+	// Party Client APIs
+	
+	// Enumerate any active beacons for parties you may wish to join
+	virtual uint32 GetNumActiveBeacons() = 0;
+	virtual PartyBeaconID_t GetBeaconByIndex( uint32 unIndex ) = 0;
+	virtual bool GetBeaconDetails( PartyBeaconID_t ulBeaconID, CSteamID *pSteamIDBeaconOwner, STEAM_OUT_STRUCT() SteamPartyBeaconLocation_t *pLocation, STEAM_OUT_STRING_COUNT(cchMetadata) char *pchMetadata, int cchMetadata ) = 0;
+
+	// Join an open party. Steam will reserve one beacon slot for your SteamID,
+	// and return the necessary JoinGame string for you to use to connect
+	STEAM_CALL_RESULT( JoinPartyCallback_t )
+	virtual SteamAPICall_t JoinParty( PartyBeaconID_t ulBeaconID ) = 0;
+
+	// =============================================================================================
+	// Party Host APIs
+
+	// Get a list of possible beacon locations
+	virtual bool GetNumAvailableBeaconLocations( uint32 *puNumLocations ) = 0;
+	virtual bool GetAvailableBeaconLocations( SteamPartyBeaconLocation_t *pLocationList, uint32 uMaxNumLocations ) = 0;
+
+	// Create a new party beacon and activate it in the selected location.
+	// unOpenSlots is the maximum number of users that Steam will send to you.
+	// When people begin responding to your beacon, Steam will send you
+	// PartyReservationCallback_t callbacks to let you know who is on the way.
+	STEAM_CALL_RESULT( CreateBeaconCallback_t )
+	virtual SteamAPICall_t CreateBeacon( uint32 unOpenSlots, SteamPartyBeaconLocation_t *pBeaconLocation, const char *pchConnectString, const char *pchMetadata ) = 0;
+
+	// Call this function when a user that had a reservation (see callback below) 
+	// has successfully joined your party.
+	// Steam will manage the remaining open slots automatically.
+	virtual void OnReservationCompleted( PartyBeaconID_t ulBeacon, CSteamID steamIDUser ) = 0;
+
+	// To cancel a reservation (due to timeout or user input), call this.
+	// Steam will open a new reservation slot.
+	// Note: The user may already be in-flight to your game, so it's possible they will still connect and try to join your party.
+	virtual void CancelReservation( PartyBeaconID_t ulBeacon, CSteamID steamIDUser ) = 0;
+
+	// Change the number of open beacon reservation slots.
+	// Call this if, for example, someone without a reservation joins your party (eg a friend, or via your own matchmaking system).
+	STEAM_CALL_RESULT( ChangeNumOpenSlotsCallback_t )
+	virtual SteamAPICall_t ChangeNumOpenSlots( PartyBeaconID_t ulBeacon, uint32 unOpenSlots ) = 0;
+
+	// Turn off the beacon. 
+	virtual bool DestroyBeacon( PartyBeaconID_t ulBeacon ) = 0;
+
+	// Utils
+	virtual bool GetBeaconLocationData( SteamPartyBeaconLocation_t BeaconLocation, ESteamPartyBeaconLocationData eData, STEAM_OUT_STRING_COUNT(cchDataStringOut) char *pchDataStringOut, int cchDataStringOut ) = 0;
+
+};
+#define STEAMPARTIES_INTERFACE_VERSION "SteamParties002"
+
+// Global interface accessor
+inline ISteamParties *SteamParties();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamParties *, SteamParties, STEAMPARTIES_INTERFACE_VERSION );
+
+
+//-----------------------------------------------------------------------------
+// Callbacks for ISteamMatchmaking (which go through the regular Steam callback registration system)
+
+//-----------------------------------------------------------------------------
+// Purpose: a server was added/removed from the favorites list, you should refresh now
+//-----------------------------------------------------------------------------
+struct FavoritesListChanged_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 2 };
+	uint32 m_nIP; // an IP of 0 means reload the whole list, any other value means just one server
+	uint32 m_nQueryPort;
+	uint32 m_nConnPort;
+	uint32 m_nAppID;
+	uint32 m_nFlags;
+	bool m_bAdd; // true if this is adding the entry, otherwise it is a remove
+	AccountID_t m_unAccountId;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Someone has invited you to join a Lobby
+//			normally you don't need to do anything with this, since
+//			the Steam UI will also display a '<user> has invited you to the lobby, join?' dialog
+//
+//			if the user outside a game chooses to join, your game will be launched with the parameter "+connect_lobby <64-bit lobby id>",
+//			or with the callback GameLobbyJoinRequested_t if they're already in-game
+//-----------------------------------------------------------------------------
+struct LobbyInvite_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 3 };
+
+	uint64 m_ulSteamIDUser;		// Steam ID of the person making the invite
+	uint64 m_ulSteamIDLobby;	// Steam ID of the Lobby
+	uint64 m_ulGameID;			// GameID of the Lobby
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Sent on entering a lobby, or on failing to enter
+//			m_EChatRoomEnterResponse will be set to k_EChatRoomEnterResponseSuccess on success,
+//			or a higher value on failure (see enum EChatRoomEnterResponse)
+//-----------------------------------------------------------------------------
+struct LobbyEnter_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 4 };
+
+	uint64 m_ulSteamIDLobby;							// SteamID of the Lobby you have entered
+	uint32 m_rgfChatPermissions;						// Permissions of the current user
+	bool m_bLocked;										// If true, then only invited users may join
+	uint32 m_EChatRoomEnterResponse;	// EChatRoomEnterResponse
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The lobby metadata has changed
+//			if m_ulSteamIDMember is the steamID of a lobby member, use GetLobbyMemberData() to access per-user details
+//			if m_ulSteamIDMember == m_ulSteamIDLobby, use GetLobbyData() to access lobby metadata
+//-----------------------------------------------------------------------------
+struct LobbyDataUpdate_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 5 };
+
+	uint64 m_ulSteamIDLobby;		// steamID of the Lobby
+	uint64 m_ulSteamIDMember;		// steamID of the member whose data changed, or the room itself
+	uint8 m_bSuccess;				// true if we lobby data was successfully changed; 
+									// will only be false if RequestLobbyData() was called on a lobby that no longer exists
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The lobby chat room state has changed
+//			this is usually sent when a user has joined or left the lobby
+//-----------------------------------------------------------------------------
+struct LobbyChatUpdate_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 6 };
+
+	uint64 m_ulSteamIDLobby;			// Lobby ID
+	uint64 m_ulSteamIDUserChanged;		// user who's status in the lobby just changed - can be recipient
+	uint64 m_ulSteamIDMakingChange;		// Chat member who made the change (different from SteamIDUserChange if kicking, muting, etc.)
+										// for example, if one user kicks another from the lobby, this will be set to the id of the user who initiated the kick
+	uint32 m_rgfChatMemberStateChange;	// bitfield of EChatMemberStateChange values
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: A chat message for this lobby has been sent
+//			use GetLobbyChatEntry( m_iChatID ) to retrieve the contents of this message
+//-----------------------------------------------------------------------------
+struct LobbyChatMsg_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 7 };
+
+	uint64 m_ulSteamIDLobby;			// the lobby id this is in
+	uint64 m_ulSteamIDUser;			// steamID of the user who has sent this message
+	uint8 m_eChatEntryType;			// type of message
+	uint32 m_iChatID;				// index of the chat entry to lookup
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: A game created a game for all the members of the lobby to join,
+//			as triggered by a SetLobbyGameServer()
+//			it's up to the individual clients to take action on this; the usual
+//			game behavior is to leave the lobby and connect to the specified game server
+//-----------------------------------------------------------------------------
+struct LobbyGameCreated_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 9 };
+
+	uint64 m_ulSteamIDLobby;		// the lobby we were in
+	uint64 m_ulSteamIDGameServer;	// the new game server that has been created or found for the lobby members
+	uint32 m_unIP;					// IP & Port of the game server (if any)
+	uint16 m_usPort;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Number of matching lobbies found
+//			iterate the returned lobbies with GetLobbyByIndex(), from values 0 to m_nLobbiesMatching-1
+//-----------------------------------------------------------------------------
+struct LobbyMatchList_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 10 };
+	uint32 m_nLobbiesMatching;		// Number of lobbies that matched search criteria and we have SteamIDs for
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: posted if a user is forcefully removed from a lobby
+//			can occur if a user loses connection to Steam
+//-----------------------------------------------------------------------------
+struct LobbyKicked_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 12 };
+	uint64 m_ulSteamIDLobby;			// Lobby
+	uint64 m_ulSteamIDAdmin;			// User who kicked you - possibly the ID of the lobby itself
+	uint8 m_bKickedDueToDisconnect;		// true if you were kicked from the lobby due to the user losing connection to Steam (currently always true)
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Result of our request to create a Lobby
+//			m_eResult == k_EResultOK on success
+//			at this point, the lobby has been joined and is ready for use
+//			a LobbyEnter_t callback will also be received (since the local user is joining their own lobby)
+//-----------------------------------------------------------------------------
+struct LobbyCreated_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 13 };
+	
+	EResult m_eResult;		// k_EResultOK - the lobby was successfully created
+							// k_EResultNoConnection - your Steam client doesn't have a connection to the back-end
+							// k_EResultTimeout - you the message to the Steam servers, but it didn't respond
+							// k_EResultFail - the server responded, but with an unknown internal error
+							// k_EResultAccessDenied - your game isn't set to allow lobbies, or your client does haven't rights to play the game
+							// k_EResultLimitExceeded - your game client has created too many lobbies
+
+	uint64 m_ulSteamIDLobby;		// chat room, zero if failed
+};
+
+// used by now obsolete RequestFriendsLobbiesResponse_t
+// enum { k_iCallback = k_iSteamMatchmakingCallbacks + 14 };
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Result of CheckForPSNGameBootInvite
+//			m_eResult == k_EResultOK on success
+//			at this point, the local user may not have finishing joining this lobby;
+//			game code should wait until the subsequent LobbyEnter_t callback is received
+//-----------------------------------------------------------------------------
+struct PSNGameBootInviteResult_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 15 };
+
+	bool m_bGameBootInviteExists;
+	CSteamID m_steamIDLobby;		// Should be valid if m_bGameBootInviteExists == true
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Result of our request to create a Lobby
+//			m_eResult == k_EResultOK on success
+//			at this point, the lobby has been joined and is ready for use
+//			a LobbyEnter_t callback will also be received (since the local user is joining their own lobby)
+//-----------------------------------------------------------------------------
+struct FavoritesListAccountsUpdated_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 16 };
+	
+	EResult m_eResult;
+};
+
+
+
+//-----------------------------------------------------------------------------
+// Callbacks for ISteamGameSearch (which go through the regular Steam callback registration system)
+
+struct SearchForGameProgressCallback_t
+{
+	enum { k_iCallback = k_iSteamGameSearchCallbacks + 1 };
+
+	uint64  m_ullSearchID;	// all future callbacks referencing this search will include this Search ID
+
+	EResult m_eResult; // if search has started this result will be k_EResultOK, any other value indicates search has failed to start or has terminated
+	CSteamID m_lobbyID; // lobby ID if lobby search, invalid steamID otherwise
+	CSteamID m_steamIDEndedSearch; // if search was terminated, steamID that terminated search
+
+	int32	m_nSecondsRemainingEstimate;
+	int32	m_cPlayersSearching;
+};
+
+// notification to all players searching that a game has been found
+struct SearchForGameResultCallback_t
+{
+	enum { k_iCallback = k_iSteamGameSearchCallbacks + 2 };
+
+	uint64  m_ullSearchID;
+
+	EResult m_eResult; // if game/host was lost this will be an error value
+
+	// if m_bGameFound is true the following are non-zero
+	int32 m_nCountPlayersInGame;
+	int32 m_nCountAcceptedGame;
+	// if m_steamIDHost is valid the host has started the game
+	CSteamID m_steamIDHost;
+	bool m_bFinalCallback;
+};
+
+
+//-----------------------------------------------------------------------------
+// ISteamGameSearch : Game Host API callbacks
+
+// callback from RequestPlayersForGame when the matchmaking service has started or ended search
+// callback will also follow a call from CancelRequestPlayersForGame - m_bSearchInProgress will be false
+struct RequestPlayersForGameProgressCallback_t
+{
+	enum { k_iCallback = k_iSteamGameSearchCallbacks + 11 };
+
+	EResult m_eResult;		// m_ullSearchID will be non-zero if this is k_EResultOK
+	uint64  m_ullSearchID; 	// all future callbacks referencing this search will include this Search ID
+};
+
+// callback from RequestPlayersForGame
+// one of these will be sent per player 
+// followed by additional callbacks when players accept or decline the game
+struct RequestPlayersForGameResultCallback_t
+{
+	enum { k_iCallback = k_iSteamGameSearchCallbacks + 12 };
+
+	EResult m_eResult;		// m_ullSearchID will be non-zero if this is k_EResultOK
+	uint64  m_ullSearchID;
+
+	CSteamID m_SteamIDPlayerFound; // player steamID
+	CSteamID m_SteamIDLobby;	// if the player is in a lobby, the lobby ID
+	enum PlayerAcceptState_t
+	{
+		k_EStateUnknown = 0,
+		k_EStatePlayerAccepted = 1,
+		k_EStatePlayerDeclined = 2,
+	};
+	PlayerAcceptState_t m_ePlayerAcceptState;
+	int32 m_nPlayerIndex;
+	int32 m_nTotalPlayersFound;		// expect this many callbacks at minimum
+	int32 m_nTotalPlayersAcceptedGame;
+	int32 m_nSuggestedTeamIndex;
+	uint64 m_ullUniqueGameID;
+};
+
+
+struct RequestPlayersForGameFinalResultCallback_t
+{
+	enum { k_iCallback = k_iSteamGameSearchCallbacks + 13 };
+
+	EResult m_eResult;
+	uint64  m_ullSearchID;
+	uint64 m_ullUniqueGameID;
+};
+
+
+
+// this callback confirms that results were received by the matchmaking service for this player
+struct SubmitPlayerResultResultCallback_t
+{
+	enum { k_iCallback = k_iSteamGameSearchCallbacks + 14 };
+
+	EResult m_eResult;
+	uint64 ullUniqueGameID;
+	CSteamID steamIDPlayer;
+};
+
+
+// this callback confirms that the game is recorded as complete on the matchmaking service
+// the next call to RequestPlayersForGame will generate a new unique game ID
+struct EndGameResultCallback_t
+{
+	enum { k_iCallback = k_iSteamGameSearchCallbacks + 15 };
+
+	EResult m_eResult;
+	uint64 ullUniqueGameID;
+};
+
+
+// Steam has responded to the user request to join a party via the given Beacon ID.
+// If successful, the connect string contains game-specific instructions to connect
+// to the game with that party.
+struct JoinPartyCallback_t
+{
+	enum { k_iCallback = k_iSteamPartiesCallbacks + 1 };
+
+	EResult m_eResult;
+	PartyBeaconID_t m_ulBeaconID;
+	CSteamID m_SteamIDBeaconOwner;
+	char m_rgchConnectString[256];
+};
+
+// Response to CreateBeacon request. If successful, the beacon ID is provided.
+struct CreateBeaconCallback_t
+{
+	enum { k_iCallback = k_iSteamPartiesCallbacks + 2 };
+
+	EResult m_eResult;
+	PartyBeaconID_t m_ulBeaconID;
+};
+
+// Someone has used the beacon to join your party - they are in-flight now
+// and we've reserved one of the open slots for them.
+// You should confirm when they join your party by calling OnReservationCompleted().
+// Otherwise, Steam may timeout their reservation eventually.
+struct ReservationNotificationCallback_t
+{
+	enum { k_iCallback = k_iSteamPartiesCallbacks + 3 };
+
+	PartyBeaconID_t m_ulBeaconID;
+	CSteamID m_steamIDJoiner;
+};
+ 
+// Response to ChangeNumOpenSlots call
+struct ChangeNumOpenSlotsCallback_t
+{
+	enum { k_iCallback = k_iSteamPartiesCallbacks + 4 };
+
+	EResult m_eResult;
+};
+
+// The list of possible Party beacon locations has changed
+struct AvailableBeaconLocationsUpdated_t
+{
+	enum { k_iCallback = k_iSteamPartiesCallbacks + 5 };
+};
+
+// The list of active beacons may have changed
+struct ActiveBeaconsUpdated_t
+{
+	enum { k_iCallback = k_iSteamPartiesCallbacks + 6 };
+};
+
+
+#pragma pack( pop )
+
+
+#endif // ISTEAMMATCHMAKING

--- a/lsteamclient/steamworks_sdk_148a/isteammusic.h
+++ b/lsteamclient/steamworks_sdk_148a/isteammusic.h
@@ -1,0 +1,71 @@
+//============ Copyright (c) Valve Corporation, All rights reserved. ============
+
+#ifndef ISTEAMMUSIC_H
+#define ISTEAMMUSIC_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+enum AudioPlayback_Status
+{
+	AudioPlayback_Undefined = 0, 
+	AudioPlayback_Playing = 1,
+	AudioPlayback_Paused = 2,
+	AudioPlayback_Idle = 3
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions to control music playback in the steam client
+//-----------------------------------------------------------------------------
+class ISteamMusic
+{
+public:
+	virtual bool BIsEnabled() = 0;
+	virtual bool BIsPlaying() = 0;
+	
+	virtual AudioPlayback_Status GetPlaybackStatus() = 0; 
+
+	virtual void Play() = 0;
+	virtual void Pause() = 0;
+	virtual void PlayPrevious() = 0;
+	virtual void PlayNext() = 0;
+
+	// volume is between 0.0 and 1.0
+	virtual void SetVolume( float flVolume ) = 0;
+	virtual float GetVolume() = 0;
+	
+};
+
+#define STEAMMUSIC_INTERFACE_VERSION "STEAMMUSIC_INTERFACE_VERSION001"
+
+// Global interface accessor
+inline ISteamMusic *SteamMusic();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamMusic *, SteamMusic, STEAMMUSIC_INTERFACE_VERSION );
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+
+
+STEAM_CALLBACK_BEGIN( PlaybackStatusHasChanged_t, k_iSteamMusicCallbacks + 1 )
+STEAM_CALLBACK_END(0)
+
+STEAM_CALLBACK_BEGIN( VolumeHasChanged_t, k_iSteamMusicCallbacks + 2 )
+ 	STEAM_CALLBACK_MEMBER( 0,	float, m_flNewVolume )
+STEAM_CALLBACK_END(1)
+
+#pragma pack( pop )
+
+
+#endif // #define ISTEAMMUSIC_H

--- a/lsteamclient/steamworks_sdk_148a/isteammusicremote.h
+++ b/lsteamclient/steamworks_sdk_148a/isteammusicremote.h
@@ -1,0 +1,133 @@
+//============ Copyright (c) Valve Corporation, All rights reserved. ============
+
+#ifndef ISTEAMMUSICREMOTE_H
+#define ISTEAMMUSICREMOTE_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+#include "isteammusic.h"
+
+#define k_SteamMusicNameMaxLength 255
+#define k_SteamMusicPNGMaxLength 65535
+ 
+
+class ISteamMusicRemote
+{
+public: 
+	// Service Definition
+ 	virtual bool RegisterSteamMusicRemote( const char *pchName ) = 0;
+ 	virtual bool DeregisterSteamMusicRemote() = 0;
+	virtual bool BIsCurrentMusicRemote() = 0;
+	virtual bool BActivationSuccess( bool bValue ) = 0;
+
+	virtual bool SetDisplayName( const char *pchDisplayName ) = 0;
+	virtual bool SetPNGIcon_64x64( void *pvBuffer, uint32 cbBufferLength ) = 0;
+	
+	// Abilities for the user interface
+	virtual bool EnablePlayPrevious(bool bValue) = 0;
+	virtual bool EnablePlayNext( bool bValue ) = 0;
+	virtual bool EnableShuffled( bool bValue ) = 0;
+	virtual bool EnableLooped( bool bValue ) = 0;
+	virtual bool EnableQueue( bool bValue ) = 0;
+	virtual bool EnablePlaylists( bool bValue ) = 0;
+
+	// Status
+ 	virtual bool UpdatePlaybackStatus( AudioPlayback_Status nStatus ) = 0;
+	virtual bool UpdateShuffled( bool bValue ) = 0;
+	virtual bool UpdateLooped( bool bValue ) = 0;
+	virtual bool UpdateVolume( float flValue ) = 0; // volume is between 0.0 and 1.0
+
+	// Current Entry
+	virtual bool CurrentEntryWillChange() = 0;
+	virtual bool CurrentEntryIsAvailable( bool bAvailable ) = 0;
+	virtual bool UpdateCurrentEntryText( const char *pchText ) = 0;
+	virtual bool UpdateCurrentEntryElapsedSeconds( int nValue ) = 0;
+	virtual bool UpdateCurrentEntryCoverArt( void *pvBuffer, uint32 cbBufferLength ) = 0;
+	virtual bool CurrentEntryDidChange() = 0;
+
+	// Queue
+	virtual bool QueueWillChange() = 0;
+	virtual bool ResetQueueEntries() = 0;
+	virtual bool SetQueueEntry( int nID, int nPosition, const char *pchEntryText ) = 0;
+	virtual bool SetCurrentQueueEntry( int nID ) = 0;
+	virtual bool QueueDidChange() = 0;
+
+	// Playlist
+	virtual bool PlaylistWillChange() = 0;
+	virtual bool ResetPlaylistEntries() = 0;
+	virtual bool SetPlaylistEntry( int nID, int nPosition, const char *pchEntryText ) = 0;
+	virtual bool SetCurrentPlaylistEntry( int nID ) = 0;
+	virtual bool PlaylistDidChange() = 0;
+};
+
+#define STEAMMUSICREMOTE_INTERFACE_VERSION "STEAMMUSICREMOTE_INTERFACE_VERSION001"
+
+// Global interface accessor
+inline ISteamMusicRemote *SteamMusicRemote();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamMusicRemote *, SteamMusicRemote, STEAMMUSICREMOTE_INTERFACE_VERSION );
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+
+
+STEAM_CALLBACK_BEGIN( MusicPlayerRemoteWillActivate_t, k_iSteamMusicRemoteCallbacks + 1)
+STEAM_CALLBACK_END(0)
+
+STEAM_CALLBACK_BEGIN( MusicPlayerRemoteWillDeactivate_t, k_iSteamMusicRemoteCallbacks + 2 )
+STEAM_CALLBACK_END(0)
+
+STEAM_CALLBACK_BEGIN( MusicPlayerRemoteToFront_t, k_iSteamMusicRemoteCallbacks + 3 )
+STEAM_CALLBACK_END(0)
+
+STEAM_CALLBACK_BEGIN( MusicPlayerWillQuit_t, k_iSteamMusicRemoteCallbacks + 4 )
+STEAM_CALLBACK_END(0)
+
+STEAM_CALLBACK_BEGIN( MusicPlayerWantsPlay_t, k_iSteamMusicRemoteCallbacks + 5 )
+STEAM_CALLBACK_END(0)
+
+STEAM_CALLBACK_BEGIN( MusicPlayerWantsPause_t, k_iSteamMusicRemoteCallbacks + 6 )
+STEAM_CALLBACK_END(0)
+
+STEAM_CALLBACK_BEGIN( MusicPlayerWantsPlayPrevious_t, k_iSteamMusicRemoteCallbacks + 7 )
+STEAM_CALLBACK_END(0)
+
+STEAM_CALLBACK_BEGIN( MusicPlayerWantsPlayNext_t, k_iSteamMusicRemoteCallbacks + 8 )
+STEAM_CALLBACK_END(0)
+
+STEAM_CALLBACK_BEGIN( MusicPlayerWantsShuffled_t, k_iSteamMusicRemoteCallbacks + 9 )
+	STEAM_CALLBACK_MEMBER( 0, bool, m_bShuffled )
+STEAM_CALLBACK_END(1)
+
+STEAM_CALLBACK_BEGIN( MusicPlayerWantsLooped_t, k_iSteamMusicRemoteCallbacks + 10 )
+	STEAM_CALLBACK_MEMBER(0, bool, m_bLooped )
+STEAM_CALLBACK_END(1)
+
+STEAM_CALLBACK_BEGIN( MusicPlayerWantsVolume_t, k_iSteamMusicCallbacks + 11 )
+	STEAM_CALLBACK_MEMBER(0, float, m_flNewVolume)
+STEAM_CALLBACK_END(1)
+
+STEAM_CALLBACK_BEGIN( MusicPlayerSelectsQueueEntry_t, k_iSteamMusicCallbacks + 12 )
+	STEAM_CALLBACK_MEMBER(0, int, nID )
+STEAM_CALLBACK_END(1)
+
+STEAM_CALLBACK_BEGIN( MusicPlayerSelectsPlaylistEntry_t, k_iSteamMusicCallbacks + 13 )
+	STEAM_CALLBACK_MEMBER(0, int, nID )
+STEAM_CALLBACK_END(1)
+
+STEAM_CALLBACK_BEGIN( MusicPlayerWantsPlayingRepeatStatus_t, k_iSteamMusicRemoteCallbacks + 14 )
+	STEAM_CALLBACK_MEMBER(0, int, m_nPlayingRepeatStatus )
+STEAM_CALLBACK_END(1)
+
+#pragma pack( pop )
+
+
+
+#endif // #define ISTEAMMUSICREMOTE_H

--- a/lsteamclient/steamworks_sdk_148a/isteamnetworking.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamnetworking.h
@@ -1,0 +1,325 @@
+//====== Copyright © 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to steam managing network connections between game clients & servers
+//
+//=============================================================================
+
+#ifndef ISTEAMNETWORKING
+#define ISTEAMNETWORKING
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+
+// list of possible errors returned by SendP2PPacket() API
+// these will be posted in the P2PSessionConnectFail_t callback
+enum EP2PSessionError
+{
+	k_EP2PSessionErrorNone = 0,
+	k_EP2PSessionErrorNotRunningApp = 1,			// target is not running the same game
+	k_EP2PSessionErrorNoRightsToApp = 2,			// local user doesn't own the app that is running
+	k_EP2PSessionErrorDestinationNotLoggedIn = 3,	// target user isn't connected to Steam
+	k_EP2PSessionErrorTimeout = 4,					// target isn't responding, perhaps not calling AcceptP2PSessionWithUser()
+													// corporate firewalls can also block this (NAT traversal is not firewall traversal)
+													// make sure that UDP ports 3478, 4379, and 4380 are open in an outbound direction
+	k_EP2PSessionErrorMax = 5
+};
+
+// SendP2PPacket() send types
+// Typically k_EP2PSendUnreliable is what you want for UDP-like packets, k_EP2PSendReliable for TCP-like packets
+enum EP2PSend
+{
+	// Basic UDP send. Packets can't be bigger than 1200 bytes (your typical MTU size). Can be lost, or arrive out of order (rare).
+	// The sending API does have some knowledge of the underlying connection, so if there is no NAT-traversal accomplished or
+	// there is a recognized adjustment happening on the connection, the packet will be batched until the connection is open again.
+	k_EP2PSendUnreliable = 0,
+
+	// As above, but if the underlying p2p connection isn't yet established the packet will just be thrown away. Using this on the first
+	// packet sent to a remote host almost guarantees the packet will be dropped.
+	// This is only really useful for kinds of data that should never buffer up, i.e. voice payload packets
+	k_EP2PSendUnreliableNoDelay = 1,
+
+	// Reliable message send. Can send up to 1MB of data in a single message. 
+	// Does fragmentation/re-assembly of messages under the hood, as well as a sliding window for efficient sends of large chunks of data. 
+	k_EP2PSendReliable = 2,
+
+	// As above, but applies the Nagle algorithm to the send - sends will accumulate 
+	// until the current MTU size (typically ~1200 bytes, but can change) or ~200ms has passed (Nagle algorithm). 
+	// Useful if you want to send a set of smaller messages but have the coalesced into a single packet
+	// Since the reliable stream is all ordered, you can do several small message sends with k_EP2PSendReliableWithBuffering and then
+	// do a normal k_EP2PSendReliable to force all the buffered data to be sent.
+	k_EP2PSendReliableWithBuffering = 3,
+
+};
+
+
+// connection state to a specified user, returned by GetP2PSessionState()
+// this is under-the-hood info about what's going on with a SendP2PPacket(), shouldn't be needed except for debuggin
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+struct P2PSessionState_t
+{
+	uint8 m_bConnectionActive;		// true if we've got an active open connection
+	uint8 m_bConnecting;			// true if we're currently trying to establish a connection
+	uint8 m_eP2PSessionError;		// last error recorded (see enum above)
+	uint8 m_bUsingRelay;			// true if it's going through a relay server (TURN)
+	int32 m_nBytesQueuedForSend;
+	int32 m_nPacketsQueuedForSend;
+	uint32 m_nRemoteIP;				// potential IP:Port of remote host. Could be TURN server. 
+	uint16 m_nRemotePort;			// Only exists for compatibility with older authentication api's
+};
+#pragma pack( pop )
+
+
+// handle to a socket
+typedef uint32 SNetSocket_t;		// CreateP2PConnectionSocket()
+typedef uint32 SNetListenSocket_t;	// CreateListenSocket()
+
+// connection progress indicators, used by CreateP2PConnectionSocket()
+enum ESNetSocketState
+{
+	k_ESNetSocketStateInvalid = 0,						
+
+	// communication is valid
+	k_ESNetSocketStateConnected = 1,				
+	
+	// states while establishing a connection
+	k_ESNetSocketStateInitiated = 10,				// the connection state machine has started
+
+	// p2p connections
+	k_ESNetSocketStateLocalCandidatesFound = 11,	// we've found our local IP info
+	k_ESNetSocketStateReceivedRemoteCandidates = 12,// we've received information from the remote machine, via the Steam back-end, about their IP info
+
+	// direct connections
+	k_ESNetSocketStateChallengeHandshake = 15,		// we've received a challenge packet from the server
+
+	// failure states
+	k_ESNetSocketStateDisconnecting = 21,			// the API shut it down, and we're in the process of telling the other end	
+	k_ESNetSocketStateLocalDisconnect = 22,			// the API shut it down, and we've completed shutdown
+	k_ESNetSocketStateTimeoutDuringConnect = 23,	// we timed out while trying to creating the connection
+	k_ESNetSocketStateRemoteEndDisconnected = 24,	// the remote end has disconnected from us
+	k_ESNetSocketStateConnectionBroken = 25,		// connection has been broken; either the other end has disappeared or our local network connection has broke
+
+};
+
+// describes how the socket is currently connected
+enum ESNetSocketConnectionType
+{
+	k_ESNetSocketConnectionTypeNotConnected = 0,
+	k_ESNetSocketConnectionTypeUDP = 1,
+	k_ESNetSocketConnectionTypeUDPRelay = 2,
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for making connections and sending data between clients,
+//			traversing NAT's where possible
+//-----------------------------------------------------------------------------
+class ISteamNetworking
+{
+public:
+	////////////////////////////////////////////////////////////////////////////////////////////
+	//
+	// UDP-style (connectionless) networking interface.  These functions send messages using
+	// an API organized around the destination.  Reliable and unreliable messages are supported.
+	//
+	// For a more TCP-style interface (meaning you have a connection handle), see the functions below.
+	// Both interface styles can send both reliable and unreliable messages.
+	//
+	// Automatically establishes NAT-traversing or Relay server connections
+
+	// Sends a P2P packet to the specified user
+	// UDP-like, unreliable and a max packet size of 1200 bytes
+	// the first packet send may be delayed as the NAT-traversal code runs
+	// if we can't get through to the user, an error will be posted via the callback P2PSessionConnectFail_t
+	// see EP2PSend enum above for the descriptions of the different ways of sending packets
+	//
+	// nChannel is a routing number you can use to help route message to different systems 	- you'll have to call ReadP2PPacket() 
+	// with the same channel number in order to retrieve the data on the other end
+	// using different channels to talk to the same user will still use the same underlying p2p connection, saving on resources
+	virtual bool SendP2PPacket( CSteamID steamIDRemote, const void *pubData, uint32 cubData, EP2PSend eP2PSendType, int nChannel = 0 ) = 0;
+
+	// returns true if any data is available for read, and the amount of data that will need to be read
+	virtual bool IsP2PPacketAvailable( uint32 *pcubMsgSize, int nChannel = 0 ) = 0;
+
+	// reads in a packet that has been sent from another user via SendP2PPacket()
+	// returns the size of the message and the steamID of the user who sent it in the last two parameters
+	// if the buffer passed in is too small, the message will be truncated
+	// this call is not blocking, and will return false if no data is available
+	virtual bool ReadP2PPacket( void *pubDest, uint32 cubDest, uint32 *pcubMsgSize, CSteamID *psteamIDRemote, int nChannel = 0 ) = 0;
+
+	// AcceptP2PSessionWithUser() should only be called in response to a P2PSessionRequest_t callback
+	// P2PSessionRequest_t will be posted if another user tries to send you a packet that you haven't talked to yet
+	// if you don't want to talk to the user, just ignore the request
+	// if the user continues to send you packets, another P2PSessionRequest_t will be posted periodically
+	// this may be called multiple times for a single user
+	// (if you've called SendP2PPacket() on the other user, this implicitly accepts the session request)
+	virtual bool AcceptP2PSessionWithUser( CSteamID steamIDRemote ) = 0;
+
+	// call CloseP2PSessionWithUser() when you're done talking to a user, will free up resources under-the-hood
+	// if the remote user tries to send data to you again, another P2PSessionRequest_t callback will be posted
+	virtual bool CloseP2PSessionWithUser( CSteamID steamIDRemote ) = 0;
+
+	// call CloseP2PChannelWithUser() when you're done talking to a user on a specific channel. Once all channels
+	// open channels to a user have been closed, the open session to the user will be closed and new data from this
+	// user will trigger a P2PSessionRequest_t callback
+	virtual bool CloseP2PChannelWithUser( CSteamID steamIDRemote, int nChannel ) = 0;
+
+	// fills out P2PSessionState_t structure with details about the underlying connection to the user
+	// should only needed for debugging purposes
+	// returns false if no connection exists to the specified user
+	virtual bool GetP2PSessionState( CSteamID steamIDRemote, P2PSessionState_t *pConnectionState ) = 0;
+
+	// Allow P2P connections to fall back to being relayed through the Steam servers if a direct connection
+	// or NAT-traversal cannot be established. Only applies to connections created after setting this value,
+	// or to existing connections that need to automatically reconnect after this value is set.
+	//
+	// P2P packet relay is allowed by default
+	virtual bool AllowP2PPacketRelay( bool bAllow ) = 0;
+
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	//
+	// LISTEN / CONNECT connection-oriented interface functions
+	//
+	// These functions are more like a client-server TCP API.  One side is the "server"
+	// and "listens" for incoming connections, which then must be "accepted."  The "client"
+	// initiates a connection by "connecting."  Sending and receiving is done through a
+	// connection handle.
+	//
+	// For a more UDP-style interface, where you do not track connection handles but
+	// simply send messages to a SteamID, use the UDP-style functions above.
+	//
+	// Both methods can send both reliable and unreliable methods.
+	//
+	////////////////////////////////////////////////////////////////////////////////////////////
+
+
+	// creates a socket and listens others to connect
+	// will trigger a SocketStatusCallback_t callback on another client connecting
+	// nVirtualP2PPort is the unique ID that the client will connect to, in case you have multiple ports
+	//		this can usually just be 0 unless you want multiple sets of connections
+	// unIP is the local IP address to bind to
+	//		pass in 0 if you just want the default local IP
+	// unPort is the port to use
+	//		pass in 0 if you don't want users to be able to connect via IP/Port, but expect to be always peer-to-peer connections only
+	virtual SNetListenSocket_t CreateListenSocket( int nVirtualP2PPort, SteamIPAddress_t nIP, uint16 nPort, bool bAllowUseOfPacketRelay ) = 0;
+
+	// creates a socket and begin connection to a remote destination
+	// can connect via a known steamID (client or game server), or directly to an IP
+	// on success will trigger a SocketStatusCallback_t callback
+	// on failure or timeout will trigger a SocketStatusCallback_t callback with a failure code in m_eSNetSocketState
+	virtual SNetSocket_t CreateP2PConnectionSocket( CSteamID steamIDTarget, int nVirtualPort, int nTimeoutSec, bool bAllowUseOfPacketRelay ) = 0;
+	virtual SNetSocket_t CreateConnectionSocket( SteamIPAddress_t nIP, uint16 nPort, int nTimeoutSec ) = 0;
+
+	// disconnects the connection to the socket, if any, and invalidates the handle
+	// any unread data on the socket will be thrown away
+	// if bNotifyRemoteEnd is set, socket will not be completely destroyed until the remote end acknowledges the disconnect
+	virtual bool DestroySocket( SNetSocket_t hSocket, bool bNotifyRemoteEnd ) = 0;
+	// destroying a listen socket will automatically kill all the regular sockets generated from it
+	virtual bool DestroyListenSocket( SNetListenSocket_t hSocket, bool bNotifyRemoteEnd ) = 0;
+
+	// sending data
+	// must be a handle to a connected socket
+	// data is all sent via UDP, and thus send sizes are limited to 1200 bytes; after this, many routers will start dropping packets
+	// use the reliable flag with caution; although the resend rate is pretty aggressive,
+	// it can still cause stalls in receiving data (like TCP)
+	virtual bool SendDataOnSocket( SNetSocket_t hSocket, void *pubData, uint32 cubData, bool bReliable ) = 0;
+
+	// receiving data
+	// returns false if there is no data remaining
+	// fills out *pcubMsgSize with the size of the next message, in bytes
+	virtual bool IsDataAvailableOnSocket( SNetSocket_t hSocket, uint32 *pcubMsgSize ) = 0; 
+
+	// fills in pubDest with the contents of the message
+	// messages are always complete, of the same size as was sent (i.e. packetized, not streaming)
+	// if *pcubMsgSize < cubDest, only partial data is written
+	// returns false if no data is available
+	virtual bool RetrieveDataFromSocket( SNetSocket_t hSocket, void *pubDest, uint32 cubDest, uint32 *pcubMsgSize ) = 0; 
+
+	// checks for data from any socket that has been connected off this listen socket
+	// returns false if there is no data remaining
+	// fills out *pcubMsgSize with the size of the next message, in bytes
+	// fills out *phSocket with the socket that data is available on
+	virtual bool IsDataAvailable( SNetListenSocket_t hListenSocket, uint32 *pcubMsgSize, SNetSocket_t *phSocket ) = 0;
+
+	// retrieves data from any socket that has been connected off this listen socket
+	// fills in pubDest with the contents of the message
+	// messages are always complete, of the same size as was sent (i.e. packetized, not streaming)
+	// if *pcubMsgSize < cubDest, only partial data is written
+	// returns false if no data is available
+	// fills out *phSocket with the socket that data is available on
+	virtual bool RetrieveData( SNetListenSocket_t hListenSocket, void *pubDest, uint32 cubDest, uint32 *pcubMsgSize, SNetSocket_t *phSocket ) = 0;
+
+	// returns information about the specified socket, filling out the contents of the pointers
+	virtual bool GetSocketInfo( SNetSocket_t hSocket, CSteamID *pSteamIDRemote, int *peSocketStatus, SteamIPAddress_t *punIPRemote, uint16 *punPortRemote ) = 0;
+
+	// returns which local port the listen socket is bound to
+	// *pnIP and *pnPort will be 0 if the socket is set to listen for P2P connections only
+	virtual bool GetListenSocketInfo( SNetListenSocket_t hListenSocket, SteamIPAddress_t *pnIP, uint16 *pnPort ) = 0;
+
+	// returns true to describe how the socket ended up connecting
+	virtual ESNetSocketConnectionType GetSocketConnectionType( SNetSocket_t hSocket ) = 0;
+
+	// max packet size, in bytes
+	virtual int GetMaxPacketSize( SNetSocket_t hSocket ) = 0;
+};
+#define STEAMNETWORKING_INTERFACE_VERSION "SteamNetworking006"
+
+// Global interface accessor
+inline ISteamNetworking *SteamNetworking();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamNetworking *, SteamNetworking, STEAMNETWORKING_INTERFACE_VERSION );
+
+// Global accessor for the gameserver client
+inline ISteamNetworking *SteamGameServerNetworking();
+STEAM_DEFINE_GAMESERVER_INTERFACE_ACCESSOR( ISteamNetworking *, SteamGameServerNetworking, STEAMNETWORKING_INTERFACE_VERSION );
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+
+// callback notification - a user wants to talk to us over the P2P channel via the SendP2PPacket() API
+// in response, a call to AcceptP2PPacketsFromUser() needs to be made, if you want to talk with them
+struct P2PSessionRequest_t
+{ 
+	enum { k_iCallback = k_iSteamNetworkingCallbacks + 2 };
+	CSteamID m_steamIDRemote;			// user who wants to talk to us
+};
+
+
+// callback notification - packets can't get through to the specified user via the SendP2PPacket() API
+// all packets queued packets unsent at this point will be dropped
+// further attempts to send will retry making the connection (but will be dropped if we fail again)
+struct P2PSessionConnectFail_t
+{ 
+	enum { k_iCallback = k_iSteamNetworkingCallbacks + 3 };
+	CSteamID m_steamIDRemote;			// user we were sending packets to
+	uint8 m_eP2PSessionError;			// EP2PSessionError indicating why we're having trouble
+};
+
+
+// callback notification - status of a socket has changed
+// used as part of the CreateListenSocket() / CreateP2PConnectionSocket() 
+struct SocketStatusCallback_t
+{ 
+	enum { k_iCallback = k_iSteamNetworkingCallbacks + 1 };
+	SNetSocket_t m_hSocket;				// the socket used to send/receive data to the remote host
+	SNetListenSocket_t m_hListenSocket;	// this is the server socket that we were listening on; NULL if this was an outgoing connection
+	CSteamID m_steamIDRemote;			// remote steamID we have connected to, if it has one
+	int m_eSNetSocketState;				// socket state, ESNetSocketState
+};
+
+#pragma pack( pop )
+
+#endif // ISTEAMNETWORKING

--- a/lsteamclient/steamworks_sdk_148a/isteamnetworkingsockets.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamnetworkingsockets.h
@@ -1,0 +1,858 @@
+//====== Copyright Valve Corporation, All rights reserved. ====================
+//
+// Networking API similar to Berkeley sockets, but for games.
+// - connection-oriented API (like TCP, not UDP)
+// - but unlike TCP, it's message-oriented, not stream-oriented
+// - mix of reliable and unreliable messages
+// - fragmentation and reassembly
+// - Supports connectivity over plain UDPv4
+// - Also supports SDR ("Steam Datagram Relay") connections, which are
+//   addressed by SteamID.  There is a "P2P" use case and also a "hosted
+//   dedicated server" use case.
+//
+//=============================================================================
+
+#ifndef ISTEAMNETWORKINGSOCKETS
+#define ISTEAMNETWORKINGSOCKETS
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steamnetworkingtypes.h"
+
+class ISteamNetworkingSocketsCallbacks;
+struct SteamNetAuthenticationStatus_t;
+class ISteamNetworkingConnectionCustomSignaling;
+class ISteamNetworkingCustomSignalingRecvContext;
+
+//-----------------------------------------------------------------------------
+/// Lower level networking interface that more closely mirrors the standard
+/// Berkeley sockets model.  Sockets are hard!  You should probably only use
+/// this interface under the existing circumstances:
+///
+/// - You have an existing socket-based codebase you want to port, or coexist with.
+/// - You want to be able to connect based on IP address, rather than (just) Steam ID.
+/// - You need low-level control of bandwidth utilization, when to drop packets, etc.
+///
+/// Note that neither of the terms "connection" and "socket" will correspond
+/// one-to-one with an underlying UDP socket.  An attempt has been made to
+/// keep the semantics as similar to the standard socket model when appropriate,
+/// but some deviations do exist.
+class ISteamNetworkingSockets
+{
+public:
+
+	/// Creates a "server" socket that listens for clients to connect to by 
+	/// calling ConnectByIPAddress, over ordinary UDP (IPv4 or IPv6)
+	///
+	/// You must select a specific local port to listen on and set it
+	/// the port field of the local address.
+	///
+	/// Usually you will set the IP portion of the address to zero (SteamNetworkingIPAddr::Clear()).
+	/// This means that you will not bind to any particular local interface (i.e. the same
+	/// as INADDR_ANY in plain socket code).  Furthermore, if possible the socket will be bound
+	/// in "dual stack" mode, which means that it can accept both IPv4 and IPv6 client connections.
+	/// If you really do wish to bind a particular interface, then set the local address to the
+	/// appropriate IPv4 or IPv6 IP.
+	///
+	/// If you need to set any initial config options, pass them here.  See
+	/// SteamNetworkingConfigValue_t for more about why this is preferable to
+	/// setting the options "immediately" after creation.
+	///
+	/// When a client attempts to connect, a SteamNetConnectionStatusChangedCallback_t
+	/// will be posted.  The connection will be in the connecting state.
+	virtual HSteamListenSocket CreateListenSocketIP( const SteamNetworkingIPAddr &localAddress, int nOptions, const SteamNetworkingConfigValue_t *pOptions ) = 0;
+
+	/// Creates a connection and begins talking to a "server" over UDP at the
+	/// given IPv4 or IPv6 address.  The remote host must be listening with a
+	/// matching call to CreateListenSocketIP on the specified port.
+	///
+	/// A SteamNetConnectionStatusChangedCallback_t callback will be triggered when we start
+	/// connecting, and then another one on either timeout or successful connection.
+	///
+	/// If the server does not have any identity configured, then their network address
+	/// will be the only identity in use.  Or, the network host may provide a platform-specific
+	/// identity with or without a valid certificate to authenticate that identity.  (These
+	/// details will be contained in the SteamNetConnectionStatusChangedCallback_t.)  It's
+	/// up to your application to decide whether to allow the connection.
+	///
+	/// By default, all connections will get basic encryption sufficient to prevent
+	/// casual eavesdropping.  But note that without certificates (or a shared secret
+	/// distributed through some other out-of-band mechanism), you don't have any
+	/// way of knowing who is actually on the other end, and thus are vulnerable to
+	/// man-in-the-middle attacks.
+	///
+	/// If you need to set any initial config options, pass them here.  See
+	/// SteamNetworkingConfigValue_t for more about why this is preferable to
+	/// setting the options "immediately" after creation.
+	virtual HSteamNetConnection ConnectByIPAddress( const SteamNetworkingIPAddr &address, int nOptions, const SteamNetworkingConfigValue_t *pOptions ) = 0;
+
+#ifdef STEAMNETWORKINGSOCKETS_ENABLE_SDR
+	/// Like CreateListenSocketIP, but clients will connect using ConnectP2P
+	///
+	/// nVirtualPort specifies how clients can connect to this socket using
+	/// ConnectP2P.  It's very common for applications to only have one listening socket;
+	/// in that case, use zero.  If you need to open multiple listen sockets and have clients
+	/// be able to connect to one or the other, then nVirtualPort should be a small integer (<1000)
+	/// unique to each listen socket you create.
+	///
+	/// If you use this, you probably want to call ISteamNetworkingUtils::InitRelayNetworkAccess()
+	/// when your app initializes
+	///
+	/// If you need to set any initial config options, pass them here.  See
+	/// SteamNetworkingConfigValue_t for more about why this is preferable to
+	/// setting the options "immediately" after creation.
+	virtual HSteamListenSocket CreateListenSocketP2P( int nVirtualPort, int nOptions, const SteamNetworkingConfigValue_t *pOptions ) = 0;
+
+	/// Begin connecting to a server that is identified using a platform-specific identifier.
+	/// This uses the default rendezvous service, which depends on the platform and library
+	/// configuration.  (E.g. on Steam, it goes through the steam backend.)  The traffic is relayed
+	/// over the Steam Datagram Relay network.
+	///
+	/// If you use this, you probably want to call ISteamNetworkingUtils::InitRelayNetworkAccess()
+	/// when your app initializes
+	///
+	/// If you need to set any initial config options, pass them here.  See
+	/// SteamNetworkingConfigValue_t for more about why this is preferable to
+	/// setting the options "immediately" after creation.
+	virtual HSteamNetConnection ConnectP2P( const SteamNetworkingIdentity &identityRemote, int nVirtualPort, int nOptions, const SteamNetworkingConfigValue_t *pOptions ) = 0;
+#endif
+
+	/// Accept an incoming connection that has been received on a listen socket.
+	///
+	/// When a connection attempt is received (perhaps after a few basic handshake
+	/// packets have been exchanged to prevent trivial spoofing), a connection interface
+	/// object is created in the k_ESteamNetworkingConnectionState_Connecting state
+	/// and a SteamNetConnectionStatusChangedCallback_t is posted.  At this point, your
+	/// application MUST either accept or close the connection.  (It may not ignore it.)
+	/// Accepting the connection will transition it either into the connected state,
+	/// or the finding route state, depending on the connection type.
+	///
+	/// You should take action within a second or two, because accepting the connection is
+	/// what actually sends the reply notifying the client that they are connected.  If you
+	/// delay taking action, from the client's perspective it is the same as the network
+	/// being unresponsive, and the client may timeout the connection attempt.  In other
+	/// words, the client cannot distinguish between a delay caused by network problems
+	/// and a delay caused by the application.
+	///
+	/// This means that if your application goes for more than a few seconds without
+	/// processing callbacks (for example, while loading a map), then there is a chance
+	/// that a client may attempt to connect in that interval and fail due to timeout.
+	///
+	/// If the application does not respond to the connection attempt in a timely manner,
+	/// and we stop receiving communication from the client, the connection attempt will
+	/// be timed out locally, transitioning the connection to the
+	/// k_ESteamNetworkingConnectionState_ProblemDetectedLocally state.  The client may also
+	/// close the connection before it is accepted, and a transition to the
+	/// k_ESteamNetworkingConnectionState_ClosedByPeer is also possible depending the exact
+	/// sequence of events.
+	///
+	/// Returns k_EResultInvalidParam if the handle is invalid.
+	/// Returns k_EResultInvalidState if the connection is not in the appropriate state.
+	/// (Remember that the connection state could change in between the time that the
+	/// notification being posted to the queue and when it is received by the application.)
+	///
+	/// A note about connection configuration options.  If you need to set any configuration
+	/// options that are common to all connections accepted through a particular listen
+	/// socket, consider setting the options on the listen socket, since such options are
+	/// inherited automatically.  If you really do need to set options that are connection
+	/// specific, it is safe to set them on the connection before accepting the connection.
+	virtual EResult AcceptConnection( HSteamNetConnection hConn ) = 0;
+
+	/// Disconnects from the remote host and invalidates the connection handle.
+	/// Any unread data on the connection is discarded.
+	///
+	/// nReason is an application defined code that will be received on the other
+	/// end and recorded (when possible) in backend analytics.  The value should
+	/// come from a restricted range.  (See ESteamNetConnectionEnd.)  If you don't need
+	/// to communicate any information to the remote host, and do not want analytics to
+	/// be able to distinguish "normal" connection terminations from "exceptional" ones,
+	/// You may pass zero, in which case the generic value of
+	/// k_ESteamNetConnectionEnd_App_Generic will be used.
+	///
+	/// pszDebug is an optional human-readable diagnostic string that will be received
+	/// by the remote host and recorded (when possible) in backend analytics.
+	///
+	/// If you wish to put the socket into a "linger" state, where an attempt is made to
+	/// flush any remaining sent data, use bEnableLinger=true.  Otherwise reliable data
+	/// is not flushed.
+	///
+	/// If the connection has already ended and you are just freeing up the
+	/// connection interface, the reason code, debug string, and linger flag are
+	/// ignored.
+	virtual bool CloseConnection( HSteamNetConnection hPeer, int nReason, const char *pszDebug, bool bEnableLinger ) = 0;
+
+	/// Destroy a listen socket.  All the connections that were accepting on the listen
+	/// socket are closed ungracefully.
+	virtual bool CloseListenSocket( HSteamListenSocket hSocket ) = 0;
+
+	/// Set connection user data.  the data is returned in the following places
+	/// - You can query it using GetConnectionUserData.
+	/// - The SteamNetworkingmessage_t structure.
+	/// - The SteamNetConnectionInfo_t structure.  (Which is a member of SteamNetConnectionStatusChangedCallback_t.)
+	///
+	/// Returns false if the handle is invalid.
+	virtual bool SetConnectionUserData( HSteamNetConnection hPeer, int64 nUserData ) = 0;
+
+	/// Fetch connection user data.  Returns -1 if handle is invalid
+	/// or if you haven't set any userdata on the connection.
+	virtual int64 GetConnectionUserData( HSteamNetConnection hPeer ) = 0;
+
+	/// Set a name for the connection, used mostly for debugging
+	virtual void SetConnectionName( HSteamNetConnection hPeer, const char *pszName ) = 0;
+
+	/// Fetch connection name.  Returns false if handle is invalid
+	virtual bool GetConnectionName( HSteamNetConnection hPeer, char *pszName, int nMaxLen ) = 0;
+
+	/// Send a message to the remote host on the specified connection.
+	///
+	/// nSendFlags determines the delivery guarantees that will be provided,
+	/// when data should be buffered, etc.  E.g. k_nSteamNetworkingSend_Unreliable
+	///
+	/// Note that the semantics we use for messages are not precisely
+	/// the same as the semantics of a standard "stream" socket.
+	/// (SOCK_STREAM)  For an ordinary stream socket, the boundaries
+	/// between chunks are not considered relevant, and the sizes of
+	/// the chunks of data written will not necessarily match up to
+	/// the sizes of the chunks that are returned by the reads on
+	/// the other end.  The remote host might read a partial chunk,
+	/// or chunks might be coalesced.  For the message semantics 
+	/// used here, however, the sizes WILL match.  Each send call 
+	/// will match a successful read call on the remote host 
+	/// one-for-one.  If you are porting existing stream-oriented 
+	/// code to the semantics of reliable messages, your code should 
+	/// work the same, since reliable message semantics are more 
+	/// strict than stream semantics.  The only caveat is related to 
+	/// performance: there is per-message overhead to retain the 
+	/// message sizes, and so if your code sends many small chunks 
+	/// of data, performance will suffer. Any code based on stream 
+	/// sockets that does not write excessively small chunks will 
+	/// work without any changes. 
+	///
+	/// The pOutMessageNumber is an optional pointer to receive the
+	/// message number assigned to the message, if sending was successful.
+	///
+	/// Returns:
+	/// - k_EResultInvalidParam: invalid connection handle, or the individual message is too big.
+	///   (See k_cbMaxSteamNetworkingSocketsMessageSizeSend)
+	/// - k_EResultInvalidState: connection is in an invalid state
+	/// - k_EResultNoConnection: connection has ended
+	/// - k_EResultIgnored: You used k_nSteamNetworkingSend_NoDelay, and the message was dropped because
+	///   we were not ready to send it.
+	/// - k_EResultLimitExceeded: there was already too much data queued to be sent.
+	///   (See k_ESteamNetworkingConfig_SendBufferSize)
+	virtual EResult SendMessageToConnection( HSteamNetConnection hConn, const void *pData, uint32 cbData, int nSendFlags, int64 *pOutMessageNumber ) = 0;
+
+	/// Send one or more messages without copying the message payload.
+	/// This is the most efficient way to send messages. To use this
+	/// function, you must first allocate a message object using
+	/// ISteamNetworkingUtils::AllocateMessage.  (Do not declare one
+	/// on the stack or allocate your own.)
+	///
+	/// You should fill in the message payload.  You can either let
+	/// it allocate the buffer for you and then fill in the payload,
+	/// or if you already have a buffer allocated, you can just point
+	/// m_pData at your buffer and set the callback to the appropriate function
+	/// to free it.  Note that if you use your own buffer, it MUST remain valid
+	/// until the callback is executed.  And also note that your callback can be
+	/// invoked at ant time from any thread (perhaps even before SendMessages
+	/// returns!), so it MUST be fast and threadsafe.
+	///
+	/// You MUST also fill in:
+	/// - m_conn - the handle of the connection to send the message to
+	/// - m_nFlags - bitmask of k_nSteamNetworkingSend_xxx flags.
+	///
+	/// All other fields are currently reserved and should not be modified.
+	///
+	/// The library will take ownership of the message structures.  They may
+	/// be modified or become invalid at any time, so you must not read them
+	/// after passing them to this function.
+	///
+	/// pOutMessageNumberOrResult is an optional array that will receive,
+	/// for each message, the message number that was assigned to the message
+	/// if sending was successful.  If sending failed, then a negative EResult
+	/// value is placed into the array.  For example, the array will hold
+	/// -k_EResultInvalidState if the connection was in an invalid state.
+	/// See ISteamNetworkingSockets::SendMessageToConnection for possible
+	/// failure codes.
+	virtual void SendMessages( int nMessages, SteamNetworkingMessage_t *const *pMessages, int64 *pOutMessageNumberOrResult ) = 0;
+
+	/// Flush any messages waiting on the Nagle timer and send them
+	/// at the next transmission opportunity (often that means right now).
+	///
+	/// If Nagle is enabled (it's on by default) then when calling 
+	/// SendMessageToConnection the message will be buffered, up to the Nagle time
+	/// before being sent, to merge small messages into the same packet.
+	/// (See k_ESteamNetworkingConfig_NagleTime)
+	///
+	/// Returns:
+	/// k_EResultInvalidParam: invalid connection handle
+	/// k_EResultInvalidState: connection is in an invalid state
+	/// k_EResultNoConnection: connection has ended
+	/// k_EResultIgnored: We weren't (yet) connected, so this operation has no effect.
+	virtual EResult FlushMessagesOnConnection( HSteamNetConnection hConn ) = 0;
+
+	/// Fetch the next available message(s) from the connection, if any.
+	/// Returns the number of messages returned into your array, up to nMaxMessages.
+	/// If the connection handle is invalid, -1 is returned.
+	///
+	/// The order of the messages returned in the array is relevant.
+	/// Reliable messages will be received in the order they were sent (and with the
+	/// same sizes --- see SendMessageToConnection for on this subtle difference from a stream socket).
+	///
+	/// Unreliable messages may be dropped, or delivered out of order with respect to
+	/// each other or with respect to reliable messages.  The same unreliable message
+	/// may be received multiple times.
+	///
+	/// If any messages are returned, you MUST call SteamNetworkingMessage_t::Release() on each
+	/// of them free up resources after you are done.  It is safe to keep the object alive for
+	/// a little while (put it into some queue, etc), and you may call Release() from any thread.
+	virtual int ReceiveMessagesOnConnection( HSteamNetConnection hConn, SteamNetworkingMessage_t **ppOutMessages, int nMaxMessages ) = 0; 
+
+	/// Returns basic information about the high-level state of the connection.
+	virtual bool GetConnectionInfo( HSteamNetConnection hConn, SteamNetConnectionInfo_t *pInfo ) = 0;
+
+	/// Returns a small set of information about the real-time state of the connection
+	/// Returns false if the connection handle is invalid, or the connection has ended.
+	virtual bool GetQuickConnectionStatus( HSteamNetConnection hConn, SteamNetworkingQuickConnectionStatus *pStats ) = 0;
+
+	/// Returns detailed connection stats in text format.  Useful
+	/// for dumping to a log, etc.
+	///
+	/// Returns:
+	/// -1 failure (bad connection handle)
+	/// 0 OK, your buffer was filled in and '\0'-terminated
+	/// >0 Your buffer was either nullptr, or it was too small and the text got truncated.
+	///    Try again with a buffer of at least N bytes.
+	virtual int GetDetailedConnectionStatus( HSteamNetConnection hConn, char *pszBuf, int cbBuf ) = 0;
+
+	/// Returns local IP and port that a listen socket created using CreateListenSocketIP is bound to.
+	///
+	/// An IPv6 address of ::0 means "any IPv4 or IPv6"
+	/// An IPv6 address of ::ffff:0000:0000 means "any IPv4"
+	virtual bool GetListenSocketAddress( HSteamListenSocket hSocket, SteamNetworkingIPAddr *address ) = 0;
+
+	/// Create a pair of connections that are talking to each other, e.g. a loopback connection.
+	/// This is very useful for testing, or so that your client/server code can work the same
+	/// even when you are running a local "server".
+	///
+	/// The two connections will immediately be placed into the connected state, and no callbacks
+	/// will be posted immediately.  After this, if you close either connection, the other connection
+	/// will receive a callback, exactly as if they were communicating over the network.  You must
+	/// close *both* sides in order to fully clean up the resources!
+	///
+	/// By default, internal buffers are used, completely bypassing the network, the chopping up of
+	/// messages into packets, encryption, copying the payload, etc.  This means that loopback
+	/// packets, by default, will not simulate lag or loss.  Passing true for bUseNetworkLoopback will
+	/// cause the socket pair to send packets through the local network loopback device (127.0.0.1)
+	/// on ephemeral ports.  Fake lag and loss are supported in this case, and CPU time is expended
+	/// to encrypt and decrypt.
+	///
+	/// If you wish to assign a specific identity to either connection, you may pass a particular
+	/// identity.  Otherwise, if you pass nullptr, the respective connection will assume a generic
+	/// "localhost" identity.  If you use real network loopback, this might be translated to the
+	/// actual bound loopback port.  Otherwise, the port will be zero.
+	virtual bool CreateSocketPair( HSteamNetConnection *pOutConnection1, HSteamNetConnection *pOutConnection2, bool bUseNetworkLoopback, const SteamNetworkingIdentity *pIdentity1, const SteamNetworkingIdentity *pIdentity2 ) = 0;
+
+	/// Get the identity assigned to this interface.
+	/// E.g. on Steam, this is the user's SteamID, or for the gameserver interface, the SteamID assigned
+	/// to the gameserver.  Returns false and sets the result to an invalid identity if we don't know
+	/// our identity yet.  (E.g. GameServer has not logged in.  On Steam, the user will know their SteamID
+	/// even if they are not signed into Steam.)
+	virtual bool GetIdentity( SteamNetworkingIdentity *pIdentity ) = 0;
+
+	/// Indicate our desire to be ready participate in authenticated communications.
+	/// If we are currently not ready, then steps will be taken to obtain the necessary
+	/// certificates.   (This includes a certificate for us, as well as any CA certificates
+	/// needed to authenticate peers.)
+	///
+	/// You can call this at program init time if you know that you are going to
+	/// be making authenticated connections, so that we will be ready immediately when
+	/// those connections are attempted.  (Note that essentially all connections require
+	/// authentication, with the exception of ordinary UDP connections with authentication
+	/// disabled using k_ESteamNetworkingConfig_IP_AllowWithoutAuth.)  If you don't call
+	/// this function, we will wait until a feature is utilized that that necessitates
+	/// these resources.
+	///
+	/// You can also call this function to force a retry, if failure has occurred.
+	/// Once we make an attempt and fail, we will not automatically retry.
+	/// In this respect, the behavior of the system after trying and failing is the same
+	/// as before the first attempt: attempting authenticated communication or calling
+	/// this function will call the system to attempt to acquire the necessary resources.
+	///
+	/// You can use GetAuthenticationStatus or listen for SteamNetAuthenticationStatus_t
+	/// to monitor the status.
+	///
+	/// Returns the current value that would be returned from GetAuthenticationStatus.
+	virtual ESteamNetworkingAvailability InitAuthentication() = 0;
+
+	/// Query our readiness to participate in authenticated communications.  A
+	/// SteamNetAuthenticationStatus_t callback is posted any time this status changes,
+	/// but you can use this function to query it at any time.
+	///
+	/// The value of SteamNetAuthenticationStatus_t::m_eAvail is returned.  If you only
+	/// want this high level status, you can pass NULL for pDetails.  If you want further
+	/// details, pass non-NULL to receive them.
+	virtual ESteamNetworkingAvailability GetAuthenticationStatus( SteamNetAuthenticationStatus_t *pDetails ) = 0;
+
+	//
+	// Poll groups.  A poll group is a set of connections that can be polled efficiently.
+	// (In our API, to "poll" a connection means to retrieve all pending messages.  We
+	// actually don't have an API to "poll" the connection *state*, like BSD sockets.)
+	//
+
+	/// Create a new poll group.
+	///
+	/// You should destroy the poll group when you are done using DestroyPollGroup
+	virtual HSteamNetPollGroup CreatePollGroup() = 0;
+
+	/// Destroy a poll group created with CreatePollGroup().
+	///
+	/// If there are any connections in the poll group, they are removed from the group,
+	/// and left in a state where they are not part of any poll group.
+	/// Returns false if passed an invalid poll group handle.
+	virtual bool DestroyPollGroup( HSteamNetPollGroup hPollGroup ) = 0;
+
+	/// Assign a connection to a poll group.  Note that a connection may only belong to a
+	/// single poll group.  Adding a connection to a poll group implicitly removes it from
+	/// any other poll group it is in.
+	///
+	/// You can pass k_HSteamNetPollGroup_Invalid to remove a connection from its current
+	/// poll group without adding it to a new poll group.
+	///
+	/// If there are received messages currently pending on the connection, an attempt
+	/// is made to add them to the queue of messages for the poll group in approximately
+	/// the order that would have applied if the connection was already part of the poll
+	/// group at the time that the messages were received.
+	///
+	/// Returns false if the connection handle is invalid, or if the poll group handle
+	/// is invalid (and not k_HSteamNetPollGroup_Invalid).
+	virtual bool SetConnectionPollGroup( HSteamNetConnection hConn, HSteamNetPollGroup hPollGroup ) = 0;
+
+	/// Same as ReceiveMessagesOnConnection, but will return the next messages available
+	/// on any connection in the poll group.  Examine SteamNetworkingMessage_t::m_conn
+	/// to know which connection.  (SteamNetworkingMessage_t::m_nConnUserData might also
+	/// be useful.)
+	///
+	/// Delivery order of messages among different connections will usually match the
+	/// order that the last packet was received which completed the message.  But this
+	/// is not a strong guarantee, especially for packets received right as a connection
+	/// is being assigned to poll group.
+	///
+	/// Delivery order of messages on the same connection is well defined and the
+	/// same guarantees are present as mentioned in ReceiveMessagesOnConnection.
+	/// (But the messages are not grouped by connection, so they will not necessarily
+	/// appear consecutively in the list; they may be interleaved with messages for
+	/// other connections.)
+	virtual int ReceiveMessagesOnPollGroup( HSteamNetPollGroup hPollGroup, SteamNetworkingMessage_t **ppOutMessages, int nMaxMessages ) = 0; 
+
+#ifdef STEAMNETWORKINGSOCKETS_ENABLE_SDR
+
+	//
+	// Clients connecting to dedicated servers hosted in a data center,
+	// using central-authority-granted tickets.
+	//
+
+	/// Call this when you receive a ticket from your backend / matchmaking system.  Puts the
+	/// ticket into a persistent cache, and optionally returns the parsed ticket.
+	///
+	/// See stamdatagram_ticketgen.h for more details.
+	virtual bool ReceivedRelayAuthTicket( const void *pvTicket, int cbTicket, SteamDatagramRelayAuthTicket *pOutParsedTicket ) = 0;
+
+	/// Search cache for a ticket to talk to the server on the specified virtual port.
+	/// If found, returns the number of seconds until the ticket expires, and optionally
+	/// the complete cracked ticket.  Returns 0 if we don't have a ticket.
+	///
+	/// Typically this is useful just to confirm that you have a ticket, before you
+	/// call ConnectToHostedDedicatedServer to connect to the server.
+	virtual int FindRelayAuthTicketForServer( const SteamNetworkingIdentity &identityGameServer, int nVirtualPort, SteamDatagramRelayAuthTicket *pOutParsedTicket ) = 0;
+
+	/// Client call to connect to a server hosted in a Valve data center, on the specified virtual
+	/// port.  You must have placed a ticket for this server into the cache, or else this connect attempt will fail!
+	///
+	/// You may wonder why tickets are stored in a cache, instead of simply being passed as an argument
+	/// here.  The reason is to make reconnection to a gameserver robust, even if the client computer loses
+	/// connection to Steam or the central backend, or the app is restarted or crashes, etc.
+	///
+	/// If you use this, you probably want to call ISteamNetworkingUtils::InitRelayNetworkAccess()
+	/// when your app initializes
+	///
+	/// If you need to set any initial config options, pass them here.  See
+	/// SteamNetworkingConfigValue_t for more about why this is preferable to
+	/// setting the options "immediately" after creation.
+	virtual HSteamNetConnection ConnectToHostedDedicatedServer( const SteamNetworkingIdentity &identityTarget, int nVirtualPort, int nOptions, const SteamNetworkingConfigValue_t *pOptions ) = 0;
+
+	//
+	// Servers hosted in data centers known to the Valve relay network
+	//
+
+	/// Returns the value of the SDR_LISTEN_PORT environment variable.  This
+	/// is the UDP server your server will be listening on.  This will
+	/// configured automatically for you in production environments.
+	///
+	/// In development, you'll need to set it yourself.  See
+	/// https://partner.steamgames.com/doc/api/ISteamNetworkingSockets
+	/// for more information on how to configure dev environments.
+	virtual uint16 GetHostedDedicatedServerPort() = 0;
+
+	/// Returns 0 if SDR_LISTEN_PORT is not set.  Otherwise, returns the data center the server
+	/// is running in.  This will be k_SteamDatagramPOPID_dev in non-production environment.
+	virtual SteamNetworkingPOPID GetHostedDedicatedServerPOPID() = 0;
+
+	/// Return info about the hosted server.  This contains the PoPID of the server,
+	/// and opaque routing information that can be used by the relays to send traffic
+	/// to your server.
+	///
+	/// You will need to send this information to your backend, and put it in tickets,
+	/// so that the relays will know how to forward traffic from
+	/// clients to your server.  See SteamDatagramRelayAuthTicket for more info.
+	///
+	/// Also, note that the routing information is contained in SteamDatagramGameCoordinatorServerLogin,
+	/// so if possible, it's preferred to use GetGameCoordinatorServerLogin to send this info
+	/// to your game coordinator service, and also login securely at the same time.
+	///
+	/// On a successful exit, k_EResultOK is returned
+	///
+	/// Unsuccessful exit:
+	/// - Something other than k_EResultOK is returned.
+	/// - k_EResultInvalidState: We are not configured to listen for SDR (SDR_LISTEN_SOCKET
+	///   is not set.)
+	/// - k_EResultPending: we do not (yet) have the authentication information needed.
+	///   (See GetAuthenticationStatus.)  If you use environment variables to pre-fetch
+	///   the network config, this data should always be available immediately.
+	/// - A non-localized diagnostic debug message will be placed in m_data that describes
+	///   the cause of the failure.
+	///
+	/// NOTE: The returned blob is not encrypted.  Send it to your backend, but don't
+	///       directly share it with clients.
+	virtual EResult GetHostedDedicatedServerAddress( SteamDatagramHostedAddress *pRouting ) = 0;
+
+	/// Create a listen socket on the specified virtual port.  The physical UDP port to use
+	/// will be determined by the SDR_LISTEN_PORT environment variable.  If a UDP port is not
+	/// configured, this call will fail.
+	///
+	/// Note that this call MUST be made through the SteamGameServerNetworkingSockets() interface
+	///
+	/// If you need to set any initial config options, pass them here.  See
+	/// SteamNetworkingConfigValue_t for more about why this is preferable to
+	/// setting the options "immediately" after creation.
+	virtual HSteamListenSocket CreateHostedDedicatedServerListenSocket( int nVirtualPort, int nOptions, const SteamNetworkingConfigValue_t *pOptions ) = 0;
+
+	/// Generate an authentication blob that can be used to securely login with
+	/// your backend, using SteamDatagram_ParseHostedServerLogin.  (See
+	/// steamdatagram_gamecoordinator.h)
+	///
+	/// Before calling the function:
+	/// - Populate the app data in pLoginInfo (m_cbAppData and m_appData).  You can leave
+	///   all other fields uninitialized.
+	/// - *pcbSignedBlob contains the size of the buffer at pBlob.  (It should be
+	///   at least k_cbMaxSteamDatagramGameCoordinatorServerLoginSerialized.)
+	///
+	/// On a successful exit:
+	/// - k_EResultOK is returned
+	/// - All of the remaining fields of pLoginInfo will be filled out.
+	/// - *pcbSignedBlob contains the size of the serialized blob that has been
+	///   placed into pBlob.
+	///
+	/// Unsuccessful exit:
+	/// - Something other than k_EResultOK is returned.
+	/// - k_EResultNotLoggedOn: you are not logged in (yet)
+	/// - See GetHostedDedicatedServerAddress for more potential failure return values.
+	/// - A non-localized diagnostic debug message will be placed in pBlob that describes
+	///   the cause of the failure.
+	///
+	/// This works by signing the contents of the SteamDatagramGameCoordinatorServerLogin
+	/// with the cert that is issued to this server.  In dev environments, it's OK if you do
+	/// not have a cert.  (You will need to enable insecure dev login in SteamDatagram_ParseHostedServerLogin.)
+	/// Otherwise, you will need a signed cert.
+	///
+	/// NOTE: The routing blob returned here is not encrypted.  Send it to your backend
+	///       and don't share it directly with clients.
+	virtual EResult GetGameCoordinatorServerLogin( SteamDatagramGameCoordinatorServerLogin *pLoginInfo, int *pcbSignedBlob, void *pBlob ) = 0;
+
+
+	//
+	// Relayed connections using custom signaling protocol
+	//
+	// This is used if you have your own method of sending out-of-band
+	// signaling / rendezvous messages through a mutually trusted channel.
+	//
+
+	/// Create a P2P "client" connection that does signaling over a custom
+	/// rendezvous/signaling channel.
+	///
+	/// pSignaling points to a new object that you create just for this connection.
+	/// It must stay valid until Release() is called.  Once you pass the
+	/// object to this function, it assumes ownership.  Release() will be called
+	/// from within the function call if the call fails.  Furthermore, until Release()
+	/// is called, you should be prepared for methods to be invoked on your
+	/// object from any thread!  You need to make sure your object is threadsafe!
+	/// Furthermore, you should make sure that dispatching the methods is done
+	/// as quickly as possible.
+	///
+	/// This function will immediately construct a connection in the "connecting"
+	/// state.  Soon after (perhaps before this function returns, perhaps in another thread),
+	/// the connection will begin sending signaling messages by calling
+	/// ISteamNetworkingConnectionCustomSignaling::SendSignal.
+	///
+	/// When the remote peer accepts the connection (See
+	/// ISteamNetworkingCustomSignalingRecvContext::OnConnectRequest),
+	/// it will begin sending signaling messages.  When these messages are received,
+	/// you can pass them to the connection using ReceivedP2PCustomSignal.
+	///
+	/// If you know the identity of the peer that you expect to be on the other end,
+	/// you can pass their identity to improve debug output or just detect bugs.
+	/// If you don't know their identity yet, you can pass NULL, and their
+	/// identity will be established in the connection handshake.  
+	///
+	/// If you use this, you probably want to call ISteamNetworkingUtils::InitRelayNetworkAccess()
+	/// when your app initializes
+	///
+	/// If you need to set any initial config options, pass them here.  See
+	/// SteamNetworkingConfigValue_t for more about why this is preferable to
+	/// setting the options "immediately" after creation.
+	virtual HSteamNetConnection ConnectP2PCustomSignaling( ISteamNetworkingConnectionCustomSignaling *pSignaling, const SteamNetworkingIdentity *pPeerIdentity, int nOptions, const SteamNetworkingConfigValue_t *pOptions ) = 0;
+
+	/// Called when custom signaling has received a message.  When your
+	/// signaling channel receives a message, it should save off whatever
+	/// routing information was in the envelope into the context object,
+	/// and then pass the payload to this function.
+	///
+	/// A few different things can happen next, depending on the message:
+	///
+	/// - If the signal is associated with existing connection, it is dealt
+	///   with immediately.  If any replies need to be sent, they will be
+	///   dispatched using the ISteamNetworkingConnectionCustomSignaling
+	///   associated with the connection.
+	/// - If the message represents a connection request (and the request
+	///   is not redundant for an existing connection), a new connection
+	///   will be created, and ReceivedConnectRequest will be called on your
+	///   context object to determine how to proceed.
+	/// - Otherwise, the message is for a connection that does not
+	///   exist (anymore).  In this case, we *may* call SendRejectionReply
+	///   on your context object.
+	///
+	/// In any case, we will not save off pContext or access it after this
+	/// function returns.
+	///
+	/// Returns true if the message was parsed and dispatched without anything
+	/// unusual or suspicious happening.  Returns false if there was some problem
+	/// with the message that prevented ordinary handling.  (Debug output will
+	/// usually have more information.)
+	///
+	/// If you expect to be using relayed connections, then you probably want
+	/// to call ISteamNetworkingUtils::InitRelayNetworkAccess() when your app initializes
+	virtual bool ReceivedP2PCustomSignal( const void *pMsg, int cbMsg, ISteamNetworkingCustomSignalingRecvContext *pContext ) = 0;
+#endif // #ifndef STEAMNETWORKINGSOCKETS_ENABLE_SDR
+
+//
+// Certificate provision by the application.  On Steam, we normally handle all this automatically
+// and you will not need to use these advanced functions.
+//
+
+	/// Get blob that describes a certificate request.  You can send this to your game coordinator.
+	/// Upon entry, *pcbBlob should contain the size of the buffer.  On successful exit, it will
+	/// return the number of bytes that were populated.  You can pass pBlob=NULL to query for the required
+	/// size.  (256 bytes is a very conservative estimate.)
+	///
+	/// Pass this blob to your game coordinator and call SteamDatagram_CreateCert.
+	virtual bool GetCertificateRequest( int *pcbBlob, void *pBlob, SteamNetworkingErrMsg &errMsg ) = 0;
+
+	/// Set the certificate.  The certificate blob should be the output of
+	/// SteamDatagram_CreateCert.
+	virtual bool SetCertificate( const void *pCertificate, int cbCertificate, SteamNetworkingErrMsg &errMsg ) = 0;
+
+	// Invoke all callbacks queued for this interface.
+	// On Steam, callbacks are dispatched via the ordinary Steamworks callbacks mechanism.
+	// So if you have code that is also targeting Steam, you should call this at about the
+	// same time you would call SteamAPI_RunCallbacks and SteamGameServer_RunCallbacks.
+#ifdef STEAMNETWORKINGSOCKETS_STANDALONELIB
+	virtual void RunCallbacks( ISteamNetworkingSocketsCallbacks *pCallbacks ) = 0;
+#endif
+protected:
+	~ISteamNetworkingSockets(); // Silence some warnings
+};
+#define STEAMNETWORKINGSOCKETS_INTERFACE_VERSION "SteamNetworkingSockets008"
+
+/// Interface used to send signaling messages for a particular connection.
+/// You will need to construct one of these per connection.
+///
+/// - For connections initiated locally, you will construct it and pass
+///   it to ISteamNetworkingSockets::ConnectP2PCustomSignaling.
+/// - For connections initiated remotely and "accepted" locally, you
+///   will return it from ISteamNetworkingCustomSignalingRecvContext::OnConnectRequest
+class ISteamNetworkingConnectionCustomSignaling
+{
+public:
+	/// Called to send a rendezvous message to the remote peer.  This may be called
+	/// from any thread, at any time, so you need to be thread-safe!  Don't take
+	/// any locks that might hold while calling into SteamNetworkingSockets functions,
+	/// because this could lead to deadlocks.
+	///
+	/// Note that when initiating a connection, we may not know the identity
+	/// of the peer, if you did not specify it in ConnectP2PCustomSignaling.
+	///
+	/// Return true if a best-effort attempt was made to deliver the message.
+	/// If you return false, it is assumed that the situation is fatal;
+	/// the connection will be closed, and Release() will be called
+	/// eventually.
+	///
+	/// Signaling objects will not be shared between connections.
+	/// You can assume that the same value of hConn will be used
+	/// every time.
+	virtual bool SendSignal( HSteamNetConnection hConn, const SteamNetConnectionInfo_t &info, const void *pMsg, int cbMsg ) = 0;
+
+	/// Called when the connection no longer needs to send signals.
+	/// Note that this happens eventually (but not immediately) after
+	/// the connection is closed.  Signals may need to be sent for a brief
+	/// time after the connection is closed, to clean up the connection.
+	virtual void Release() = 0;
+};
+
+/// Interface used when a custom signal is received.
+/// See ISteamNetworkingSockets::ReceivedP2PCustomSignal
+class ISteamNetworkingCustomSignalingRecvContext
+{
+public:
+
+	/// Called when the signal represents a request for a new connection.
+	///
+	/// If you want to ignore the request, just return NULL.  In this case,
+	/// the peer will NOT receive any reply.  You should consider ignoring
+	/// requests rather than actively rejecting them, as a security measure.
+	/// If you actively reject requests, then this makes it possible to detect
+	/// if a user is online or not, just by sending them a request.
+	///
+	/// If you wish to send back a rejection, then use
+	/// ISteamNetworkingSockets::CloseConnection() and then return NULL.
+	/// We will marshal a properly formatted rejection signal and
+	/// call SendRejectionSignal() so you can send it to them.
+	///
+	/// If you return a signaling object, the connection is NOT immediately
+	/// accepted by default.  Instead, it stays in the "connecting" state,
+	/// and the usual callback is posted, and your app can accept the
+	/// connection using ISteamNetworkingSockets::AcceptConnection.  This
+	/// may be useful so that these sorts of connections can be more similar
+	/// to your application code as other types of connections accepted on
+	/// a listen socket.  If this is not useful and you want to skip this
+	/// callback process and immediately accept the connection, call
+	/// ISteamNetworkingSockets::AcceptConnection before returning the
+	/// signaling object.
+	///
+	/// After accepting a connection (through either means), the connection
+	/// will transition into the "finding route" state.
+	virtual ISteamNetworkingConnectionCustomSignaling *OnConnectRequest( HSteamNetConnection hConn, const SteamNetworkingIdentity &identityPeer ) = 0;
+
+	/// This is called actively communication rejection or failure
+	/// to the incoming message.  If you intend to ignore all incoming requests
+	/// that you do not wish to accept, then it's not strictly necessary to
+	/// implement this.
+	virtual void SendRejectionSignal( const SteamNetworkingIdentity &identityPeer, const void *pMsg, int cbMsg ) = 0;
+};
+
+
+// Global accessor.
+#if defined( STEAMNETWORKINGSOCKETS_PARTNER )
+
+	// Standalone lib.  Use different symbol name, so that we can dynamically switch between steamclient.dll
+	// and the standalone lib
+	STEAMNETWORKINGSOCKETS_INTERFACE ISteamNetworkingSockets *SteamNetworkingSockets_Lib();
+	STEAMNETWORKINGSOCKETS_INTERFACE ISteamNetworkingSockets *SteamGameServerNetworkingSockets_Lib();
+	inline ISteamNetworkingSockets *SteamNetworkingSockets() { return SteamNetworkingSockets_Lib(); }
+	inline ISteamNetworkingSockets *SteamGameServerNetworkingSockets() { return SteamGameServerNetworkingSockets_Lib(); }
+
+#elif defined( STEAMNETWORKINGSOCKETS_OPENSOURCE ) || defined( STEAMNETWORKINGSOCKETS_STREAMINGCLIENT )
+
+	// Opensource GameNetworkingSockets
+	STEAMNETWORKINGSOCKETS_INTERFACE ISteamNetworkingSockets *SteamNetworkingSockets();
+
+#else
+
+	// Steamworks SDK
+	inline ISteamNetworkingSockets *SteamNetworkingSockets();
+	STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamNetworkingSockets *, SteamNetworkingSockets, STEAMNETWORKINGSOCKETS_INTERFACE_VERSION );
+	inline ISteamNetworkingSockets *SteamGameServerNetworkingSockets();
+	STEAM_DEFINE_GAMESERVER_INTERFACE_ACCESSOR( ISteamNetworkingSockets *, SteamGameServerNetworkingSockets, STEAMNETWORKINGSOCKETS_INTERFACE_VERSION );
+#endif
+
+/// Callback struct used to notify when a connection has changed state
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error "Must define VALVE_CALLBACK_PACK_SMALL or VALVE_CALLBACK_PACK_LARGE"
+#endif
+
+/// This callback is posted whenever a connection is created, destroyed, or changes state.
+/// The m_info field will contain a complete description of the connection at the time the
+/// change occurred and the callback was posted.  In particular, m_eState will have the
+/// new connection state.
+///
+/// You will usually need to listen for this callback to know when:
+/// - A new connection arrives on a listen socket.
+///   m_info.m_hListenSocket will be set, m_eOldState = k_ESteamNetworkingConnectionState_None,
+///   and m_info.m_eState = k_ESteamNetworkingConnectionState_Connecting.
+///   See ISteamNetworkigSockets::AcceptConnection.
+/// - A connection you initiated has been accepted by the remote host.
+///   m_eOldState = k_ESteamNetworkingConnectionState_Connecting, and
+///   m_info.m_eState = k_ESteamNetworkingConnectionState_Connected.
+///   Some connections might transition to k_ESteamNetworkingConnectionState_FindingRoute first.
+/// - A connection has been actively rejected or closed by the remote host.
+///   m_eOldState = k_ESteamNetworkingConnectionState_Connecting or k_ESteamNetworkingConnectionState_Connected,
+///   and m_info.m_eState = k_ESteamNetworkingConnectionState_ClosedByPeer.  m_info.m_eEndReason
+///   and m_info.m_szEndDebug will have for more details.
+///   NOTE: upon receiving this callback, you must still destroy the connection using
+///   ISteamNetworkingSockets::CloseConnection to free up local resources.  (The details
+///   passed to the function are not used in this case, since the connection is already closed.)
+/// - A problem was detected with the connection, and it has been closed by the local host.
+///   The most common failure is timeout, but other configuration or authentication failures
+///   can cause this.  m_eOldState = k_ESteamNetworkingConnectionState_Connecting or
+///   k_ESteamNetworkingConnectionState_Connected, and m_info.m_eState = k_ESteamNetworkingConnectionState_ProblemDetectedLocally.
+///   m_info.m_eEndReason and m_info.m_szEndDebug will have for more details.
+///   NOTE: upon receiving this callback, you must still destroy the connection using
+///   ISteamNetworkingSockets::CloseConnection to free up local resources.  (The details
+///   passed to the function are not used in this case, since the connection is already closed.)
+///
+/// Remember that callbacks are posted to a queue, and networking connections can
+/// change at any time.  It is possible that the connection has already changed
+/// state by the time you process this callback.
+///
+/// Also note that callbacks will be posted when connections are created and destroyed by your own API calls.
+struct SteamNetConnectionStatusChangedCallback_t
+{ 
+	enum { k_iCallback = k_iSteamNetworkingSocketsCallbacks + 1 };
+
+	/// Connection handle
+	HSteamNetConnection m_hConn;
+
+	/// Full connection info
+	SteamNetConnectionInfo_t m_info;
+
+	/// Previous state.  (Current state is in m_info.m_eState)
+	ESteamNetworkingConnectionState m_eOldState;
+};
+
+/// A struct used to describe our readiness to participate in authenticated,
+/// encrypted communication.  In order to do this we need:
+///
+/// - The list of trusted CA certificates that might be relevant for this
+///   app.
+/// - A valid certificate issued by a CA.
+///
+/// This callback is posted whenever the state of our readiness changes.
+struct SteamNetAuthenticationStatus_t
+{ 
+	enum { k_iCallback = k_iSteamNetworkingSocketsCallbacks + 2 };
+
+	/// Status
+	ESteamNetworkingAvailability m_eAvail;
+
+	/// Non-localized English language status.  For diagnostic/debugging
+	/// purposes only.
+	char m_debugMsg[ 256 ];
+};
+
+#pragma pack( pop )
+
+#endif // ISTEAMNETWORKINGSOCKETS

--- a/lsteamclient/steamworks_sdk_148a/isteamnetworkingutils.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamnetworkingutils.h
@@ -1,0 +1,397 @@
+//====== Copyright Valve Corporation, All rights reserved. ====================
+//
+// Purpose: misc networking utilities
+//
+//=============================================================================
+
+#ifndef ISTEAMNETWORKINGUTILS
+#define ISTEAMNETWORKINGUTILS
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include <stdint.h>
+
+#include "steamnetworkingtypes.h"
+struct SteamDatagramRelayAuthTicket;
+struct SteamRelayNetworkStatus_t;
+
+//-----------------------------------------------------------------------------
+/// Misc networking utilities for checking the local networking environment
+/// and estimating pings.
+class ISteamNetworkingUtils
+{
+public:
+	//
+	// Efficient message sending
+	//
+
+	/// Allocate and initialize a message object.  Usually the reason
+	/// you call this is to pass it to ISteamNetworkingSockets::SendMessages.
+	/// The returned object will have all of the relevant fields cleared to zero.
+	///
+	/// Optionally you can also request that this system allocate space to
+	/// hold the payload itself.  If cbAllocateBuffer is nonzero, the system
+	/// will allocate memory to hold a payload of at least cbAllocateBuffer bytes.
+	/// m_pData will point to the allocated buffer, m_cbSize will be set to the
+	/// size, and m_pfnFreeData will be set to the proper function to free up
+	/// the buffer.
+	///
+	/// If cbAllocateBuffer=0, then no buffer is allocated.  m_pData will be NULL,
+	/// m_cbSize will be zero, and m_pfnFreeData will be NULL.  You will need to
+	/// set each of these.
+	virtual SteamNetworkingMessage_t *AllocateMessage( int cbAllocateBuffer ) = 0;
+
+	//
+	// Access to Steam Datagram Relay (SDR) network
+	//
+
+#ifdef STEAMNETWORKINGSOCKETS_ENABLE_SDR
+
+	//
+	// Initialization and status check
+	//
+
+	/// If you know that you are going to be using the relay network (for example,
+	/// because you anticipate making P2P connections), call this to initialize the
+	/// relay network.  If you do not call this, the initialization will
+	/// be delayed until the first time you use a feature that requires access
+	/// to the relay network, which will delay that first access.
+	///
+	/// You can also call this to force a retry if the previous attempt has failed.
+	/// Performing any action that requires access to the relay network will also
+	/// trigger a retry, and so calling this function is never strictly necessary,
+	/// but it can be useful to call it a program launch time, if access to the
+	/// relay network is anticipated.
+	///
+	/// Use GetRelayNetworkStatus or listen for SteamRelayNetworkStatus_t
+	/// callbacks to know when initialization has completed.
+	/// Typically initialization completes in a few seconds.
+	///
+	/// Note: dedicated servers hosted in known data centers do *not* need
+	/// to call this, since they do not make routing decisions.  However, if
+	/// the dedicated server will be using P2P functionality, it will act as
+	/// a "client" and this should be called.
+	inline void InitRelayNetworkAccess();
+
+	/// Fetch current status of the relay network.
+	///
+	/// SteamRelayNetworkStatus_t is also a callback.  It will be triggered on
+	/// both the user and gameserver interfaces any time the status changes, or
+	/// ping measurement starts or stops.
+	///
+	/// SteamRelayNetworkStatus_t::m_eAvail is returned.  If you want
+	/// more details, you can pass a non-NULL value.
+	virtual ESteamNetworkingAvailability GetRelayNetworkStatus( SteamRelayNetworkStatus_t *pDetails ) = 0;
+
+	//
+	// "Ping location" functions
+	//
+	// We use the ping times to the valve relays deployed worldwide to
+	// generate a "marker" that describes the location of an Internet host.
+	// Given two such markers, we can estimate the network latency between
+	// two hosts, without sending any packets.  The estimate is based on the
+	// optimal route that is found through the Valve network.  If you are
+	// using the Valve network to carry the traffic, then this is precisely
+	// the ping you want.  If you are not, then the ping time will probably
+	// still be a reasonable estimate.
+	//
+	// This is extremely useful to select peers for matchmaking!
+	//
+	// The markers can also be converted to a string, so they can be transmitted.
+	// We have a separate library you can use on your app's matchmaking/coordinating
+	// server to manipulate these objects.  (See steamdatagram_gamecoordinator.h)
+
+	/// Return location info for the current host.  Returns the approximate
+	/// age of the data, in seconds, or -1 if no data is available.
+	///
+	/// It takes a few seconds to initialize access to the relay network.  If
+	/// you call this very soon after calling InitRelayNetworkAccess,
+	/// the data may not be available yet.
+	///
+	/// This always return the most up-to-date information we have available
+	/// right now, even if we are in the middle of re-calculating ping times.
+	virtual float GetLocalPingLocation( SteamNetworkPingLocation_t &result ) = 0;
+
+	/// Estimate the round-trip latency between two arbitrary locations, in
+	/// milliseconds.  This is a conservative estimate, based on routing through
+	/// the relay network.  For most basic relayed connections, this ping time
+	/// will be pretty accurate, since it will be based on the route likely to
+	/// be actually used.
+	///
+	/// If a direct IP route is used (perhaps via NAT traversal), then the route
+	/// will be different, and the ping time might be better.  Or it might actually
+	/// be a bit worse!  Standard IP routing is frequently suboptimal!
+	///
+	/// But even in this case, the estimate obtained using this method is a
+	/// reasonable upper bound on the ping time.  (Also it has the advantage
+	/// of returning immediately and not sending any packets.)
+	///
+	/// In a few cases we might not able to estimate the route.  In this case
+	/// a negative value is returned.  k_nSteamNetworkingPing_Failed means
+	/// the reason was because of some networking difficulty.  (Failure to
+	/// ping, etc)  k_nSteamNetworkingPing_Unknown is returned if we cannot
+	/// currently answer the question for some other reason.
+	///
+	/// Do you need to be able to do this from a backend/matchmaking server?
+	/// You are looking for the "ticketgen" library.
+	virtual int EstimatePingTimeBetweenTwoLocations( const SteamNetworkPingLocation_t &location1, const SteamNetworkPingLocation_t &location2 ) = 0;
+
+	/// Same as EstimatePingTime, but assumes that one location is the local host.
+	/// This is a bit faster, especially if you need to calculate a bunch of
+	/// these in a loop to find the fastest one.
+	///
+	/// In rare cases this might return a slightly different estimate than combining
+	/// GetLocalPingLocation with EstimatePingTimeBetweenTwoLocations.  That's because
+	/// this function uses a slightly more complete set of information about what
+	/// route would be taken.
+	virtual int EstimatePingTimeFromLocalHost( const SteamNetworkPingLocation_t &remoteLocation ) = 0;
+
+	/// Convert a ping location into a text format suitable for sending over the wire.
+	/// The format is a compact and human readable.  However, it is subject to change
+	/// so please do not parse it yourself.  Your buffer must be at least
+	/// k_cchMaxSteamNetworkingPingLocationString bytes.
+	virtual void ConvertPingLocationToString( const SteamNetworkPingLocation_t &location, char *pszBuf, int cchBufSize ) = 0;
+
+	/// Parse back SteamNetworkPingLocation_t string.  Returns false if we couldn't understand
+	/// the string.
+	virtual bool ParsePingLocationString( const char *pszString, SteamNetworkPingLocation_t &result ) = 0;
+
+	/// Check if the ping data of sufficient recency is available, and if
+	/// it's too old, start refreshing it.
+	///
+	/// Please only call this function when you *really* do need to force an
+	/// immediate refresh of the data.  (For example, in response to a specific
+	/// user input to refresh this information.)  Don't call it "just in case",
+	/// before every connection, etc.  That will cause extra traffic to be sent
+	/// for no benefit. The library will automatically refresh the information
+	/// as needed.
+	///
+	/// Returns true if sufficiently recent data is already available.
+	///
+	/// Returns false if sufficiently recent data is not available.  In this
+	/// case, ping measurement is initiated, if it is not already active.
+	/// (You cannot restart a measurement already in progress.)
+	///
+	/// You can use GetRelayNetworkStatus or listen for SteamRelayNetworkStatus_t
+	/// to know when ping measurement completes.
+	virtual bool CheckPingDataUpToDate( float flMaxAgeSeconds ) = 0;
+
+	//
+	// List of Valve data centers, and ping times to them.  This might
+	// be useful to you if you are use our hosting, or just need to measure
+	// latency to a cloud data center where we are running relays.
+	//
+
+	/// Fetch ping time of best available relayed route from this host to
+	/// the specified data center.
+	virtual int GetPingToDataCenter( SteamNetworkingPOPID popID, SteamNetworkingPOPID *pViaRelayPoP ) = 0;
+
+	/// Get *direct* ping time to the relays at the data center.
+	virtual int GetDirectPingToPOP( SteamNetworkingPOPID popID ) = 0;
+
+	/// Get number of network points of presence in the config
+	virtual int GetPOPCount() = 0;
+
+	/// Get list of all POP IDs.  Returns the number of entries that were filled into
+	/// your list.
+	virtual int GetPOPList( SteamNetworkingPOPID *list, int nListSz ) = 0;
+#endif // #ifdef STEAMNETWORKINGSOCKETS_ENABLE_SDR
+
+	//
+	// Misc
+	//
+
+	/// Fetch current timestamp.  This timer has the following properties:
+	///
+	/// - Monotonicity is guaranteed.
+	/// - The initial value will be at least 24*3600*30*1e6, i.e. about
+	///   30 days worth of microseconds.  In this way, the timestamp value of
+	///   0 will always be at least "30 days ago".  Also, negative numbers
+	///   will never be returned.
+	/// - Wraparound / overflow is not a practical concern.
+	///
+	/// If you are running under the debugger and stop the process, the clock
+	/// might not advance the full wall clock time that has elapsed between
+	/// calls.  If the process is not blocked from normal operation, the
+	/// timestamp values will track wall clock time, even if you don't call
+	/// the function frequently.
+	///
+	/// The value is only meaningful for this run of the process.  Don't compare
+	/// it to values obtained on another computer, or other runs of the same process.
+	virtual SteamNetworkingMicroseconds GetLocalTimestamp() = 0;
+
+	/// Set a function to receive network-related information that is useful for debugging.
+	/// This can be very useful during development, but it can also be useful for troubleshooting
+	/// problems with tech savvy end users.  If you have a console or other log that customers
+	/// can examine, these log messages can often be helpful to troubleshoot network issues.
+	/// (Especially any warning/error messages.)
+	///
+	/// The detail level indicates what message to invoke your callback on.  Lower numeric
+	/// value means more important, and the value you pass is the lowest priority (highest
+	/// numeric value) you wish to receive callbacks for.
+	///
+	/// Except when debugging, you should only use k_ESteamNetworkingSocketsDebugOutputType_Msg
+	/// or k_ESteamNetworkingSocketsDebugOutputType_Warning.  For best performance, do NOT
+	/// request a high detail level and then filter out messages in your callback.  This incurs
+	/// all of the expense of formatting the messages, which are then discarded.  Setting a high
+	/// priority value (low numeric value) here allows the library to avoid doing this work.
+	///
+	/// IMPORTANT: This may be called from a service thread, while we own a mutex, etc.
+	/// Your output function must be threadsafe and fast!  Do not make any other
+	/// Steamworks calls from within the handler.
+	virtual void SetDebugOutputFunction( ESteamNetworkingSocketsDebugOutputType eDetailLevel, FSteamNetworkingSocketsDebugOutput pfnFunc ) = 0;
+
+	//
+	// Set and get configuration values, see ESteamNetworkingConfigValue for individual descriptions.
+	//
+
+	// Shortcuts for common cases.  (Implemented as inline functions below)
+	bool SetGlobalConfigValueInt32( ESteamNetworkingConfigValue eValue, int32 val );
+	bool SetGlobalConfigValueFloat( ESteamNetworkingConfigValue eValue, float val );
+	bool SetGlobalConfigValueString( ESteamNetworkingConfigValue eValue, const char *val );
+	bool SetConnectionConfigValueInt32( HSteamNetConnection hConn, ESteamNetworkingConfigValue eValue, int32 val );
+	bool SetConnectionConfigValueFloat( HSteamNetConnection hConn, ESteamNetworkingConfigValue eValue, float val );
+	bool SetConnectionConfigValueString( HSteamNetConnection hConn, ESteamNetworkingConfigValue eValue, const char *val );
+
+	/// Set a configuration value.
+	/// - eValue: which value is being set
+	/// - eScope: Onto what type of object are you applying the setting?
+	/// - scopeArg: Which object you want to change?  (Ignored for global scope).  E.g. connection handle, listen socket handle, interface pointer, etc.
+	/// - eDataType: What type of data is in the buffer at pValue?  This must match the type of the variable exactly!
+	/// - pArg: Value to set it to.  You can pass NULL to remove a non-global setting at this scope,
+	///   causing the value for that object to use global defaults.  Or at global scope, passing NULL
+	///   will reset any custom value and restore it to the system default.
+	///   NOTE: When setting callback functions, do not pass the function pointer directly.
+	///   Your argument should be a pointer to a function pointer.
+	virtual bool SetConfigValue( ESteamNetworkingConfigValue eValue, ESteamNetworkingConfigScope eScopeType, intptr_t scopeObj,
+		ESteamNetworkingConfigDataType eDataType, const void *pArg ) = 0;
+
+	/// Set a configuration value, using a struct to pass the value.
+	/// (This is just a convenience shortcut; see below for the implementation and
+	/// a little insight into how SteamNetworkingConfigValue_t is used when
+	/// setting config options during listen socket and connection creation.)
+	bool SetConfigValueStruct( const SteamNetworkingConfigValue_t &opt, ESteamNetworkingConfigScope eScopeType, intptr_t scopeObj );
+
+	/// Get a configuration value.
+	/// - eValue: which value to fetch
+	/// - eScopeType: query setting on what type of object
+	/// - eScopeArg: the object to query the setting for
+	/// - pOutDataType: If non-NULL, the data type of the value is returned.
+	/// - pResult: Where to put the result.  Pass NULL to query the required buffer size.  (k_ESteamNetworkingGetConfigValue_BufferTooSmall will be returned.)
+	/// - cbResult: IN: the size of your buffer.  OUT: the number of bytes filled in or required.
+	virtual ESteamNetworkingGetConfigValueResult GetConfigValue( ESteamNetworkingConfigValue eValue, ESteamNetworkingConfigScope eScopeType, intptr_t scopeObj,
+		ESteamNetworkingConfigDataType *pOutDataType, void *pResult, size_t *cbResult ) = 0;
+
+	/// Returns info about a configuration value.  Returns false if the value does not exist.
+	/// pOutNextValue can be used to iterate through all of the known configuration values.
+	/// (Use GetFirstConfigValue() to begin the iteration, will be k_ESteamNetworkingConfig_Invalid on the last value)
+	/// Any of the output parameters can be NULL if you do not need that information.
+	///
+	/// See k_ESteamNetworkingConfig_EnumerateDevVars for some more info about "dev" variables,
+	/// which are usually excluded from the set of variables enumerated using this function.
+	virtual bool GetConfigValueInfo( ESteamNetworkingConfigValue eValue, const char **pOutName, ESteamNetworkingConfigDataType *pOutDataType, ESteamNetworkingConfigScope *pOutScope, ESteamNetworkingConfigValue *pOutNextValue ) = 0;
+
+	/// Return the lowest numbered configuration value available in the current environment.
+	virtual ESteamNetworkingConfigValue GetFirstConfigValue() = 0;
+
+	// String conversions.  You'll usually access these using the respective
+	// inline methods.
+	virtual void SteamNetworkingIPAddr_ToString( const SteamNetworkingIPAddr &addr, char *buf, size_t cbBuf, bool bWithPort ) = 0;
+	virtual bool SteamNetworkingIPAddr_ParseString( SteamNetworkingIPAddr *pAddr, const char *pszStr ) = 0;
+	virtual void SteamNetworkingIdentity_ToString( const SteamNetworkingIdentity &identity, char *buf, size_t cbBuf ) = 0;
+	virtual bool SteamNetworkingIdentity_ParseString( SteamNetworkingIdentity *pIdentity, const char *pszStr ) = 0;
+
+protected:
+	~ISteamNetworkingUtils(); // Silence some warnings
+};
+#define STEAMNETWORKINGUTILS_INTERFACE_VERSION "SteamNetworkingUtils003"
+
+// Global accessor.
+#ifdef STEAMNETWORKINGSOCKETS_STANDALONELIB
+
+	// Standalone lib
+	STEAMNETWORKINGSOCKETS_INTERFACE ISteamNetworkingUtils *SteamNetworkingUtils_Lib();
+	inline ISteamNetworkingUtils *SteamNetworkingUtils() { return SteamNetworkingUtils_Lib(); }
+
+#else
+
+	// Steamworks SDK
+	inline ISteamNetworkingUtils *SteamNetworkingUtils();
+	STEAM_DEFINE_INTERFACE_ACCESSOR( ISteamNetworkingUtils *, SteamNetworkingUtils,
+		/* Prefer user version of the interface.  But if it isn't found, then use
+		gameserver one.  Yes, this is a completely terrible hack */
+		SteamInternal_FindOrCreateUserInterface( 0, STEAMNETWORKINGUTILS_INTERFACE_VERSION ) ?
+		SteamInternal_FindOrCreateUserInterface( 0, STEAMNETWORKINGUTILS_INTERFACE_VERSION ) :
+		SteamInternal_FindOrCreateGameServerInterface( 0, STEAMNETWORKINGUTILS_INTERFACE_VERSION ),
+		"global",
+		STEAMNETWORKINGUTILS_INTERFACE_VERSION
+	)
+#endif
+
+/// A struct used to describe our readiness to use the relay network.
+/// To do this we first need to fetch the network configuration,
+/// which describes what POPs are available.
+struct SteamRelayNetworkStatus_t
+{ 
+	enum { k_iCallback = k_iSteamNetworkingUtilsCallbacks + 1 };
+
+	/// Summary status.  When this is "current", initialization has
+	/// completed.  Anything else means you are not ready yet, or
+	/// there is a significant problem.
+	ESteamNetworkingAvailability m_eAvail;
+
+	/// Nonzero if latency measurement is in progress (or pending,
+	/// awaiting a prerequisite).
+	int m_bPingMeasurementInProgress;
+
+	/// Status obtaining the network config.  This is a prerequisite
+	/// for relay network access.
+	///
+	/// Failure to obtain the network config almost always indicates
+	/// a problem with the local internet connection.
+	ESteamNetworkingAvailability m_eAvailNetworkConfig;
+
+	/// Current ability to communicate with ANY relay.  Note that
+	/// the complete failure to communicate with any relays almost
+	/// always indicates a problem with the local Internet connection.
+	/// (However, just because you can reach a single relay doesn't
+	/// mean that the local connection is in perfect health.)
+	ESteamNetworkingAvailability m_eAvailAnyRelay;
+
+	/// Non-localized English language status.  For diagnostic/debugging
+	/// purposes only.
+	char m_debugMsg[ 256 ];
+};
+
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// Internal stuff
+
+#ifdef STEAMNETWORKINGSOCKETS_ENABLE_SDR
+inline void ISteamNetworkingUtils::InitRelayNetworkAccess() { CheckPingDataUpToDate( 1e10f ); }
+#endif
+
+inline bool ISteamNetworkingUtils::SetGlobalConfigValueInt32( ESteamNetworkingConfigValue eValue, int32 val ) { return SetConfigValue( eValue, k_ESteamNetworkingConfig_Global, 0, k_ESteamNetworkingConfig_Int32, &val ); }
+inline bool ISteamNetworkingUtils::SetGlobalConfigValueFloat( ESteamNetworkingConfigValue eValue, float val ) { return SetConfigValue( eValue, k_ESteamNetworkingConfig_Global, 0, k_ESteamNetworkingConfig_Float, &val ); }
+inline bool ISteamNetworkingUtils::SetGlobalConfigValueString( ESteamNetworkingConfigValue eValue, const char *val ) { return SetConfigValue( eValue, k_ESteamNetworkingConfig_Global, 0, k_ESteamNetworkingConfig_String, val ); }
+inline bool ISteamNetworkingUtils::SetConnectionConfigValueInt32( HSteamNetConnection hConn, ESteamNetworkingConfigValue eValue, int32 val ) { return SetConfigValue( eValue, k_ESteamNetworkingConfig_Connection, hConn, k_ESteamNetworkingConfig_Int32, &val ); }
+inline bool ISteamNetworkingUtils::SetConnectionConfigValueFloat( HSteamNetConnection hConn, ESteamNetworkingConfigValue eValue, float val ) { return SetConfigValue( eValue, k_ESteamNetworkingConfig_Connection, hConn, k_ESteamNetworkingConfig_Float, &val ); }
+inline bool ISteamNetworkingUtils::SetConnectionConfigValueString( HSteamNetConnection hConn, ESteamNetworkingConfigValue eValue, const char *val ) { return SetConfigValue( eValue, k_ESteamNetworkingConfig_Connection, hConn, k_ESteamNetworkingConfig_String, val ); }
+inline bool ISteamNetworkingUtils::SetConfigValueStruct( const SteamNetworkingConfigValue_t &opt, ESteamNetworkingConfigScope eScopeType, intptr_t scopeObj )
+{
+	// Locate the argument.  Strings are a special case, since the
+	// "value" (the whole string buffer) doesn't fit in the struct
+	const void *pVal = ( opt.m_eDataType == k_ESteamNetworkingConfig_String ) ? (const void *)opt.m_val.m_string : (const void *)&opt.m_val;
+	return SetConfigValue( opt.m_eValue, eScopeType, scopeObj, opt.m_eDataType, pVal );
+}
+
+#if !defined( STEAMNETWORKINGSOCKETS_STATIC_LINK ) && defined( STEAMNETWORKINGSOCKETS_STEAMCLIENT )
+inline void SteamNetworkingIPAddr::ToString( char *buf, size_t cbBuf, bool bWithPort ) const { SteamNetworkingUtils()->SteamNetworkingIPAddr_ToString( *this, buf, cbBuf, bWithPort ); }
+inline bool SteamNetworkingIPAddr::ParseString( const char *pszStr ) { return SteamNetworkingUtils()->SteamNetworkingIPAddr_ParseString( this, pszStr ); }
+inline void SteamNetworkingIdentity::ToString( char *buf, size_t cbBuf ) const { SteamNetworkingUtils()->SteamNetworkingIdentity_ToString( *this, buf, cbBuf ); }
+inline bool SteamNetworkingIdentity::ParseString( const char *pszStr ) { return SteamNetworkingUtils()->SteamNetworkingIdentity_ParseString( this, pszStr ); }
+#endif
+
+#endif // ISTEAMNETWORKINGUTILS

--- a/lsteamclient/steamworks_sdk_148a/isteamparentalsettings.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamparentalsettings.h
@@ -1,0 +1,63 @@
+//====== Copyright � 2013-, Valve Corporation, All rights reserved. =======
+//
+// Purpose: Interface to Steam parental settings (Family View)
+//
+//=============================================================================
+
+#ifndef ISTEAMPARENTALSETTINGS_H
+#define ISTEAMPARENTALSETTINGS_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+
+// Feature types for parental settings
+enum EParentalFeature
+{
+	k_EFeatureInvalid = 0,
+	k_EFeatureStore = 1,
+	k_EFeatureCommunity = 2,
+	k_EFeatureProfile = 3,
+	k_EFeatureFriends = 4,
+	k_EFeatureNews = 5,
+	k_EFeatureTrading = 6,
+	k_EFeatureSettings = 7,
+	k_EFeatureConsole = 8,
+	k_EFeatureBrowser = 9,
+	k_EFeatureParentalSetup = 10,
+	k_EFeatureLibrary = 11,
+	k_EFeatureTest = 12,
+	k_EFeatureSiteLicense = 13,
+	k_EFeatureMax
+};
+
+class ISteamParentalSettings
+{
+public:
+	virtual bool BIsParentalLockEnabled() = 0;
+	virtual bool BIsParentalLockLocked() = 0;
+
+	virtual bool BIsAppBlocked( AppId_t nAppID ) = 0;
+	virtual bool BIsAppInBlockList( AppId_t nAppID ) = 0;
+
+	virtual bool BIsFeatureBlocked( EParentalFeature eFeature ) = 0;
+	virtual bool BIsFeatureInBlockList( EParentalFeature eFeature ) = 0;
+};
+
+#define STEAMPARENTALSETTINGS_INTERFACE_VERSION "STEAMPARENTALSETTINGS_INTERFACE_VERSION001"
+
+// Global interface accessor
+inline ISteamParentalSettings *SteamParentalSettings();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamParentalSettings *, SteamParentalSettings, STEAMPARENTALSETTINGS_INTERFACE_VERSION );
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback for querying UGC
+//-----------------------------------------------------------------------------
+struct SteamParentalSettingsChanged_t
+{
+	enum { k_iCallback = k_ISteamParentalSettingsCallbacks + 1 };
+};
+
+
+#endif // ISTEAMPARENTALSETTINGS_H

--- a/lsteamclient/steamworks_sdk_148a/isteamps3overlayrenderer.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamps3overlayrenderer.h
@@ -1,0 +1,91 @@
+//====== Copyright © 1996-2010, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface the game must provide Steam with on PS3 in order for the
+// Steam overlay to render.
+//
+//=============================================================================
+
+#ifndef ISTEAMPS3OVERLAYRENDERER_H
+#define ISTEAMPS3OVERLAYRENDERER_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "cell/pad.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: Enum for supported gradient directions
+//-----------------------------------------------------------------------------
+enum EOverlayGradientDirection
+{
+	k_EOverlayGradientHorizontal = 1,
+	k_EOverlayGradientVertical = 2,
+	k_EOverlayGradientNone = 3,
+};
+
+// Helpers for fetching individual color components from ARGB packed DWORD colors Steam PS3 overlay renderer uses.
+#define STEAM_COLOR_RED( color ) \
+	(int)(((color)>>16)&0xff)
+
+#define STEAM_COLOR_GREEN( color ) \
+	(int)(((color)>>8)&0xff)
+
+#define STEAM_COLOR_BLUE( color ) \
+	(int)((color)&0xff)
+
+#define STEAM_COLOR_ALPHA( color ) \
+	(int)(((color)>>24)&0xff)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Interface the game must expose to Steam for rendering
+//-----------------------------------------------------------------------------
+class ISteamPS3OverlayRenderHost
+{
+public:
+
+	// Interface for game engine to implement which Steam requires to render.
+
+	// Draw a textured rect.  This may use only part of the texture and will pass texture coords, it will also possibly request a gradient and will specify colors for vertexes.
+	virtual void DrawTexturedRect( int x0, int y0, int x1, int y1, float u0, float v0, float u1, float v1, int32 iTextureID, DWORD colorStart, DWORD colorEnd, EOverlayGradientDirection eDirection ) = 0;
+
+	// Load a RGBA texture for Steam, or update a previously loaded one.  Updates may be partial.  You must not evict or remove this texture once Steam has uploaded it.
+	virtual void LoadOrUpdateTexture( int32 iTextureID, bool bIsFullTexture, int x0, int y0, uint32 uWidth, uint32 uHeight, int32 iBytes, char *pData ) = 0;
+
+	// Delete a texture Steam previously uploaded
+	virtual void DeleteTexture( int32 iTextureID ) = 0;
+
+	// Delete all previously uploaded textures
+	virtual void DeleteAllTextures() = 0;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Interface Steam exposes for the game to tell it when to render, etc.
+//-----------------------------------------------------------------------------
+class ISteamPS3OverlayRender
+{
+public:
+
+	// Call once at startup to initialize the Steam overlay and pass it your host interface ptr
+	virtual bool BHostInitialize( uint32 unScreenWidth, uint32 unScreenHeight, uint32 unRefreshRate, ISteamPS3OverlayRenderHost *pRenderHost, void *CellFontLib ) = 0;
+
+	// Call this once a frame when you are ready for the Steam overlay to render (ie, right before flipping buffers, after all your rendering)
+	virtual void Render() = 0;
+
+	// Call this everytime you read input on PS3.
+	// 
+	// If this returns true, then the overlay is active and has consumed the input, your game
+	// should then ignore all the input until BHandleCellPadData once again returns false, which
+	// will mean the overlay is deactivated.
+	virtual bool BHandleCellPadData( const CellPadData &padData ) = 0;
+
+	// Call this if you detect no controllers connected or that the XMB is intercepting input
+	// 
+	// This is important to clear input state for the overlay, so keys left down during XMB activation
+	// are not continued to be processed.
+	virtual bool BResetInputState() = 0;
+};
+
+
+#endif // ISTEAMPS3OVERLAYRENDERER_H

--- a/lsteamclient/steamworks_sdk_148a/isteamremoteplay.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamremoteplay.h
@@ -1,0 +1,88 @@
+//============ Copyright (c) Valve Corporation, All rights reserved. ============
+
+#ifndef ISTEAMREMOTEPLAY_H
+#define ISTEAMREMOTEPLAY_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The form factor of a device
+//-----------------------------------------------------------------------------
+enum ESteamDeviceFormFactor
+{
+	k_ESteamDeviceFormFactorUnknown		= 0,
+	k_ESteamDeviceFormFactorPhone		= 1,
+	k_ESteamDeviceFormFactorTablet		= 2,
+	k_ESteamDeviceFormFactorComputer	= 3,
+	k_ESteamDeviceFormFactorTV			= 4,
+};
+
+// Steam Remote Play session ID
+typedef uint32 RemotePlaySessionID_t;
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions to provide information about Steam Remote Play sessions
+//-----------------------------------------------------------------------------
+class ISteamRemotePlay
+{
+public:
+	// Get the number of currently connected Steam Remote Play sessions
+	virtual uint32 GetSessionCount() = 0;
+	
+	// Get the currently connected Steam Remote Play session ID at the specified index. Returns zero if index is out of bounds.
+	virtual RemotePlaySessionID_t GetSessionID( int iSessionIndex ) = 0;
+
+	// Get the SteamID of the connected user
+	virtual CSteamID GetSessionSteamID( RemotePlaySessionID_t unSessionID ) = 0;
+
+	// Get the name of the session client device
+	// This returns NULL if the sessionID is not valid
+	virtual const char *GetSessionClientName( RemotePlaySessionID_t unSessionID ) = 0;
+
+	// Get the form factor of the session client device
+	virtual ESteamDeviceFormFactor GetSessionClientFormFactor( RemotePlaySessionID_t unSessionID ) = 0;
+
+	// Get the resolution, in pixels, of the session client device
+	// This is set to 0x0 if the resolution is not available
+	virtual bool BGetSessionClientResolution( RemotePlaySessionID_t unSessionID, int *pnResolutionX, int *pnResolutionY ) = 0;
+
+	// Invite a friend to Remote Play Together
+	// This returns false if the invite can't be sent
+	virtual bool BSendRemotePlayTogetherInvite( CSteamID steamIDFriend ) = 0;
+};
+
+#define STEAMREMOTEPLAY_INTERFACE_VERSION "STEAMREMOTEPLAY_INTERFACE_VERSION001"
+
+// Global interface accessor
+inline ISteamRemotePlay *SteamRemotePlay();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamRemotePlay *, SteamRemotePlay, STEAMREMOTEPLAY_INTERFACE_VERSION );
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+
+
+STEAM_CALLBACK_BEGIN( SteamRemotePlaySessionConnected_t, k_iSteamRemotePlayCallbacks + 1 )
+	STEAM_CALLBACK_MEMBER( 0, RemotePlaySessionID_t, m_unSessionID )
+STEAM_CALLBACK_END( 0 )
+
+
+STEAM_CALLBACK_BEGIN( SteamRemotePlaySessionDisconnected_t, k_iSteamRemotePlayCallbacks + 2 )
+	STEAM_CALLBACK_MEMBER( 0, RemotePlaySessionID_t, m_unSessionID )
+STEAM_CALLBACK_END( 0 )
+
+
+#pragma pack( pop )
+
+
+#endif // #define ISTEAMREMOTEPLAY_H

--- a/lsteamclient/steamworks_sdk_148a/isteamremotestorage.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamremotestorage.h
@@ -1,0 +1,688 @@
+//====== Copyright � 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: public interface to user remote file storage in Steam
+//
+//=============================================================================
+
+#ifndef ISTEAMREMOTESTORAGE_H
+#define ISTEAMREMOTESTORAGE_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Defines the largest allowed file size. Cloud files cannot be written
+// in a single chunk over 100MB (and cannot be over 200MB total.)
+//-----------------------------------------------------------------------------
+const uint32 k_unMaxCloudFileChunkSize = 100 * 1024 * 1024;
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Structure that contains an array of const char * strings and the number of those strings
+//-----------------------------------------------------------------------------
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+struct SteamParamStringArray_t
+{
+	const char ** m_ppStrings;
+	int32 m_nNumStrings;
+};
+#pragma pack( pop )
+
+// A handle to a piece of user generated content
+typedef uint64 UGCHandle_t;
+typedef uint64 PublishedFileUpdateHandle_t;
+typedef uint64 PublishedFileId_t;
+const PublishedFileId_t k_PublishedFileIdInvalid = 0;
+const UGCHandle_t k_UGCHandleInvalid = 0xffffffffffffffffull;
+const PublishedFileUpdateHandle_t k_PublishedFileUpdateHandleInvalid = 0xffffffffffffffffull;
+
+// Handle for writing to Steam Cloud
+typedef uint64 UGCFileWriteStreamHandle_t;
+const UGCFileWriteStreamHandle_t k_UGCFileStreamHandleInvalid = 0xffffffffffffffffull;
+
+const uint32 k_cchPublishedDocumentTitleMax = 128 + 1;
+const uint32 k_cchPublishedDocumentDescriptionMax = 8000;
+const uint32 k_cchPublishedDocumentChangeDescriptionMax = 8000;
+const uint32 k_unEnumeratePublishedFilesMaxResults = 50;
+const uint32 k_cchTagListMax = 1024 + 1;
+const uint32 k_cchFilenameMax = 260;
+const uint32 k_cchPublishedFileURLMax = 256;
+
+
+enum ERemoteStoragePlatform
+{
+	k_ERemoteStoragePlatformNone		= 0,
+	k_ERemoteStoragePlatformWindows		= (1 << 0),
+	k_ERemoteStoragePlatformOSX			= (1 << 1),
+	k_ERemoteStoragePlatformPS3			= (1 << 2),
+	k_ERemoteStoragePlatformLinux		= (1 << 3),
+	k_ERemoteStoragePlatformSwitch		= (1 << 4),
+	k_ERemoteStoragePlatformAndroid		= (1 << 5),
+	k_ERemoteStoragePlatformIOS			= (1 << 6),
+	// NB we get one more before we need to widen some things
+
+	k_ERemoteStoragePlatformAll = 0xffffffff
+};
+
+enum ERemoteStoragePublishedFileVisibility
+{
+	k_ERemoteStoragePublishedFileVisibilityPublic = 0,
+	k_ERemoteStoragePublishedFileVisibilityFriendsOnly = 1,
+	k_ERemoteStoragePublishedFileVisibilityPrivate = 2,
+	k_ERemoteStoragePublishedFileVisibilityUnlisted = 3,
+};
+
+
+enum EWorkshopFileType
+{
+	k_EWorkshopFileTypeFirst = 0,
+
+	k_EWorkshopFileTypeCommunity			  = 0,		// normal Workshop item that can be subscribed to
+	k_EWorkshopFileTypeMicrotransaction		  = 1,		// Workshop item that is meant to be voted on for the purpose of selling in-game
+	k_EWorkshopFileTypeCollection			  = 2,		// a collection of Workshop or Greenlight items
+	k_EWorkshopFileTypeArt					  = 3,		// artwork
+	k_EWorkshopFileTypeVideo				  = 4,		// external video
+	k_EWorkshopFileTypeScreenshot			  = 5,		// screenshot
+	k_EWorkshopFileTypeGame					  = 6,		// Greenlight game entry
+	k_EWorkshopFileTypeSoftware				  = 7,		// Greenlight software entry
+	k_EWorkshopFileTypeConcept				  = 8,		// Greenlight concept
+	k_EWorkshopFileTypeWebGuide				  = 9,		// Steam web guide
+	k_EWorkshopFileTypeIntegratedGuide		  = 10,		// application integrated guide
+	k_EWorkshopFileTypeMerch				  = 11,		// Workshop merchandise meant to be voted on for the purpose of being sold
+	k_EWorkshopFileTypeControllerBinding	  = 12,		// Steam Controller bindings
+	k_EWorkshopFileTypeSteamworksAccessInvite = 13,		// internal
+	k_EWorkshopFileTypeSteamVideo			  = 14,		// Steam video
+	k_EWorkshopFileTypeGameManagedItem		  = 15,		// managed completely by the game, not the user, and not shown on the web
+
+	// Update k_EWorkshopFileTypeMax if you add values.
+	k_EWorkshopFileTypeMax = 16
+	
+};
+
+enum EWorkshopVote
+{
+	k_EWorkshopVoteUnvoted = 0,
+	k_EWorkshopVoteFor = 1,
+	k_EWorkshopVoteAgainst = 2,
+	k_EWorkshopVoteLater = 3,
+};
+
+enum EWorkshopFileAction
+{
+	k_EWorkshopFileActionPlayed = 0,
+	k_EWorkshopFileActionCompleted = 1,
+};
+
+enum EWorkshopEnumerationType
+{
+	k_EWorkshopEnumerationTypeRankedByVote = 0,
+	k_EWorkshopEnumerationTypeRecent = 1,
+	k_EWorkshopEnumerationTypeTrending = 2,
+	k_EWorkshopEnumerationTypeFavoritesOfFriends = 3,
+	k_EWorkshopEnumerationTypeVotedByFriends = 4,
+	k_EWorkshopEnumerationTypeContentByFriends = 5,
+	k_EWorkshopEnumerationTypeRecentFromFollowedUsers = 6,
+};
+
+enum EWorkshopVideoProvider
+{
+	k_EWorkshopVideoProviderNone = 0,
+	k_EWorkshopVideoProviderYoutube = 1
+};
+
+
+enum EUGCReadAction
+{
+	// Keeps the file handle open unless the last byte is read.  You can use this when reading large files (over 100MB) in sequential chunks.
+	// If the last byte is read, this will behave the same as k_EUGCRead_Close.  Otherwise, it behaves the same as k_EUGCRead_ContinueReading.
+	// This value maintains the same behavior as before the EUGCReadAction parameter was introduced.
+	k_EUGCRead_ContinueReadingUntilFinished = 0,
+
+	// Keeps the file handle open.  Use this when using UGCRead to seek to different parts of the file.
+	// When you are done seeking around the file, make a final call with k_EUGCRead_Close to close it.
+	k_EUGCRead_ContinueReading = 1,
+
+	// Frees the file handle.  Use this when you're done reading the content.  
+	// To read the file from Steam again you will need to call UGCDownload again. 
+	k_EUGCRead_Close = 2,	
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for accessing, reading and writing files stored remotely 
+//			and cached locally
+//-----------------------------------------------------------------------------
+class ISteamRemoteStorage
+{
+	public:
+		// NOTE
+		//
+		// Filenames are case-insensitive, and will be converted to lowercase automatically.
+		// So "foo.bar" and "Foo.bar" are the same file, and if you write "Foo.bar" then
+		// iterate the files, the filename returned will be "foo.bar".
+		//
+
+		// file operations
+		virtual bool	FileWrite( const char *pchFile, const void *pvData, int32 cubData ) = 0;
+		virtual int32	FileRead( const char *pchFile, void *pvData, int32 cubDataToRead ) = 0;
+		
+		STEAM_CALL_RESULT( RemoteStorageFileWriteAsyncComplete_t )
+		virtual SteamAPICall_t FileWriteAsync( const char *pchFile, const void *pvData, uint32 cubData ) = 0;
+		
+		STEAM_CALL_RESULT( RemoteStorageFileReadAsyncComplete_t )
+		virtual SteamAPICall_t FileReadAsync( const char *pchFile, uint32 nOffset, uint32 cubToRead ) = 0;
+		virtual bool	FileReadAsyncComplete( SteamAPICall_t hReadCall, void *pvBuffer, uint32 cubToRead ) = 0;
+		
+		virtual bool	FileForget( const char *pchFile ) = 0;
+		virtual bool	FileDelete( const char *pchFile ) = 0;
+		STEAM_CALL_RESULT( RemoteStorageFileShareResult_t )
+		virtual SteamAPICall_t FileShare( const char *pchFile ) = 0;
+		virtual bool	SetSyncPlatforms( const char *pchFile, ERemoteStoragePlatform eRemoteStoragePlatform ) = 0;
+
+		// file operations that cause network IO
+		virtual UGCFileWriteStreamHandle_t FileWriteStreamOpen( const char *pchFile ) = 0;
+		virtual bool FileWriteStreamWriteChunk( UGCFileWriteStreamHandle_t writeHandle, const void *pvData, int32 cubData ) = 0;
+		virtual bool FileWriteStreamClose( UGCFileWriteStreamHandle_t writeHandle ) = 0;
+		virtual bool FileWriteStreamCancel( UGCFileWriteStreamHandle_t writeHandle ) = 0;
+
+		// file information
+		virtual bool	FileExists( const char *pchFile ) = 0;
+		virtual bool	FilePersisted( const char *pchFile ) = 0;
+		virtual int32	GetFileSize( const char *pchFile ) = 0;
+		virtual int64	GetFileTimestamp( const char *pchFile ) = 0;
+		virtual ERemoteStoragePlatform GetSyncPlatforms( const char *pchFile ) = 0;
+
+		// iteration
+		virtual int32 GetFileCount() = 0;
+		virtual const char *GetFileNameAndSize( int iFile, int32 *pnFileSizeInBytes ) = 0;
+
+		// configuration management
+		virtual bool GetQuota( uint64 *pnTotalBytes, uint64 *puAvailableBytes ) = 0;
+		virtual bool IsCloudEnabledForAccount() = 0;
+		virtual bool IsCloudEnabledForApp() = 0;
+		virtual void SetCloudEnabledForApp( bool bEnabled ) = 0;
+
+		// user generated content
+
+		// Downloads a UGC file.  A priority value of 0 will download the file immediately,
+		// otherwise it will wait to download the file until all downloads with a lower priority
+		// value are completed.  Downloads with equal priority will occur simultaneously.
+		STEAM_CALL_RESULT( RemoteStorageDownloadUGCResult_t )
+		virtual SteamAPICall_t UGCDownload( UGCHandle_t hContent, uint32 unPriority ) = 0;
+		
+		// Gets the amount of data downloaded so far for a piece of content. pnBytesExpected can be 0 if function returns false
+		// or if the transfer hasn't started yet, so be careful to check for that before dividing to get a percentage
+		virtual bool	GetUGCDownloadProgress( UGCHandle_t hContent, int32 *pnBytesDownloaded, int32 *pnBytesExpected ) = 0;
+
+		// Gets metadata for a file after it has been downloaded. This is the same metadata given in the RemoteStorageDownloadUGCResult_t call result
+		virtual bool	GetUGCDetails( UGCHandle_t hContent, AppId_t *pnAppID, STEAM_OUT_STRING() char **ppchName, int32 *pnFileSizeInBytes, STEAM_OUT_STRUCT() CSteamID *pSteamIDOwner ) = 0;
+
+		// After download, gets the content of the file.  
+		// Small files can be read all at once by calling this function with an offset of 0 and cubDataToRead equal to the size of the file.
+		// Larger files can be read in chunks to reduce memory usage (since both sides of the IPC client and the game itself must allocate
+		// enough memory for each chunk).  Once the last byte is read, the file is implicitly closed and further calls to UGCRead will fail
+		// unless UGCDownload is called again.
+		// For especially large files (anything over 100MB) it is a requirement that the file is read in chunks.
+		virtual int32	UGCRead( UGCHandle_t hContent, void *pvData, int32 cubDataToRead, uint32 cOffset, EUGCReadAction eAction ) = 0;
+
+		// Functions to iterate through UGC that has finished downloading but has not yet been read via UGCRead()
+		virtual int32	GetCachedUGCCount() = 0;
+		virtual	UGCHandle_t GetCachedUGCHandle( int32 iCachedContent ) = 0;
+
+		// The following functions are only necessary on the Playstation 3. On PC & Mac, the Steam client will handle these operations for you
+		// On Playstation 3, the game controls which files are stored in the cloud, via FilePersist, FileFetch, and FileForget.
+			
+#if defined(_PS3) || defined(_SERVER)
+		// Connect to Steam and get a list of files in the Cloud - results in a RemoteStorageAppSyncStatusCheck_t callback
+		virtual void GetFileListFromServer() = 0;
+		// Indicate this file should be downloaded in the next sync
+		virtual bool FileFetch( const char *pchFile ) = 0;
+		// Indicate this file should be persisted in the next sync
+		virtual bool FilePersist( const char *pchFile ) = 0;
+		// Pull any requested files down from the Cloud - results in a RemoteStorageAppSyncedClient_t callback
+		virtual bool SynchronizeToClient() = 0;
+		// Upload any requested files to the Cloud - results in a RemoteStorageAppSyncedServer_t callback
+		virtual bool SynchronizeToServer() = 0;
+		// Reset any fetch/persist/etc requests
+		virtual bool ResetFileRequestState() = 0;
+#endif
+
+		// publishing UGC
+		STEAM_CALL_RESULT( RemoteStoragePublishFileProgress_t )
+		virtual SteamAPICall_t	PublishWorkshopFile( const char *pchFile, const char *pchPreviewFile, AppId_t nConsumerAppId, const char *pchTitle, const char *pchDescription, ERemoteStoragePublishedFileVisibility eVisibility, SteamParamStringArray_t *pTags, EWorkshopFileType eWorkshopFileType ) = 0;
+		virtual PublishedFileUpdateHandle_t CreatePublishedFileUpdateRequest( PublishedFileId_t unPublishedFileId ) = 0;
+		virtual bool UpdatePublishedFileFile( PublishedFileUpdateHandle_t updateHandle, const char *pchFile ) = 0;
+		virtual bool UpdatePublishedFilePreviewFile( PublishedFileUpdateHandle_t updateHandle, const char *pchPreviewFile ) = 0;
+		virtual bool UpdatePublishedFileTitle( PublishedFileUpdateHandle_t updateHandle, const char *pchTitle ) = 0;
+		virtual bool UpdatePublishedFileDescription( PublishedFileUpdateHandle_t updateHandle, const char *pchDescription ) = 0;
+		virtual bool UpdatePublishedFileVisibility( PublishedFileUpdateHandle_t updateHandle, ERemoteStoragePublishedFileVisibility eVisibility ) = 0;
+		virtual bool UpdatePublishedFileTags( PublishedFileUpdateHandle_t updateHandle, SteamParamStringArray_t *pTags ) = 0;
+		STEAM_CALL_RESULT( RemoteStorageUpdatePublishedFileResult_t )
+		virtual SteamAPICall_t	CommitPublishedFileUpdate( PublishedFileUpdateHandle_t updateHandle ) = 0;
+		// Gets published file details for the given publishedfileid.  If unMaxSecondsOld is greater than 0,
+		// cached data may be returned, depending on how long ago it was cached.  A value of 0 will force a refresh.
+		// A value of k_WorkshopForceLoadPublishedFileDetailsFromCache will use cached data if it exists, no matter how old it is.
+		STEAM_CALL_RESULT( RemoteStorageGetPublishedFileDetailsResult_t )
+		virtual SteamAPICall_t	GetPublishedFileDetails( PublishedFileId_t unPublishedFileId, uint32 unMaxSecondsOld ) = 0;
+		STEAM_CALL_RESULT( RemoteStorageDeletePublishedFileResult_t )
+		virtual SteamAPICall_t	DeletePublishedFile( PublishedFileId_t unPublishedFileId ) = 0;
+		// enumerate the files that the current user published with this app
+		STEAM_CALL_RESULT( RemoteStorageEnumerateUserPublishedFilesResult_t )
+		virtual SteamAPICall_t	EnumerateUserPublishedFiles( uint32 unStartIndex ) = 0;
+		STEAM_CALL_RESULT( RemoteStorageSubscribePublishedFileResult_t )
+		virtual SteamAPICall_t	SubscribePublishedFile( PublishedFileId_t unPublishedFileId ) = 0;
+		STEAM_CALL_RESULT( RemoteStorageEnumerateUserSubscribedFilesResult_t )
+		virtual SteamAPICall_t	EnumerateUserSubscribedFiles( uint32 unStartIndex ) = 0;
+		STEAM_CALL_RESULT( RemoteStorageUnsubscribePublishedFileResult_t )
+		virtual SteamAPICall_t	UnsubscribePublishedFile( PublishedFileId_t unPublishedFileId ) = 0;
+		virtual bool UpdatePublishedFileSetChangeDescription( PublishedFileUpdateHandle_t updateHandle, const char *pchChangeDescription ) = 0;
+		STEAM_CALL_RESULT( RemoteStorageGetPublishedItemVoteDetailsResult_t )
+		virtual SteamAPICall_t	GetPublishedItemVoteDetails( PublishedFileId_t unPublishedFileId ) = 0;
+		STEAM_CALL_RESULT( RemoteStorageUpdateUserPublishedItemVoteResult_t )
+		virtual SteamAPICall_t	UpdateUserPublishedItemVote( PublishedFileId_t unPublishedFileId, bool bVoteUp ) = 0;
+		STEAM_CALL_RESULT( RemoteStorageGetPublishedItemVoteDetailsResult_t )
+		virtual SteamAPICall_t	GetUserPublishedItemVoteDetails( PublishedFileId_t unPublishedFileId ) = 0;
+		STEAM_CALL_RESULT( RemoteStorageEnumerateUserPublishedFilesResult_t )
+		virtual SteamAPICall_t	EnumerateUserSharedWorkshopFiles( CSteamID steamId, uint32 unStartIndex, SteamParamStringArray_t *pRequiredTags, SteamParamStringArray_t *pExcludedTags ) = 0;
+		STEAM_CALL_RESULT( RemoteStoragePublishFileProgress_t )
+		virtual SteamAPICall_t	PublishVideo( EWorkshopVideoProvider eVideoProvider, const char *pchVideoAccount, const char *pchVideoIdentifier, const char *pchPreviewFile, AppId_t nConsumerAppId, const char *pchTitle, const char *pchDescription, ERemoteStoragePublishedFileVisibility eVisibility, SteamParamStringArray_t *pTags ) = 0;
+		STEAM_CALL_RESULT( RemoteStorageSetUserPublishedFileActionResult_t )
+		virtual SteamAPICall_t	SetUserPublishedFileAction( PublishedFileId_t unPublishedFileId, EWorkshopFileAction eAction ) = 0;
+		STEAM_CALL_RESULT( RemoteStorageEnumeratePublishedFilesByUserActionResult_t )
+		virtual SteamAPICall_t	EnumeratePublishedFilesByUserAction( EWorkshopFileAction eAction, uint32 unStartIndex ) = 0;
+		// this method enumerates the public view of workshop files
+		STEAM_CALL_RESULT( RemoteStorageEnumerateWorkshopFilesResult_t )
+		virtual SteamAPICall_t	EnumeratePublishedWorkshopFiles( EWorkshopEnumerationType eEnumerationType, uint32 unStartIndex, uint32 unCount, uint32 unDays, SteamParamStringArray_t *pTags, SteamParamStringArray_t *pUserTags ) = 0;
+
+		STEAM_CALL_RESULT( RemoteStorageDownloadUGCResult_t )
+		virtual SteamAPICall_t UGCDownloadToLocation( UGCHandle_t hContent, const char *pchLocation, uint32 unPriority ) = 0;
+};
+
+#define STEAMREMOTESTORAGE_INTERFACE_VERSION "STEAMREMOTESTORAGE_INTERFACE_VERSION014"
+
+// Global interface accessor
+inline ISteamRemoteStorage *SteamRemoteStorage();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamRemoteStorage *, SteamRemoteStorage, STEAMREMOTESTORAGE_INTERFACE_VERSION );
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+
+//-----------------------------------------------------------------------------
+// Purpose: sent when the local file cache is fully synced with the server for an app
+//          That means that an application can be started and has all latest files
+//-----------------------------------------------------------------------------
+struct RemoteStorageAppSyncedClient_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 1 };
+	AppId_t m_nAppID;
+	EResult m_eResult;
+	int m_unNumDownloads;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: sent when the server is fully synced with the local file cache for an app
+//          That means that we can shutdown Steam and our data is stored on the server
+//-----------------------------------------------------------------------------
+struct RemoteStorageAppSyncedServer_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 2 };
+	AppId_t m_nAppID;
+	EResult m_eResult;
+	int m_unNumUploads;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: Status of up and downloads during a sync session
+//       
+//-----------------------------------------------------------------------------
+struct RemoteStorageAppSyncProgress_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 3 };
+	char m_rgchCurrentFile[k_cchFilenameMax];				// Current file being transferred
+	AppId_t m_nAppID;							// App this info relates to
+	uint32 m_uBytesTransferredThisChunk;		// Bytes transferred this chunk
+	double m_dAppPercentComplete;				// Percent complete that this app's transfers are
+	bool m_bUploading;							// if false, downloading
+};
+
+//
+// IMPORTANT! k_iClientRemoteStorageCallbacks + 4 is used, see iclientremotestorage.h
+//
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Sent after we've determined the list of files that are out of sync
+//          with the server.
+//-----------------------------------------------------------------------------
+struct RemoteStorageAppSyncStatusCheck_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 5 };
+	AppId_t m_nAppID;
+	EResult m_eResult;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to FileShare()
+//-----------------------------------------------------------------------------
+struct RemoteStorageFileShareResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 7 };
+	EResult m_eResult;			// The result of the operation
+	UGCHandle_t m_hFile;		// The handle that can be shared with users and features
+	char m_rgchFilename[k_cchFilenameMax]; // The name of the file that was shared
+};
+
+
+// k_iClientRemoteStorageCallbacks + 8 is deprecated! Do not reuse
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to PublishFile()
+//-----------------------------------------------------------------------------
+struct RemoteStoragePublishFileResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 9 };
+	EResult m_eResult;				// The result of the operation.
+	PublishedFileId_t m_nPublishedFileId;
+	bool m_bUserNeedsToAcceptWorkshopLegalAgreement;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to DeletePublishedFile()
+//-----------------------------------------------------------------------------
+struct RemoteStorageDeletePublishedFileResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 11 };
+	EResult m_eResult;				// The result of the operation.
+	PublishedFileId_t m_nPublishedFileId;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to EnumerateUserPublishedFiles()
+//-----------------------------------------------------------------------------
+struct RemoteStorageEnumerateUserPublishedFilesResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 12 };
+	EResult m_eResult;				// The result of the operation.
+	int32 m_nResultsReturned;
+	int32 m_nTotalResultCount;
+	PublishedFileId_t m_rgPublishedFileId[ k_unEnumeratePublishedFilesMaxResults ];
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to SubscribePublishedFile()
+//-----------------------------------------------------------------------------
+struct RemoteStorageSubscribePublishedFileResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 13 };
+	EResult m_eResult;				// The result of the operation.
+	PublishedFileId_t m_nPublishedFileId;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to EnumerateSubscribePublishedFiles()
+//-----------------------------------------------------------------------------
+struct RemoteStorageEnumerateUserSubscribedFilesResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 14 };
+	EResult m_eResult;				// The result of the operation.
+	int32 m_nResultsReturned;
+	int32 m_nTotalResultCount;
+	PublishedFileId_t m_rgPublishedFileId[ k_unEnumeratePublishedFilesMaxResults ];
+	uint32 m_rgRTimeSubscribed[ k_unEnumeratePublishedFilesMaxResults ];
+};
+
+#if defined(VALVE_CALLBACK_PACK_SMALL)
+	VALVE_COMPILE_TIME_ASSERT( sizeof( RemoteStorageEnumerateUserSubscribedFilesResult_t ) == (1 + 1 + 1 + 50 + 100) * 4 );
+#elif defined(VALVE_CALLBACK_PACK_LARGE)
+	VALVE_COMPILE_TIME_ASSERT( sizeof( RemoteStorageEnumerateUserSubscribedFilesResult_t ) == (1 + 1 + 1 + 50 + 100) * 4 + 4 );
+#else
+#warning You must first include steam_api_common.h
+#endif
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to UnsubscribePublishedFile()
+//-----------------------------------------------------------------------------
+struct RemoteStorageUnsubscribePublishedFileResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 15 };
+	EResult m_eResult;				// The result of the operation.
+	PublishedFileId_t m_nPublishedFileId;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to CommitPublishedFileUpdate()
+//-----------------------------------------------------------------------------
+struct RemoteStorageUpdatePublishedFileResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 16 };
+	EResult m_eResult;				// The result of the operation.
+	PublishedFileId_t m_nPublishedFileId;
+	bool m_bUserNeedsToAcceptWorkshopLegalAgreement;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to UGCDownload()
+//-----------------------------------------------------------------------------
+struct RemoteStorageDownloadUGCResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 17 };
+	EResult m_eResult;				// The result of the operation.
+	UGCHandle_t m_hFile;			// The handle to the file that was attempted to be downloaded.
+	AppId_t m_nAppID;				// ID of the app that created this file.
+	int32 m_nSizeInBytes;			// The size of the file that was downloaded, in bytes.
+	char m_pchFileName[k_cchFilenameMax];		// The name of the file that was downloaded. 
+	uint64 m_ulSteamIDOwner;		// Steam ID of the user who created this content.
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to GetPublishedFileDetails()
+//-----------------------------------------------------------------------------
+struct RemoteStorageGetPublishedFileDetailsResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 18 };
+	EResult m_eResult;				// The result of the operation.
+	PublishedFileId_t m_nPublishedFileId;
+	AppId_t m_nCreatorAppID;		// ID of the app that created this file.
+	AppId_t m_nConsumerAppID;		// ID of the app that will consume this file.
+	char m_rgchTitle[k_cchPublishedDocumentTitleMax];		// title of document
+	char m_rgchDescription[k_cchPublishedDocumentDescriptionMax];	// description of document
+	UGCHandle_t m_hFile;			// The handle of the primary file
+	UGCHandle_t m_hPreviewFile;		// The handle of the preview file
+	uint64 m_ulSteamIDOwner;		// Steam ID of the user who created this content.
+	uint32 m_rtimeCreated;			// time when the published file was created
+	uint32 m_rtimeUpdated;			// time when the published file was last updated
+	ERemoteStoragePublishedFileVisibility m_eVisibility;
+	bool m_bBanned;
+	char m_rgchTags[k_cchTagListMax];	// comma separated list of all tags associated with this file
+	bool m_bTagsTruncated;			// whether the list of tags was too long to be returned in the provided buffer
+	char m_pchFileName[k_cchFilenameMax];		// The name of the primary file
+	int32 m_nFileSize;				// Size of the primary file
+	int32 m_nPreviewFileSize;		// Size of the preview file
+	char m_rgchURL[k_cchPublishedFileURLMax];	// URL (for a video or a website)
+	EWorkshopFileType m_eFileType;	// Type of the file
+	bool m_bAcceptedForUse;			// developer has specifically flagged this item as accepted in the Workshop
+};
+
+
+struct RemoteStorageEnumerateWorkshopFilesResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 19 };
+	EResult m_eResult;
+	int32 m_nResultsReturned;
+	int32 m_nTotalResultCount;
+	PublishedFileId_t m_rgPublishedFileId[ k_unEnumeratePublishedFilesMaxResults ];
+	float m_rgScore[ k_unEnumeratePublishedFilesMaxResults ];
+	AppId_t m_nAppId;
+	uint32 m_unStartIndex;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of GetPublishedItemVoteDetails
+//-----------------------------------------------------------------------------
+struct RemoteStorageGetPublishedItemVoteDetailsResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 20 };
+	EResult m_eResult;
+	PublishedFileId_t m_unPublishedFileId;
+	int32 m_nVotesFor;
+	int32 m_nVotesAgainst;
+	int32 m_nReports;
+	float m_fScore;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: User subscribed to a file for the app (from within the app or on the web)
+//-----------------------------------------------------------------------------
+struct RemoteStoragePublishedFileSubscribed_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 21 };
+	PublishedFileId_t m_nPublishedFileId;	// The published file id
+	AppId_t m_nAppID;						// ID of the app that will consume this file.
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: User unsubscribed from a file for the app (from within the app or on the web)
+//-----------------------------------------------------------------------------
+struct RemoteStoragePublishedFileUnsubscribed_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 22 };
+	PublishedFileId_t m_nPublishedFileId;	// The published file id
+	AppId_t m_nAppID;						// ID of the app that will consume this file.
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Published file that a user owns was deleted (from within the app or the web)
+//-----------------------------------------------------------------------------
+struct RemoteStoragePublishedFileDeleted_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 23 };
+	PublishedFileId_t m_nPublishedFileId;	// The published file id
+	AppId_t m_nAppID;						// ID of the app that will consume this file.
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to UpdateUserPublishedItemVote()
+//-----------------------------------------------------------------------------
+struct RemoteStorageUpdateUserPublishedItemVoteResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 24 };
+	EResult m_eResult;				// The result of the operation.
+	PublishedFileId_t m_nPublishedFileId;	// The published file id
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to GetUserPublishedItemVoteDetails()
+//-----------------------------------------------------------------------------
+struct RemoteStorageUserVoteDetails_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 25 };
+	EResult m_eResult;				// The result of the operation.
+	PublishedFileId_t m_nPublishedFileId;	// The published file id
+	EWorkshopVote m_eVote;			// what the user voted
+};
+
+struct RemoteStorageEnumerateUserSharedWorkshopFilesResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 26 };
+	EResult m_eResult;				// The result of the operation.
+	int32 m_nResultsReturned;
+	int32 m_nTotalResultCount;
+	PublishedFileId_t m_rgPublishedFileId[ k_unEnumeratePublishedFilesMaxResults ];
+};
+
+struct RemoteStorageSetUserPublishedFileActionResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 27 };
+	EResult m_eResult;				// The result of the operation.
+	PublishedFileId_t m_nPublishedFileId;	// The published file id
+	EWorkshopFileAction m_eAction;	// the action that was attempted
+};
+
+struct RemoteStorageEnumeratePublishedFilesByUserActionResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 28 };
+	EResult m_eResult;				// The result of the operation.
+	EWorkshopFileAction m_eAction;	// the action that was filtered on
+	int32 m_nResultsReturned;
+	int32 m_nTotalResultCount;
+	PublishedFileId_t m_rgPublishedFileId[ k_unEnumeratePublishedFilesMaxResults ];
+	uint32 m_rgRTimeUpdated[ k_unEnumeratePublishedFilesMaxResults ];
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Called periodically while a PublishWorkshopFile is in progress
+//-----------------------------------------------------------------------------
+struct RemoteStoragePublishFileProgress_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 29 };
+	double m_dPercentFile;
+	bool m_bPreview;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Called when the content for a published file is updated
+//-----------------------------------------------------------------------------
+struct RemoteStoragePublishedFileUpdated_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 30 };
+	PublishedFileId_t m_nPublishedFileId;	// The published file id
+	AppId_t m_nAppID;						// ID of the app that will consume this file.
+	uint64 m_ulUnused;						// not used anymore
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: Called when a FileWriteAsync completes
+//-----------------------------------------------------------------------------
+struct RemoteStorageFileWriteAsyncComplete_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 31 };
+	EResult	m_eResult;						// result
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: Called when a FileReadAsync completes
+//-----------------------------------------------------------------------------
+struct RemoteStorageFileReadAsyncComplete_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 32 };
+	SteamAPICall_t m_hFileReadAsync;		// call handle of the async read which was made
+	EResult	m_eResult;						// result
+	uint32 m_nOffset;						// offset in the file this read was at
+	uint32 m_cubRead;						// amount read - will the <= the amount requested
+};
+
+#pragma pack( pop )
+
+
+#endif // ISTEAMREMOTESTORAGE_H

--- a/lsteamclient/steamworks_sdk_148a/isteamscreenshots.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamscreenshots.h
@@ -1,0 +1,120 @@
+//====== Copyright � 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: public interface to user remote file storage in Steam
+//
+//=============================================================================
+
+#ifndef ISTEAMSCREENSHOTS_H
+#define ISTEAMSCREENSHOTS_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+
+const uint32 k_nScreenshotMaxTaggedUsers = 32;
+const uint32 k_nScreenshotMaxTaggedPublishedFiles = 32;
+const int k_cubUFSTagTypeMax = 255;
+const int k_cubUFSTagValueMax = 255;
+
+// Required with of a thumbnail provided to AddScreenshotToLibrary.  If you do not provide a thumbnail
+// one will be generated.
+const int k_ScreenshotThumbWidth = 200;
+
+// Handle is valid for the lifetime of your process and no longer
+typedef uint32 ScreenshotHandle; 
+#define INVALID_SCREENSHOT_HANDLE 0
+
+enum EVRScreenshotType
+{
+	k_EVRScreenshotType_None			= 0,
+	k_EVRScreenshotType_Mono			= 1,
+	k_EVRScreenshotType_Stereo			= 2,
+	k_EVRScreenshotType_MonoCubemap		= 3,
+	k_EVRScreenshotType_MonoPanorama	= 4,
+	k_EVRScreenshotType_StereoPanorama	= 5
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for adding screenshots to the user's screenshot library
+//-----------------------------------------------------------------------------
+class ISteamScreenshots
+{
+public:
+	// Writes a screenshot to the user's screenshot library given the raw image data, which must be in RGB format.
+	// The return value is a handle that is valid for the duration of the game process and can be used to apply tags.
+	virtual ScreenshotHandle WriteScreenshot( void *pubRGB, uint32 cubRGB, int nWidth, int nHeight ) = 0;
+
+	// Adds a screenshot to the user's screenshot library from disk.  If a thumbnail is provided, it must be 200 pixels wide and the same aspect ratio
+	// as the screenshot, otherwise a thumbnail will be generated if the user uploads the screenshot.  The screenshots must be in either JPEG or TGA format.
+	// The return value is a handle that is valid for the duration of the game process and can be used to apply tags.
+	// JPEG, TGA, and PNG formats are supported.
+	virtual ScreenshotHandle AddScreenshotToLibrary( const char *pchFilename, const char *pchThumbnailFilename, int nWidth, int nHeight ) = 0;
+
+	// Causes the Steam overlay to take a screenshot.  If screenshots are being hooked by the game then a ScreenshotRequested_t callback is sent back to the game instead. 
+	virtual void TriggerScreenshot() = 0;
+
+	// Toggles whether the overlay handles screenshots when the user presses the screenshot hotkey, or the game handles them.  If the game is hooking screenshots,
+	// then the ScreenshotRequested_t callback will be sent if the user presses the hotkey, and the game is expected to call WriteScreenshot or AddScreenshotToLibrary
+	// in response.
+	virtual void HookScreenshots( bool bHook ) = 0;
+
+	// Sets metadata about a screenshot's location (for example, the name of the map)
+	virtual bool SetLocation( ScreenshotHandle hScreenshot, const char *pchLocation ) = 0;
+	
+	// Tags a user as being visible in the screenshot
+	virtual bool TagUser( ScreenshotHandle hScreenshot, CSteamID steamID ) = 0;
+
+	// Tags a published file as being visible in the screenshot
+	virtual bool TagPublishedFile( ScreenshotHandle hScreenshot, PublishedFileId_t unPublishedFileID ) = 0;
+
+	// Returns true if the app has hooked the screenshot
+	virtual bool IsScreenshotsHooked() = 0;
+
+	// Adds a VR screenshot to the user's screenshot library from disk in the supported type.
+	// pchFilename should be the normal 2D image used in the library view
+	// pchVRFilename should contain the image that matches the correct type
+	// The return value is a handle that is valid for the duration of the game process and can be used to apply tags.
+	// JPEG, TGA, and PNG formats are supported.
+	virtual ScreenshotHandle AddVRScreenshotToLibrary( EVRScreenshotType eType, const char *pchFilename, const char *pchVRFilename ) = 0;
+};
+
+#define STEAMSCREENSHOTS_INTERFACE_VERSION "STEAMSCREENSHOTS_INTERFACE_VERSION003"
+
+// Global interface accessor
+inline ISteamScreenshots *SteamScreenshots();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamScreenshots *, SteamScreenshots, STEAMSCREENSHOTS_INTERFACE_VERSION );
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+//-----------------------------------------------------------------------------
+// Purpose: Screenshot successfully written or otherwise added to the library
+// and can now be tagged
+//-----------------------------------------------------------------------------
+struct ScreenshotReady_t
+{
+	enum { k_iCallback = k_iSteamScreenshotsCallbacks + 1 };
+	ScreenshotHandle m_hLocal;
+	EResult m_eResult;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: Screenshot has been requested by the user.  Only sent if
+// HookScreenshots() has been called, in which case Steam will not take
+// the screenshot itself.
+//-----------------------------------------------------------------------------
+struct ScreenshotRequested_t
+{
+	enum { k_iCallback = k_iSteamScreenshotsCallbacks + 2 };
+};
+
+#pragma pack( pop )
+
+#endif // ISTEAMSCREENSHOTS_H
+

--- a/lsteamclient/steamworks_sdk_148a/isteamugc.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamugc.h
@@ -1,0 +1,569 @@
+//====== Copyright 1996-2013, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to steam ugc
+//
+//=============================================================================
+
+#ifndef ISTEAMUGC_H
+#define ISTEAMUGC_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+#include "isteamremotestorage.h"
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+
+
+typedef uint64 UGCQueryHandle_t;
+typedef uint64 UGCUpdateHandle_t;
+
+
+const UGCQueryHandle_t k_UGCQueryHandleInvalid = 0xffffffffffffffffull;
+const UGCUpdateHandle_t k_UGCUpdateHandleInvalid = 0xffffffffffffffffull;
+
+
+// Matching UGC types for queries
+enum EUGCMatchingUGCType
+{
+	k_EUGCMatchingUGCType_Items				 = 0,		// both mtx items and ready-to-use items
+	k_EUGCMatchingUGCType_Items_Mtx			 = 1,
+	k_EUGCMatchingUGCType_Items_ReadyToUse	 = 2,
+	k_EUGCMatchingUGCType_Collections		 = 3,
+	k_EUGCMatchingUGCType_Artwork			 = 4,
+	k_EUGCMatchingUGCType_Videos			 = 5,
+	k_EUGCMatchingUGCType_Screenshots		 = 6,
+	k_EUGCMatchingUGCType_AllGuides			 = 7,		// both web guides and integrated guides
+	k_EUGCMatchingUGCType_WebGuides			 = 8,
+	k_EUGCMatchingUGCType_IntegratedGuides	 = 9,
+	k_EUGCMatchingUGCType_UsableInGame		 = 10,		// ready-to-use items and integrated guides
+	k_EUGCMatchingUGCType_ControllerBindings = 11,
+	k_EUGCMatchingUGCType_GameManagedItems	 = 12,		// game managed items (not managed by users)
+	k_EUGCMatchingUGCType_All				 = ~0,		// @note: will only be valid for CreateQueryUserUGCRequest requests
+};
+
+// Different lists of published UGC for a user.
+// If the current logged in user is different than the specified user, then some options may not be allowed.
+enum EUserUGCList
+{
+	k_EUserUGCList_Published,
+	k_EUserUGCList_VotedOn,
+	k_EUserUGCList_VotedUp,
+	k_EUserUGCList_VotedDown,
+	k_EUserUGCList_WillVoteLater,
+	k_EUserUGCList_Favorited,
+	k_EUserUGCList_Subscribed,
+	k_EUserUGCList_UsedOrPlayed,
+	k_EUserUGCList_Followed,
+};
+
+// Sort order for user published UGC lists (defaults to creation order descending)
+enum EUserUGCListSortOrder
+{
+	k_EUserUGCListSortOrder_CreationOrderDesc,
+	k_EUserUGCListSortOrder_CreationOrderAsc,
+	k_EUserUGCListSortOrder_TitleAsc,
+	k_EUserUGCListSortOrder_LastUpdatedDesc,
+	k_EUserUGCListSortOrder_SubscriptionDateDesc,
+	k_EUserUGCListSortOrder_VoteScoreDesc,
+	k_EUserUGCListSortOrder_ForModeration,
+};
+
+// Combination of sorting and filtering for queries across all UGC
+enum EUGCQuery
+{
+	k_EUGCQuery_RankedByVote								  = 0,
+	k_EUGCQuery_RankedByPublicationDate						  = 1,
+	k_EUGCQuery_AcceptedForGameRankedByAcceptanceDate		  = 2,
+	k_EUGCQuery_RankedByTrend								  = 3,
+	k_EUGCQuery_FavoritedByFriendsRankedByPublicationDate	  = 4,
+	k_EUGCQuery_CreatedByFriendsRankedByPublicationDate		  = 5,
+	k_EUGCQuery_RankedByNumTimesReported					  = 6,
+	k_EUGCQuery_CreatedByFollowedUsersRankedByPublicationDate = 7,
+	k_EUGCQuery_NotYetRated									  = 8,
+	k_EUGCQuery_RankedByTotalVotesAsc						  = 9,
+	k_EUGCQuery_RankedByVotesUp								  = 10,
+	k_EUGCQuery_RankedByTextSearch							  = 11,
+	k_EUGCQuery_RankedByTotalUniqueSubscriptions			  = 12,
+	k_EUGCQuery_RankedByPlaytimeTrend						  = 13,
+	k_EUGCQuery_RankedByTotalPlaytime						  = 14,
+	k_EUGCQuery_RankedByAveragePlaytimeTrend				  = 15,
+	k_EUGCQuery_RankedByLifetimeAveragePlaytime				  = 16,
+	k_EUGCQuery_RankedByPlaytimeSessionsTrend				  = 17,
+	k_EUGCQuery_RankedByLifetimePlaytimeSessions			  = 18,
+};
+
+enum EItemUpdateStatus
+{
+	k_EItemUpdateStatusInvalid 				= 0, // The item update handle was invalid, job might be finished, listen too SubmitItemUpdateResult_t
+	k_EItemUpdateStatusPreparingConfig 		= 1, // The item update is processing configuration data
+	k_EItemUpdateStatusPreparingContent		= 2, // The item update is reading and processing content files
+	k_EItemUpdateStatusUploadingContent		= 3, // The item update is uploading content changes to Steam
+	k_EItemUpdateStatusUploadingPreviewFile	= 4, // The item update is uploading new preview file image
+	k_EItemUpdateStatusCommittingChanges	= 5  // The item update is committing all changes
+};
+
+enum EItemState
+{
+	k_EItemStateNone			= 0,	// item not tracked on client
+	k_EItemStateSubscribed		= 1,	// current user is subscribed to this item. Not just cached.
+	k_EItemStateLegacyItem		= 2,	// item was created with ISteamRemoteStorage
+	k_EItemStateInstalled		= 4,	// item is installed and usable (but maybe out of date)
+	k_EItemStateNeedsUpdate		= 8,	// items needs an update. Either because it's not installed yet or creator updated content
+	k_EItemStateDownloading		= 16,	// item update is currently downloading
+	k_EItemStateDownloadPending	= 32,	// DownloadItem() was called for this item, content isn't available until DownloadItemResult_t is fired
+};
+
+enum EItemStatistic
+{
+	k_EItemStatistic_NumSubscriptions					 = 0,
+	k_EItemStatistic_NumFavorites						 = 1,
+	k_EItemStatistic_NumFollowers						 = 2,
+	k_EItemStatistic_NumUniqueSubscriptions				 = 3,
+	k_EItemStatistic_NumUniqueFavorites					 = 4,
+	k_EItemStatistic_NumUniqueFollowers					 = 5,
+	k_EItemStatistic_NumUniqueWebsiteViews				 = 6,
+	k_EItemStatistic_ReportScore						 = 7,
+	k_EItemStatistic_NumSecondsPlayed					 = 8,
+	k_EItemStatistic_NumPlaytimeSessions				 = 9,
+	k_EItemStatistic_NumComments						 = 10,
+	k_EItemStatistic_NumSecondsPlayedDuringTimePeriod	 = 11,
+	k_EItemStatistic_NumPlaytimeSessionsDuringTimePeriod = 12,
+};
+
+enum EItemPreviewType
+{
+	k_EItemPreviewType_Image							= 0,	// standard image file expected (e.g. jpg, png, gif, etc.)
+	k_EItemPreviewType_YouTubeVideo						= 1,	// video id is stored
+	k_EItemPreviewType_Sketchfab						= 2,	// model id is stored
+	k_EItemPreviewType_EnvironmentMap_HorizontalCross	= 3,	// standard image file expected - cube map in the layout
+																// +---+---+-------+
+																// |   |Up |       |
+																// +---+---+---+---+
+																// | L | F | R | B |
+																// +---+---+---+---+
+																// |   |Dn |       |
+																// +---+---+---+---+
+	k_EItemPreviewType_EnvironmentMap_LatLong			= 4,	// standard image file expected
+	k_EItemPreviewType_ReservedMax						= 255,	// you can specify your own types above this value
+};
+
+const uint32 kNumUGCResultsPerPage = 50;
+const uint32 k_cchDeveloperMetadataMax = 5000;
+
+// Details for a single published file/UGC
+struct SteamUGCDetails_t
+{
+	PublishedFileId_t m_nPublishedFileId;
+	EResult m_eResult;												// The result of the operation.	
+	EWorkshopFileType m_eFileType;									// Type of the file
+	AppId_t m_nCreatorAppID;										// ID of the app that created this file.
+	AppId_t m_nConsumerAppID;										// ID of the app that will consume this file.
+	char m_rgchTitle[k_cchPublishedDocumentTitleMax];				// title of document
+	char m_rgchDescription[k_cchPublishedDocumentDescriptionMax];	// description of document
+	uint64 m_ulSteamIDOwner;										// Steam ID of the user who created this content.
+	uint32 m_rtimeCreated;											// time when the published file was created
+	uint32 m_rtimeUpdated;											// time when the published file was last updated
+	uint32 m_rtimeAddedToUserList;									// time when the user added the published file to their list (not always applicable)
+	ERemoteStoragePublishedFileVisibility m_eVisibility;			// visibility
+	bool m_bBanned;													// whether the file was banned
+	bool m_bAcceptedForUse;											// developer has specifically flagged this item as accepted in the Workshop
+	bool m_bTagsTruncated;											// whether the list of tags was too long to be returned in the provided buffer
+	char m_rgchTags[k_cchTagListMax];								// comma separated list of all tags associated with this file	
+	// file/url information
+	UGCHandle_t m_hFile;											// The handle of the primary file
+	UGCHandle_t m_hPreviewFile;										// The handle of the preview file
+	char m_pchFileName[k_cchFilenameMax];							// The cloud filename of the primary file
+	int32 m_nFileSize;												// Size of the primary file
+	int32 m_nPreviewFileSize;										// Size of the preview file
+	char m_rgchURL[k_cchPublishedFileURLMax];						// URL (for a video or a website)
+	// voting information
+	uint32 m_unVotesUp;												// number of votes up
+	uint32 m_unVotesDown;											// number of votes down
+	float m_flScore;												// calculated score
+	// collection details
+	uint32 m_unNumChildren;							
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: Steam UGC support API
+//-----------------------------------------------------------------------------
+class ISteamUGC
+{
+public:
+
+	// Query UGC associated with a user. Creator app id or consumer app id must be valid and be set to the current running app. unPage should start at 1.
+	virtual UGCQueryHandle_t CreateQueryUserUGCRequest( AccountID_t unAccountID, EUserUGCList eListType, EUGCMatchingUGCType eMatchingUGCType, EUserUGCListSortOrder eSortOrder, AppId_t nCreatorAppID, AppId_t nConsumerAppID, uint32 unPage ) = 0;
+
+	// Query for all matching UGC. Creator app id or consumer app id must be valid and be set to the current running app. unPage should start at 1.
+	STEAM_FLAT_NAME( CreateQueryAllUGCRequestPage )
+	virtual UGCQueryHandle_t CreateQueryAllUGCRequest( EUGCQuery eQueryType, EUGCMatchingUGCType eMatchingeMatchingUGCTypeFileType, AppId_t nCreatorAppID, AppId_t nConsumerAppID, uint32 unPage ) = 0;
+
+	// Query for all matching UGC using the new deep paging interface. Creator app id or consumer app id must be valid and be set to the current running app. pchCursor should be set to NULL or "*" to get the first result set.
+	STEAM_FLAT_NAME( CreateQueryAllUGCRequestCursor )
+	virtual UGCQueryHandle_t CreateQueryAllUGCRequest( EUGCQuery eQueryType, EUGCMatchingUGCType eMatchingeMatchingUGCTypeFileType, AppId_t nCreatorAppID, AppId_t nConsumerAppID, const char *pchCursor = NULL ) = 0;
+
+	// Query for the details of the given published file ids (the RequestUGCDetails call is deprecated and replaced with this)
+	virtual UGCQueryHandle_t CreateQueryUGCDetailsRequest( PublishedFileId_t *pvecPublishedFileID, uint32 unNumPublishedFileIDs ) = 0;
+
+	// Send the query to Steam
+	STEAM_CALL_RESULT( SteamUGCQueryCompleted_t )
+	virtual SteamAPICall_t SendQueryUGCRequest( UGCQueryHandle_t handle ) = 0;
+
+	// Retrieve an individual result after receiving the callback for querying UGC
+	virtual bool GetQueryUGCResult( UGCQueryHandle_t handle, uint32 index, SteamUGCDetails_t *pDetails ) = 0;
+	virtual bool GetQueryUGCPreviewURL( UGCQueryHandle_t handle, uint32 index, STEAM_OUT_STRING_COUNT(cchURLSize) char *pchURL, uint32 cchURLSize ) = 0;
+	virtual bool GetQueryUGCMetadata( UGCQueryHandle_t handle, uint32 index, STEAM_OUT_STRING_COUNT(cchMetadatasize) char *pchMetadata, uint32 cchMetadatasize ) = 0;
+	virtual bool GetQueryUGCChildren( UGCQueryHandle_t handle, uint32 index, PublishedFileId_t* pvecPublishedFileID, uint32 cMaxEntries ) = 0;
+	virtual bool GetQueryUGCStatistic( UGCQueryHandle_t handle, uint32 index, EItemStatistic eStatType, uint64 *pStatValue ) = 0;
+	virtual uint32 GetQueryUGCNumAdditionalPreviews( UGCQueryHandle_t handle, uint32 index ) = 0;
+	virtual bool GetQueryUGCAdditionalPreview( UGCQueryHandle_t handle, uint32 index, uint32 previewIndex, STEAM_OUT_STRING_COUNT(cchURLSize) char *pchURLOrVideoID, uint32 cchURLSize, STEAM_OUT_STRING_COUNT(cchURLSize) char *pchOriginalFileName, uint32 cchOriginalFileNameSize, EItemPreviewType *pPreviewType ) = 0;
+	virtual uint32 GetQueryUGCNumKeyValueTags( UGCQueryHandle_t handle, uint32 index ) = 0;
+
+	virtual bool GetQueryUGCKeyValueTag( UGCQueryHandle_t handle, uint32 index, uint32 keyValueTagIndex, STEAM_OUT_STRING_COUNT(cchKeySize) char *pchKey, uint32 cchKeySize, STEAM_OUT_STRING_COUNT(cchValueSize) char *pchValue, uint32 cchValueSize ) = 0;
+
+	// Return the first value matching the pchKey. Note that a key may map to multiple values.  Returns false if there was an error or no matching value was found.
+	STEAM_FLAT_NAME( GetQueryFirstUGCKeyValueTag )
+	virtual bool GetQueryUGCKeyValueTag( UGCQueryHandle_t handle, uint32 index, const char *pchKey, STEAM_OUT_STRING_COUNT(cchValueSize) char *pchValue, uint32 cchValueSize ) = 0;
+
+	// Release the request to free up memory, after retrieving results
+	virtual bool ReleaseQueryUGCRequest( UGCQueryHandle_t handle ) = 0;
+
+	// Options to set for querying UGC
+	virtual bool AddRequiredTag( UGCQueryHandle_t handle, const char *pTagName ) = 0;
+	virtual bool AddRequiredTagGroup( UGCQueryHandle_t handle, const SteamParamStringArray_t *pTagGroups ) = 0; // match any of the tags in this group
+	virtual bool AddExcludedTag( UGCQueryHandle_t handle, const char *pTagName ) = 0;
+	virtual bool SetReturnOnlyIDs( UGCQueryHandle_t handle, bool bReturnOnlyIDs ) = 0;
+	virtual bool SetReturnKeyValueTags( UGCQueryHandle_t handle, bool bReturnKeyValueTags ) = 0;
+	virtual bool SetReturnLongDescription( UGCQueryHandle_t handle, bool bReturnLongDescription ) = 0;
+	virtual bool SetReturnMetadata( UGCQueryHandle_t handle, bool bReturnMetadata ) = 0;
+	virtual bool SetReturnChildren( UGCQueryHandle_t handle, bool bReturnChildren ) = 0;
+	virtual bool SetReturnAdditionalPreviews( UGCQueryHandle_t handle, bool bReturnAdditionalPreviews ) = 0;
+	virtual bool SetReturnTotalOnly( UGCQueryHandle_t handle, bool bReturnTotalOnly ) = 0;
+	virtual bool SetReturnPlaytimeStats( UGCQueryHandle_t handle, uint32 unDays ) = 0;
+	virtual bool SetLanguage( UGCQueryHandle_t handle, const char *pchLanguage ) = 0;
+	virtual bool SetAllowCachedResponse( UGCQueryHandle_t handle, uint32 unMaxAgeSeconds ) = 0;
+
+	// Options only for querying user UGC
+	virtual bool SetCloudFileNameFilter( UGCQueryHandle_t handle, const char *pMatchCloudFileName ) = 0;
+
+	// Options only for querying all UGC
+	virtual bool SetMatchAnyTag( UGCQueryHandle_t handle, bool bMatchAnyTag ) = 0;
+	virtual bool SetSearchText( UGCQueryHandle_t handle, const char *pSearchText ) = 0;
+	virtual bool SetRankedByTrendDays( UGCQueryHandle_t handle, uint32 unDays ) = 0;
+	virtual bool AddRequiredKeyValueTag( UGCQueryHandle_t handle, const char *pKey, const char *pValue ) = 0;
+
+	// DEPRECATED - Use CreateQueryUGCDetailsRequest call above instead!
+	STEAM_CALL_RESULT( SteamUGCRequestUGCDetailsResult_t )
+	virtual SteamAPICall_t RequestUGCDetails( PublishedFileId_t nPublishedFileID, uint32 unMaxAgeSeconds ) = 0;
+
+	// Steam Workshop Creator API
+	STEAM_CALL_RESULT( CreateItemResult_t )
+	virtual SteamAPICall_t CreateItem( AppId_t nConsumerAppId, EWorkshopFileType eFileType ) = 0; // create new item for this app with no content attached yet
+
+	virtual UGCUpdateHandle_t StartItemUpdate( AppId_t nConsumerAppId, PublishedFileId_t nPublishedFileID ) = 0; // start an UGC item update. Set changed properties before commiting update with CommitItemUpdate()
+
+	virtual bool SetItemTitle( UGCUpdateHandle_t handle, const char *pchTitle ) = 0; // change the title of an UGC item
+	virtual bool SetItemDescription( UGCUpdateHandle_t handle, const char *pchDescription ) = 0; // change the description of an UGC item
+	virtual bool SetItemUpdateLanguage( UGCUpdateHandle_t handle, const char *pchLanguage ) = 0; // specify the language of the title or description that will be set
+	virtual bool SetItemMetadata( UGCUpdateHandle_t handle, const char *pchMetaData ) = 0; // change the metadata of an UGC item (max = k_cchDeveloperMetadataMax)
+	virtual bool SetItemVisibility( UGCUpdateHandle_t handle, ERemoteStoragePublishedFileVisibility eVisibility ) = 0; // change the visibility of an UGC item
+	virtual bool SetItemTags( UGCUpdateHandle_t updateHandle, const SteamParamStringArray_t *pTags ) = 0; // change the tags of an UGC item
+	virtual bool SetItemContent( UGCUpdateHandle_t handle, const char *pszContentFolder ) = 0; // update item content from this local folder
+	virtual bool SetItemPreview( UGCUpdateHandle_t handle, const char *pszPreviewFile ) = 0; //  change preview image file for this item. pszPreviewFile points to local image file, which must be under 1MB in size
+	virtual bool SetAllowLegacyUpload( UGCUpdateHandle_t handle, bool bAllowLegacyUpload ) = 0; //  use legacy upload for a single small file. The parameter to SetItemContent() should either be a directory with one file or the full path to the file.  The file must also be less than 10MB in size.
+	virtual bool RemoveAllItemKeyValueTags( UGCUpdateHandle_t handle ) = 0; // remove all existing key-value tags (you can add new ones via the AddItemKeyValueTag function)
+	virtual bool RemoveItemKeyValueTags( UGCUpdateHandle_t handle, const char *pchKey ) = 0; // remove any existing key-value tags with the specified key
+	virtual bool AddItemKeyValueTag( UGCUpdateHandle_t handle, const char *pchKey, const char *pchValue ) = 0; // add new key-value tags for the item. Note that there can be multiple values for a tag.
+	virtual bool AddItemPreviewFile( UGCUpdateHandle_t handle, const char *pszPreviewFile, EItemPreviewType type ) = 0; //  add preview file for this item. pszPreviewFile points to local file, which must be under 1MB in size
+	virtual bool AddItemPreviewVideo( UGCUpdateHandle_t handle, const char *pszVideoID ) = 0; //  add preview video for this item
+	virtual bool UpdateItemPreviewFile( UGCUpdateHandle_t handle, uint32 index, const char *pszPreviewFile ) = 0; //  updates an existing preview file for this item. pszPreviewFile points to local file, which must be under 1MB in size
+	virtual bool UpdateItemPreviewVideo( UGCUpdateHandle_t handle, uint32 index, const char *pszVideoID ) = 0; //  updates an existing preview video for this item
+	virtual bool RemoveItemPreview( UGCUpdateHandle_t handle, uint32 index ) = 0; // remove a preview by index starting at 0 (previews are sorted)
+
+	STEAM_CALL_RESULT( SubmitItemUpdateResult_t )
+	virtual SteamAPICall_t SubmitItemUpdate( UGCUpdateHandle_t handle, const char *pchChangeNote ) = 0; // commit update process started with StartItemUpdate()
+	virtual EItemUpdateStatus GetItemUpdateProgress( UGCUpdateHandle_t handle, uint64 *punBytesProcessed, uint64* punBytesTotal ) = 0;
+
+	// Steam Workshop Consumer API
+	STEAM_CALL_RESULT( SetUserItemVoteResult_t )
+	virtual SteamAPICall_t SetUserItemVote( PublishedFileId_t nPublishedFileID, bool bVoteUp ) = 0;
+	STEAM_CALL_RESULT( GetUserItemVoteResult_t )
+	virtual SteamAPICall_t GetUserItemVote( PublishedFileId_t nPublishedFileID ) = 0;
+	STEAM_CALL_RESULT( UserFavoriteItemsListChanged_t )
+	virtual SteamAPICall_t AddItemToFavorites( AppId_t nAppId, PublishedFileId_t nPublishedFileID ) = 0;
+	STEAM_CALL_RESULT( UserFavoriteItemsListChanged_t )
+	virtual SteamAPICall_t RemoveItemFromFavorites( AppId_t nAppId, PublishedFileId_t nPublishedFileID ) = 0;
+	STEAM_CALL_RESULT( RemoteStorageSubscribePublishedFileResult_t )
+	virtual SteamAPICall_t SubscribeItem( PublishedFileId_t nPublishedFileID ) = 0; // subscribe to this item, will be installed ASAP
+	STEAM_CALL_RESULT( RemoteStorageUnsubscribePublishedFileResult_t )
+	virtual SteamAPICall_t UnsubscribeItem( PublishedFileId_t nPublishedFileID ) = 0; // unsubscribe from this item, will be uninstalled after game quits
+	virtual uint32 GetNumSubscribedItems() = 0; // number of subscribed items 
+	virtual uint32 GetSubscribedItems( PublishedFileId_t* pvecPublishedFileID, uint32 cMaxEntries ) = 0; // all subscribed item PublishFileIDs
+
+	// get EItemState flags about item on this client
+	virtual uint32 GetItemState( PublishedFileId_t nPublishedFileID ) = 0;
+
+	// get info about currently installed content on disc for items that have k_EItemStateInstalled set
+	// if k_EItemStateLegacyItem is set, pchFolder contains the path to the legacy file itself (not a folder)
+	virtual bool GetItemInstallInfo( PublishedFileId_t nPublishedFileID, uint64 *punSizeOnDisk, STEAM_OUT_STRING_COUNT( cchFolderSize ) char *pchFolder, uint32 cchFolderSize, uint32 *punTimeStamp ) = 0;
+
+	// get info about pending update for items that have k_EItemStateNeedsUpdate set. punBytesTotal will be valid after download started once
+	virtual bool GetItemDownloadInfo( PublishedFileId_t nPublishedFileID, uint64 *punBytesDownloaded, uint64 *punBytesTotal ) = 0;
+		
+	// download new or update already installed item. If function returns true, wait for DownloadItemResult_t. If the item is already installed,
+	// then files on disk should not be used until callback received. If item is not subscribed to, it will be cached for some time.
+	// If bHighPriority is set, any other item download will be suspended and this item downloaded ASAP.
+	virtual bool DownloadItem( PublishedFileId_t nPublishedFileID, bool bHighPriority ) = 0;
+
+	// game servers can set a specific workshop folder before issuing any UGC commands.
+	// This is helpful if you want to support multiple game servers running out of the same install folder
+	virtual bool BInitWorkshopForGameServer( DepotId_t unWorkshopDepotID, const char *pszFolder ) = 0;
+
+	// SuspendDownloads( true ) will suspend all workshop downloads until SuspendDownloads( false ) is called or the game ends
+	virtual void SuspendDownloads( bool bSuspend ) = 0;
+
+	// usage tracking
+	STEAM_CALL_RESULT( StartPlaytimeTrackingResult_t )
+	virtual SteamAPICall_t StartPlaytimeTracking( PublishedFileId_t *pvecPublishedFileID, uint32 unNumPublishedFileIDs ) = 0;
+	STEAM_CALL_RESULT( StopPlaytimeTrackingResult_t )
+	virtual SteamAPICall_t StopPlaytimeTracking( PublishedFileId_t *pvecPublishedFileID, uint32 unNumPublishedFileIDs ) = 0;
+	STEAM_CALL_RESULT( StopPlaytimeTrackingResult_t )
+	virtual SteamAPICall_t StopPlaytimeTrackingForAllItems() = 0;
+
+	// parent-child relationship or dependency management
+	STEAM_CALL_RESULT( AddUGCDependencyResult_t )
+	virtual SteamAPICall_t AddDependency( PublishedFileId_t nParentPublishedFileID, PublishedFileId_t nChildPublishedFileID ) = 0;
+	STEAM_CALL_RESULT( RemoveUGCDependencyResult_t )
+	virtual SteamAPICall_t RemoveDependency( PublishedFileId_t nParentPublishedFileID, PublishedFileId_t nChildPublishedFileID ) = 0;
+
+	// add/remove app dependence/requirements (usually DLC)
+	STEAM_CALL_RESULT( AddAppDependencyResult_t )
+	virtual SteamAPICall_t AddAppDependency( PublishedFileId_t nPublishedFileID, AppId_t nAppID ) = 0;
+	STEAM_CALL_RESULT( RemoveAppDependencyResult_t )
+	virtual SteamAPICall_t RemoveAppDependency( PublishedFileId_t nPublishedFileID, AppId_t nAppID ) = 0;
+	// request app dependencies. note that whatever callback you register for GetAppDependenciesResult_t may be called multiple times
+	// until all app dependencies have been returned
+	STEAM_CALL_RESULT( GetAppDependenciesResult_t )
+	virtual SteamAPICall_t GetAppDependencies( PublishedFileId_t nPublishedFileID ) = 0;
+	
+	// delete the item without prompting the user
+	STEAM_CALL_RESULT( DeleteItemResult_t )
+	virtual SteamAPICall_t DeleteItem( PublishedFileId_t nPublishedFileID ) = 0;
+};
+
+#define STEAMUGC_INTERFACE_VERSION "STEAMUGC_INTERFACE_VERSION014"
+
+// Global interface accessor
+inline ISteamUGC *SteamUGC();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamUGC *, SteamUGC, STEAMUGC_INTERFACE_VERSION );
+
+// Global accessor for the gameserver client
+inline ISteamUGC *SteamGameServerUGC();
+STEAM_DEFINE_GAMESERVER_INTERFACE_ACCESSOR( ISteamUGC *, SteamGameServerUGC, STEAMUGC_INTERFACE_VERSION );
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback for querying UGC
+//-----------------------------------------------------------------------------
+struct SteamUGCQueryCompleted_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 1 };
+	UGCQueryHandle_t m_handle;
+	EResult m_eResult;
+	uint32 m_unNumResultsReturned;
+	uint32 m_unTotalMatchingResults;
+	bool m_bCachedData;	// indicates whether this data was retrieved from the local on-disk cache
+	char m_rgchNextCursor[k_cchPublishedFileURLMax]; // If a paging cursor was used, then this will be the next cursor to get the next result set.
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback for requesting details on one piece of UGC
+//-----------------------------------------------------------------------------
+struct SteamUGCRequestUGCDetailsResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 2 };
+	SteamUGCDetails_t m_details;
+	bool m_bCachedData; // indicates whether this data was retrieved from the local on-disk cache
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: result for ISteamUGC::CreateItem() 
+//-----------------------------------------------------------------------------
+struct CreateItemResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 3 };
+	EResult m_eResult;
+	PublishedFileId_t m_nPublishedFileId; // new item got this UGC PublishFileID
+	bool m_bUserNeedsToAcceptWorkshopLegalAgreement;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: result for ISteamUGC::SubmitItemUpdate() 
+//-----------------------------------------------------------------------------
+struct SubmitItemUpdateResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 4 };
+	EResult m_eResult;
+	bool m_bUserNeedsToAcceptWorkshopLegalAgreement;
+	PublishedFileId_t m_nPublishedFileId;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: a Workshop item has been installed or updated
+//-----------------------------------------------------------------------------
+struct ItemInstalled_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 5 };
+	AppId_t m_unAppID;
+	PublishedFileId_t m_nPublishedFileId;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: result of DownloadItem(), existing item files can be accessed again
+//-----------------------------------------------------------------------------
+struct DownloadItemResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 6 };
+	AppId_t m_unAppID;
+	PublishedFileId_t m_nPublishedFileId;
+	EResult m_eResult;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: result of AddItemToFavorites() or RemoveItemFromFavorites()
+//-----------------------------------------------------------------------------
+struct UserFavoriteItemsListChanged_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 7 };
+	PublishedFileId_t m_nPublishedFileId;
+	EResult m_eResult;
+	bool m_bWasAddRequest;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to SetUserItemVote()
+//-----------------------------------------------------------------------------
+struct SetUserItemVoteResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 8 };
+	PublishedFileId_t m_nPublishedFileId;
+	EResult m_eResult;
+	bool m_bVoteUp;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to GetUserItemVote()
+//-----------------------------------------------------------------------------
+struct GetUserItemVoteResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 9 };
+	PublishedFileId_t m_nPublishedFileId;
+	EResult m_eResult;
+	bool m_bVotedUp;
+	bool m_bVotedDown;
+	bool m_bVoteSkipped;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to StartPlaytimeTracking()
+//-----------------------------------------------------------------------------
+struct StartPlaytimeTrackingResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 10 };
+	EResult m_eResult;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to StopPlaytimeTracking()
+//-----------------------------------------------------------------------------
+struct StopPlaytimeTrackingResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 11 };
+	EResult m_eResult;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to AddDependency
+//-----------------------------------------------------------------------------
+struct AddUGCDependencyResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 12 };
+	EResult m_eResult;
+	PublishedFileId_t m_nPublishedFileId;
+	PublishedFileId_t m_nChildPublishedFileId;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to RemoveDependency
+//-----------------------------------------------------------------------------
+struct RemoveUGCDependencyResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 13 };
+	EResult m_eResult;
+	PublishedFileId_t m_nPublishedFileId;
+	PublishedFileId_t m_nChildPublishedFileId;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to AddAppDependency
+//-----------------------------------------------------------------------------
+struct AddAppDependencyResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 14 };
+	EResult m_eResult;
+	PublishedFileId_t m_nPublishedFileId;
+	AppId_t m_nAppID;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to RemoveAppDependency
+//-----------------------------------------------------------------------------
+struct RemoveAppDependencyResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 15 };
+	EResult m_eResult;
+	PublishedFileId_t m_nPublishedFileId;
+	AppId_t m_nAppID;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to GetAppDependencies.  Callback may be called
+//			multiple times until all app dependencies have been returned.
+//-----------------------------------------------------------------------------
+struct GetAppDependenciesResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 16 };
+	EResult m_eResult;
+	PublishedFileId_t m_nPublishedFileId;
+	AppId_t m_rgAppIDs[32];
+	uint32 m_nNumAppDependencies;		// number returned in this struct
+	uint32 m_nTotalNumAppDependencies;	// total found
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to DeleteItem
+//-----------------------------------------------------------------------------
+struct DeleteItemResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 17 };
+	EResult m_eResult;
+	PublishedFileId_t m_nPublishedFileId;
+};
+
+#pragma pack( pop )
+
+#endif // ISTEAMUGC_H

--- a/lsteamclient/steamworks_sdk_148a/isteamuser.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamuser.h
@@ -1,0 +1,405 @@
+//====== Copyright (c) 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to user account information in Steam
+//
+//=============================================================================
+
+#ifndef ISTEAMUSER_H
+#define ISTEAMUSER_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for accessing and manipulating a steam account
+//			associated with one client instance
+//-----------------------------------------------------------------------------
+class ISteamUser
+{
+public:
+	// returns the HSteamUser this interface represents
+	// this is only used internally by the API, and by a few select interfaces that support multi-user
+	virtual HSteamUser GetHSteamUser() = 0;
+
+	// returns true if the Steam client current has a live connection to the Steam servers. 
+	// If false, it means there is no active connection due to either a networking issue on the local machine, or the Steam server is down/busy.
+	// The Steam client will automatically be trying to recreate the connection as often as possible.
+	virtual bool BLoggedOn() = 0;
+
+	// returns the CSteamID of the account currently logged into the Steam client
+	// a CSteamID is a unique identifier for an account, and used to differentiate users in all parts of the Steamworks API
+	virtual CSteamID GetSteamID() = 0;
+
+	// Multiplayer Authentication functions
+	
+	// InitiateGameConnection() starts the state machine for authenticating the game client with the game server
+	// It is the client portion of a three-way handshake between the client, the game server, and the steam servers
+	//
+	// Parameters:
+	// void *pAuthBlob - a pointer to empty memory that will be filled in with the authentication token.
+	// int cbMaxAuthBlob - the number of bytes of allocated memory in pBlob. Should be at least 2048 bytes.
+	// CSteamID steamIDGameServer - the steamID of the game server, received from the game server by the client
+	// CGameID gameID - the ID of the current game. For games without mods, this is just CGameID( <appID> )
+	// uint32 unIPServer, uint16 usPortServer - the IP address of the game server
+	// bool bSecure - whether or not the client thinks that the game server is reporting itself as secure (i.e. VAC is running)
+	//
+	// return value - returns the number of bytes written to pBlob. If the return is 0, then the buffer passed in was too small, and the call has failed
+	// The contents of pBlob should then be sent to the game server, for it to use to complete the authentication process.
+	virtual int InitiateGameConnection( void *pAuthBlob, int cbMaxAuthBlob, CSteamID steamIDGameServer, uint32 unIPServer, uint16 usPortServer, bool bSecure ) = 0;
+
+	// notify of disconnect
+	// needs to occur when the game client leaves the specified game server, needs to match with the InitiateGameConnection() call
+	virtual void TerminateGameConnection( uint32 unIPServer, uint16 usPortServer ) = 0;
+
+	// Legacy functions
+
+	// used by only a few games to track usage events
+	virtual void TrackAppUsageEvent( CGameID gameID, int eAppUsageEvent, const char *pchExtraInfo = "" ) = 0;
+
+	// get the local storage folder for current Steam account to write application data, e.g. save games, configs etc.
+	// this will usually be something like "C:\Progam Files\Steam\userdata\<SteamID>\<AppID>\local"
+	virtual bool GetUserDataFolder( char *pchBuffer, int cubBuffer ) = 0;
+
+	// Starts voice recording. Once started, use GetVoice() to get the data
+	virtual void StartVoiceRecording( ) = 0;
+
+	// Stops voice recording. Because people often release push-to-talk keys early, the system will keep recording for
+	// a little bit after this function is called. GetVoice() should continue to be called until it returns
+	// k_eVoiceResultNotRecording
+	virtual void StopVoiceRecording( ) = 0;
+
+	// Determine the size of captured audio data that is available from GetVoice.
+	// Most applications will only use compressed data and should ignore the other
+	// parameters, which exist primarily for backwards compatibility. See comments
+	// below for further explanation of "uncompressed" data.
+	virtual EVoiceResult GetAvailableVoice( uint32 *pcbCompressed, uint32 *pcbUncompressed_Deprecated = 0, uint32 nUncompressedVoiceDesiredSampleRate_Deprecated = 0 ) = 0;
+
+	// ---------------------------------------------------------------------------
+	// NOTE: "uncompressed" audio is a deprecated feature and should not be used
+	// by most applications. It is raw single-channel 16-bit PCM wave data which
+	// may have been run through preprocessing filters and/or had silence removed,
+	// so the uncompressed audio could have a shorter duration than you expect.
+	// There may be no data at all during long periods of silence. Also, fetching
+	// uncompressed audio will cause GetVoice to discard any leftover compressed
+	// audio, so you must fetch both types at once. Finally, GetAvailableVoice is
+	// not precisely accurate when the uncompressed size is requested. So if you
+	// really need to use uncompressed audio, you should call GetVoice frequently
+	// with two very large (20kb+) output buffers instead of trying to allocate
+	// perfectly-sized buffers. But most applications should ignore all of these
+	// details and simply leave the "uncompressed" parameters as NULL/zero.
+	// ---------------------------------------------------------------------------
+
+	// Read captured audio data from the microphone buffer. This should be called
+	// at least once per frame, and preferably every few milliseconds, to keep the
+	// microphone input delay as low as possible. Most applications will only use
+	// compressed data and should pass NULL/zero for the "uncompressed" parameters.
+	// Compressed data can be transmitted by your application and decoded into raw
+	// using the DecompressVoice function below.
+	virtual EVoiceResult GetVoice( bool bWantCompressed, void *pDestBuffer, uint32 cbDestBufferSize, uint32 *nBytesWritten, bool bWantUncompressed_Deprecated = false, void *pUncompressedDestBuffer_Deprecated = 0, uint32 cbUncompressedDestBufferSize_Deprecated = 0, uint32 *nUncompressBytesWritten_Deprecated = 0, uint32 nUncompressedVoiceDesiredSampleRate_Deprecated = 0 ) = 0;
+
+	// Decodes the compressed voice data returned by GetVoice. The output data is
+	// raw single-channel 16-bit PCM audio. The decoder supports any sample rate
+	// from 11025 to 48000; see GetVoiceOptimalSampleRate() below for details.
+	// If the output buffer is not large enough, then *nBytesWritten will be set
+	// to the required buffer size, and k_EVoiceResultBufferTooSmall is returned.
+	// It is suggested to start with a 20kb buffer and reallocate as necessary.
+	virtual EVoiceResult DecompressVoice( const void *pCompressed, uint32 cbCompressed, void *pDestBuffer, uint32 cbDestBufferSize, uint32 *nBytesWritten, uint32 nDesiredSampleRate ) = 0;
+
+	// This returns the native sample rate of the Steam voice decompressor; using
+	// this sample rate for DecompressVoice will perform the least CPU processing.
+	// However, the final audio quality will depend on how well the audio device
+	// (and/or your application's audio output SDK) deals with lower sample rates.
+	// You may find that you get the best audio output quality when you ignore
+	// this function and use the native sample rate of your audio output device,
+	// which is usually 48000 or 44100.
+	virtual uint32 GetVoiceOptimalSampleRate() = 0;
+
+	// Retrieve ticket to be sent to the entity who wishes to authenticate you. 
+	// pcbTicket retrieves the length of the actual ticket.
+	virtual HAuthTicket GetAuthSessionTicket( void *pTicket, int cbMaxTicket, uint32 *pcbTicket ) = 0;
+
+	// Authenticate ticket from entity steamID to be sure it is valid and isnt reused
+	// Registers for callbacks if the entity goes offline or cancels the ticket ( see ValidateAuthTicketResponse_t callback and EAuthSessionResponse )
+	virtual EBeginAuthSessionResult BeginAuthSession( const void *pAuthTicket, int cbAuthTicket, CSteamID steamID ) = 0;
+
+	// Stop tracking started by BeginAuthSession - called when no longer playing game with this entity
+	virtual void EndAuthSession( CSteamID steamID ) = 0;
+
+	// Cancel auth ticket from GetAuthSessionTicket, called when no longer playing game with the entity you gave the ticket to
+	virtual void CancelAuthTicket( HAuthTicket hAuthTicket ) = 0;
+
+	// After receiving a user's authentication data, and passing it to BeginAuthSession, use this function
+	// to determine if the user owns downloadable content specified by the provided AppID.
+	virtual EUserHasLicenseForAppResult UserHasLicenseForApp( CSteamID steamID, AppId_t appID ) = 0;
+	
+	// returns true if this users looks like they are behind a NAT device. Only valid once the user has connected to steam 
+	// (i.e a SteamServersConnected_t has been issued) and may not catch all forms of NAT.
+	virtual bool BIsBehindNAT() = 0;
+
+	// set data to be replicated to friends so that they can join your game
+	// CSteamID steamIDGameServer - the steamID of the game server, received from the game server by the client
+	// uint32 unIPServer, uint16 usPortServer - the IP address of the game server
+	virtual void AdvertiseGame( CSteamID steamIDGameServer, uint32 unIPServer, uint16 usPortServer ) = 0;
+
+	// Requests a ticket encrypted with an app specific shared key
+	// pDataToInclude, cbDataToInclude will be encrypted into the ticket
+	// ( This is asynchronous, you must wait for the ticket to be completed by the server )
+	STEAM_CALL_RESULT( EncryptedAppTicketResponse_t )
+	virtual SteamAPICall_t RequestEncryptedAppTicket( void *pDataToInclude, int cbDataToInclude ) = 0;
+
+	// Retrieves a finished ticket.
+	// If no ticket is available, or your buffer is too small, returns false.
+	// Upon exit, *pcbTicket will be either the size of the ticket copied into your buffer
+	// (if true was returned), or the size needed (if false was returned).  To determine the
+	// proper size of the ticket, you can pass pTicket=NULL and cbMaxTicket=0; if a ticket
+	// is available, *pcbTicket will contain the size needed, otherwise it will be zero.
+	virtual bool GetEncryptedAppTicket( void *pTicket, int cbMaxTicket, uint32 *pcbTicket ) = 0;
+
+	// Trading Card badges data access
+	// if you only have one set of cards, the series will be 1
+	// the user has can have two different badges for a series; the regular (max level 5) and the foil (max level 1)
+	virtual int GetGameBadgeLevel( int nSeries, bool bFoil ) = 0;
+
+	// gets the Steam Level of the user, as shown on their profile
+	virtual int GetPlayerSteamLevel() = 0;
+
+	// Requests a URL which authenticates an in-game browser for store check-out,
+	// and then redirects to the specified URL. As long as the in-game browser
+	// accepts and handles session cookies, Steam microtransaction checkout pages
+	// will automatically recognize the user instead of presenting a login page.
+	// The result of this API call will be a StoreAuthURLResponse_t callback.
+	// NOTE: The URL has a very short lifetime to prevent history-snooping attacks,
+	// so you should only call this API when you are about to launch the browser,
+	// or else immediately navigate to the result URL using a hidden browser window.
+	// NOTE 2: The resulting authorization cookie has an expiration time of one day,
+	// so it would be a good idea to request and visit a new auth URL every 12 hours.
+	STEAM_CALL_RESULT( StoreAuthURLResponse_t )
+	virtual SteamAPICall_t RequestStoreAuthURL( const char *pchRedirectURL ) = 0;
+
+	// gets whether the users phone number is verified 
+	virtual bool BIsPhoneVerified() = 0;
+
+	// gets whether the user has two factor enabled on their account
+	virtual bool BIsTwoFactorEnabled() = 0;
+
+	// gets whether the users phone number is identifying
+	virtual bool BIsPhoneIdentifying() = 0;
+
+	// gets whether the users phone number is awaiting (re)verification
+	virtual bool BIsPhoneRequiringVerification() = 0;
+
+	STEAM_CALL_RESULT( MarketEligibilityResponse_t )
+	virtual SteamAPICall_t GetMarketEligibility() = 0;
+
+	// Retrieves anti indulgence / duration control for current user
+	STEAM_CALL_RESULT( DurationControl_t )
+	virtual SteamAPICall_t GetDurationControl() = 0;
+
+};
+
+#define STEAMUSER_INTERFACE_VERSION "SteamUser020"
+
+// Global interface accessor
+inline ISteamUser *SteamUser();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamUser *, SteamUser, STEAMUSER_INTERFACE_VERSION );
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+
+//-----------------------------------------------------------------------------
+// Purpose: called when a connections to the Steam back-end has been established
+//			this means the Steam client now has a working connection to the Steam servers
+//			usually this will have occurred before the game has launched, and should
+//			only be seen if the user has dropped connection due to a networking issue
+//			or a Steam server update
+//-----------------------------------------------------------------------------
+struct SteamServersConnected_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 1 };
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: called when a connection attempt has failed
+//			this will occur periodically if the Steam client is not connected, 
+//			and has failed in it's retry to establish a connection
+//-----------------------------------------------------------------------------
+struct SteamServerConnectFailure_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 2 };
+	EResult m_eResult;
+	bool m_bStillRetrying;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: called if the client has lost connection to the Steam servers
+//			real-time services will be disabled until a matching SteamServersConnected_t has been posted
+//-----------------------------------------------------------------------------
+struct SteamServersDisconnected_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 3 };
+	EResult m_eResult;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Sent by the Steam server to the client telling it to disconnect from the specified game server,
+//			which it may be in the process of or already connected to.
+//			The game client should immediately disconnect upon receiving this message.
+//			This can usually occur if the user doesn't have rights to play on the game server.
+//-----------------------------------------------------------------------------
+struct ClientGameServerDeny_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 13 };
+
+	uint32 m_uAppID;
+	uint32 m_unGameServerIP;
+	uint16 m_usGameServerPort;
+	uint16 m_bSecure;
+	uint32 m_uReason;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: called when the callback system for this client is in an error state (and has flushed pending callbacks)
+//			When getting this message the client should disconnect from Steam, reset any stored Steam state and reconnect.
+//			This usually occurs in the rare event the Steam client has some kind of fatal error.
+//-----------------------------------------------------------------------------
+struct IPCFailure_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 17 };
+	enum EFailureType 
+	{ 
+		k_EFailureFlushedCallbackQueue, 
+		k_EFailurePipeFail,
+	};
+	uint8 m_eFailureType;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Signaled whenever licenses change
+//-----------------------------------------------------------------------------
+struct LicensesUpdated_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 25 };
+};
+
+
+//-----------------------------------------------------------------------------
+// callback for BeginAuthSession
+//-----------------------------------------------------------------------------
+struct ValidateAuthTicketResponse_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 43 };
+	CSteamID m_SteamID;
+	EAuthSessionResponse m_eAuthSessionResponse;
+	CSteamID m_OwnerSteamID; // different from m_SteamID if borrowed
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: called when a user has responded to a microtransaction authorization request
+//-----------------------------------------------------------------------------
+struct MicroTxnAuthorizationResponse_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 52 };
+	
+	uint32 m_unAppID;			// AppID for this microtransaction
+	uint64 m_ulOrderID;			// OrderID provided for the microtransaction
+	uint8 m_bAuthorized;		// if user authorized transaction
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Result from RequestEncryptedAppTicket
+//-----------------------------------------------------------------------------
+struct EncryptedAppTicketResponse_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 54 };
+
+	EResult m_eResult;
+};
+
+//-----------------------------------------------------------------------------
+// callback for GetAuthSessionTicket
+//-----------------------------------------------------------------------------
+struct GetAuthSessionTicketResponse_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 63 };
+	HAuthTicket m_hAuthTicket;
+	EResult m_eResult;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: sent to your game in response to a steam://gamewebcallback/ command
+//-----------------------------------------------------------------------------
+struct GameWebCallback_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 64 };
+	char m_szURL[256];
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: sent to your game in response to ISteamUser::RequestStoreAuthURL
+//-----------------------------------------------------------------------------
+struct StoreAuthURLResponse_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 65 };
+	char m_szURL[512];
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: sent in response to ISteamUser::GetMarketEligibility
+//-----------------------------------------------------------------------------
+struct MarketEligibilityResponse_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 66 };
+	bool m_bAllowed;
+	EMarketNotAllowedReasonFlags m_eNotAllowedReason;
+	RTime32 m_rtAllowedAtTime;
+
+	int m_cdaySteamGuardRequiredDays; // The number of days any user is required to have had Steam Guard before they can use the market
+	int m_cdayNewDeviceCooldown; // The number of days after initial device authorization a user must wait before using the market on that device
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: sent for games with enabled anti indulgence / duration control, for
+// enabled users. Lets the game know whether the user can keep playing or
+// whether the game should exit, and returns info about remaining gameplay time.
+//
+// This callback is fired asynchronously in response to timers triggering.
+// It is also fired in response to calls to GetDurationControl().
+//-----------------------------------------------------------------------------
+struct DurationControl_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 67 };
+
+	EResult	m_eResult;								// result of call (always k_EResultOK for asynchronous timer-based notifications)
+	AppId_t m_appid;								// appid generating playtime
+
+	bool	m_bApplicable;							// is duration control applicable to user + game combination
+	int32	m_csecsLast5h;							// playtime since most recent 5 hour gap in playtime, only counting up to regulatory limit of playtime, in seconds
+
+	EDurationControlProgress m_progress;			// recommended progress (either everything is fine, or please exit game)
+	EDurationControlNotification m_notification;	// notification to show, if any (always k_EDurationControlNotification_None for API calls)
+
+	int32	m_csecsToday;							// playtime on current calendar day
+	int32	m_csecsRemaining;						// playtime remaining until the user hits a regulatory limit
+};
+
+
+#pragma pack( pop )
+
+#endif // ISTEAMUSER_H

--- a/lsteamclient/steamworks_sdk_148a/isteamuserstats.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamuserstats.h
@@ -1,0 +1,498 @@
+//====== Copyright � 1996-2009, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to stats, achievements, and leaderboards 
+//
+//=============================================================================
+
+#ifndef ISTEAMUSERSTATS_H
+#define ISTEAMUSERSTATS_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+#include "isteamremotestorage.h"
+
+// size limit on stat or achievement name (UTF-8 encoded)
+enum { k_cchStatNameMax = 128 };
+
+// maximum number of bytes for a leaderboard name (UTF-8 encoded)
+enum { k_cchLeaderboardNameMax = 128 };
+
+// maximum number of details int32's storable for a single leaderboard entry
+enum { k_cLeaderboardDetailsMax = 64 };
+
+// handle to a single leaderboard
+typedef uint64 SteamLeaderboard_t;
+
+// handle to a set of downloaded entries in a leaderboard
+typedef uint64 SteamLeaderboardEntries_t;
+
+// type of data request, when downloading leaderboard entries
+enum ELeaderboardDataRequest
+{
+	k_ELeaderboardDataRequestGlobal = 0,
+	k_ELeaderboardDataRequestGlobalAroundUser = 1,
+	k_ELeaderboardDataRequestFriends = 2,
+	k_ELeaderboardDataRequestUsers = 3
+};
+
+// the sort order of a leaderboard
+enum ELeaderboardSortMethod
+{
+	k_ELeaderboardSortMethodNone = 0,
+	k_ELeaderboardSortMethodAscending = 1,	// top-score is lowest number
+	k_ELeaderboardSortMethodDescending = 2,	// top-score is highest number
+};
+
+// the display type (used by the Steam Community web site) for a leaderboard
+enum ELeaderboardDisplayType
+{
+	k_ELeaderboardDisplayTypeNone = 0, 
+	k_ELeaderboardDisplayTypeNumeric = 1,			// simple numerical score
+	k_ELeaderboardDisplayTypeTimeSeconds = 2,		// the score represents a time, in seconds
+	k_ELeaderboardDisplayTypeTimeMilliSeconds = 3,	// the score represents a time, in milliseconds
+};
+
+enum ELeaderboardUploadScoreMethod
+{
+	k_ELeaderboardUploadScoreMethodNone = 0,
+	k_ELeaderboardUploadScoreMethodKeepBest = 1,	// Leaderboard will keep user's best score
+	k_ELeaderboardUploadScoreMethodForceUpdate = 2,	// Leaderboard will always replace score with specified
+};
+
+// a single entry in a leaderboard, as returned by GetDownloadedLeaderboardEntry()
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+
+struct LeaderboardEntry_t
+{
+	CSteamID m_steamIDUser; // user with the entry - use SteamFriends()->GetFriendPersonaName() & SteamFriends()->GetFriendAvatar() to get more info
+	int32 m_nGlobalRank;	// [1..N], where N is the number of users with an entry in the leaderboard
+	int32 m_nScore;			// score as set in the leaderboard
+	int32 m_cDetails;		// number of int32 details available for this entry
+	UGCHandle_t m_hUGC;		// handle for UGC attached to the entry
+};
+
+#pragma pack( pop )
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for accessing stats, achievements, and leaderboard information
+//-----------------------------------------------------------------------------
+class ISteamUserStats
+{
+public:
+	// Ask the server to send down this user's data and achievements for this game
+	STEAM_CALL_BACK( UserStatsReceived_t )
+	virtual bool RequestCurrentStats() = 0;
+
+	// Data accessors
+	STEAM_FLAT_NAME( GetStatInt32 )
+	virtual bool GetStat( const char *pchName, int32 *pData ) = 0;
+
+	STEAM_FLAT_NAME( GetStatFloat )
+	virtual bool GetStat( const char *pchName, float *pData ) = 0;
+
+	// Set / update data
+	STEAM_FLAT_NAME( SetStatInt32 )
+	virtual bool SetStat( const char *pchName, int32 nData ) = 0;
+
+	STEAM_FLAT_NAME( SetStatFloat )
+	virtual bool SetStat( const char *pchName, float fData ) = 0;
+
+	virtual bool UpdateAvgRateStat( const char *pchName, float flCountThisSession, double dSessionLength ) = 0;
+
+	// Achievement flag accessors
+	virtual bool GetAchievement( const char *pchName, bool *pbAchieved ) = 0;
+	virtual bool SetAchievement( const char *pchName ) = 0;
+	virtual bool ClearAchievement( const char *pchName ) = 0;
+
+	// Get the achievement status, and the time it was unlocked if unlocked.
+	// If the return value is true, but the unlock time is zero, that means it was unlocked before Steam 
+	// began tracking achievement unlock times (December 2009). Time is seconds since January 1, 1970.
+	virtual bool GetAchievementAndUnlockTime( const char *pchName, bool *pbAchieved, uint32 *punUnlockTime ) = 0;
+
+	// Store the current data on the server, will get a callback when set
+	// And one callback for every new achievement
+	//
+	// If the callback has a result of k_EResultInvalidParam, one or more stats 
+	// uploaded has been rejected, either because they broke constraints
+	// or were out of date. In this case the server sends back updated values.
+	// The stats should be re-iterated to keep in sync.
+	virtual bool StoreStats() = 0;
+
+	// Achievement / GroupAchievement metadata
+
+	// Gets the icon of the achievement, which is a handle to be used in ISteamUtils::GetImageRGBA(), or 0 if none set. 
+	// A return value of 0 may indicate we are still fetching data, and you can wait for the UserAchievementIconFetched_t callback
+	// which will notify you when the bits are ready. If the callback still returns zero, then there is no image set for the
+	// specified achievement.
+	virtual int GetAchievementIcon( const char *pchName ) = 0;
+
+	// Get general attributes for an achievement. Accepts the following keys:
+	// - "name" and "desc" for retrieving the localized achievement name and description (returned in UTF8)
+	// - "hidden" for retrieving if an achievement is hidden (returns "0" when not hidden, "1" when hidden)
+	virtual const char *GetAchievementDisplayAttribute( const char *pchName, const char *pchKey ) = 0;
+
+	// Achievement progress - triggers an AchievementProgress callback, that is all.
+	// Calling this w/ N out of N progress will NOT set the achievement, the game must still do that.
+	virtual bool IndicateAchievementProgress( const char *pchName, uint32 nCurProgress, uint32 nMaxProgress ) = 0;
+
+	// Used for iterating achievements. In general games should not need these functions because they should have a
+	// list of existing achievements compiled into them
+	virtual uint32 GetNumAchievements() = 0;
+	// Get achievement name iAchievement in [0,GetNumAchievements)
+	virtual const char *GetAchievementName( uint32 iAchievement ) = 0;
+
+	// Friends stats & achievements
+
+	// downloads stats for the user
+	// returns a UserStatsReceived_t received when completed
+	// if the other user has no stats, UserStatsReceived_t.m_eResult will be set to k_EResultFail
+	// these stats won't be auto-updated; you'll need to call RequestUserStats() again to refresh any data
+	STEAM_CALL_RESULT( UserStatsReceived_t )
+	virtual SteamAPICall_t RequestUserStats( CSteamID steamIDUser ) = 0;
+
+	// requests stat information for a user, usable after a successful call to RequestUserStats()
+	STEAM_FLAT_NAME( GetUserStatInt32 )
+	virtual bool GetUserStat( CSteamID steamIDUser, const char *pchName, int32 *pData ) = 0;
+
+	STEAM_FLAT_NAME( GetUserStatFloat )
+	virtual bool GetUserStat( CSteamID steamIDUser, const char *pchName, float *pData ) = 0;
+
+	virtual bool GetUserAchievement( CSteamID steamIDUser, const char *pchName, bool *pbAchieved ) = 0;
+	// See notes for GetAchievementAndUnlockTime above
+	virtual bool GetUserAchievementAndUnlockTime( CSteamID steamIDUser, const char *pchName, bool *pbAchieved, uint32 *punUnlockTime ) = 0;
+
+	// Reset stats 
+	virtual bool ResetAllStats( bool bAchievementsToo ) = 0;
+
+	// Leaderboard functions
+
+	// asks the Steam back-end for a leaderboard by name, and will create it if it's not yet
+	// This call is asynchronous, with the result returned in LeaderboardFindResult_t
+	STEAM_CALL_RESULT(LeaderboardFindResult_t)
+	virtual SteamAPICall_t FindOrCreateLeaderboard( const char *pchLeaderboardName, ELeaderboardSortMethod eLeaderboardSortMethod, ELeaderboardDisplayType eLeaderboardDisplayType ) = 0;
+
+	// as above, but won't create the leaderboard if it's not found
+	// This call is asynchronous, with the result returned in LeaderboardFindResult_t
+	STEAM_CALL_RESULT( LeaderboardFindResult_t )
+	virtual SteamAPICall_t FindLeaderboard( const char *pchLeaderboardName ) = 0;
+
+	// returns the name of a leaderboard
+	virtual const char *GetLeaderboardName( SteamLeaderboard_t hSteamLeaderboard ) = 0;
+
+	// returns the total number of entries in a leaderboard, as of the last request
+	virtual int GetLeaderboardEntryCount( SteamLeaderboard_t hSteamLeaderboard ) = 0;
+
+	// returns the sort method of the leaderboard
+	virtual ELeaderboardSortMethod GetLeaderboardSortMethod( SteamLeaderboard_t hSteamLeaderboard ) = 0;
+
+	// returns the display type of the leaderboard
+	virtual ELeaderboardDisplayType GetLeaderboardDisplayType( SteamLeaderboard_t hSteamLeaderboard ) = 0;
+
+	// Asks the Steam back-end for a set of rows in the leaderboard.
+	// This call is asynchronous, with the result returned in LeaderboardScoresDownloaded_t
+	// LeaderboardScoresDownloaded_t will contain a handle to pull the results from GetDownloadedLeaderboardEntries() (below)
+	// You can ask for more entries than exist, and it will return as many as do exist.
+	// k_ELeaderboardDataRequestGlobal requests rows in the leaderboard from the full table, with nRangeStart & nRangeEnd in the range [1, TotalEntries]
+	// k_ELeaderboardDataRequestGlobalAroundUser requests rows around the current user, nRangeStart being negate
+	//   e.g. DownloadLeaderboardEntries( hLeaderboard, k_ELeaderboardDataRequestGlobalAroundUser, -3, 3 ) will return 7 rows, 3 before the user, 3 after
+	// k_ELeaderboardDataRequestFriends requests all the rows for friends of the current user 
+	STEAM_CALL_RESULT( LeaderboardScoresDownloaded_t )
+	virtual SteamAPICall_t DownloadLeaderboardEntries( SteamLeaderboard_t hSteamLeaderboard, ELeaderboardDataRequest eLeaderboardDataRequest, int nRangeStart, int nRangeEnd ) = 0;
+	// as above, but downloads leaderboard entries for an arbitrary set of users - ELeaderboardDataRequest is k_ELeaderboardDataRequestUsers
+	// if a user doesn't have a leaderboard entry, they won't be included in the result
+	// a max of 100 users can be downloaded at a time, with only one outstanding call at a time
+	STEAM_METHOD_DESC(Downloads leaderboard entries for an arbitrary set of users - ELeaderboardDataRequest is k_ELeaderboardDataRequestUsers)
+		STEAM_CALL_RESULT( LeaderboardScoresDownloaded_t )
+	virtual SteamAPICall_t DownloadLeaderboardEntriesForUsers( SteamLeaderboard_t hSteamLeaderboard,
+															   STEAM_ARRAY_COUNT_D(cUsers, Array of users to retrieve) CSteamID *prgUsers, int cUsers ) = 0;
+
+	// Returns data about a single leaderboard entry
+	// use a for loop from 0 to LeaderboardScoresDownloaded_t::m_cEntryCount to get all the downloaded entries
+	// e.g.
+	//		void OnLeaderboardScoresDownloaded( LeaderboardScoresDownloaded_t *pLeaderboardScoresDownloaded )
+	//		{
+	//			for ( int index = 0; index < pLeaderboardScoresDownloaded->m_cEntryCount; index++ )
+	//			{
+	//				LeaderboardEntry_t leaderboardEntry;
+	//				int32 details[3];		// we know this is how many we've stored previously
+	//				GetDownloadedLeaderboardEntry( pLeaderboardScoresDownloaded->m_hSteamLeaderboardEntries, index, &leaderboardEntry, details, 3 );
+	//				assert( leaderboardEntry.m_cDetails == 3 );
+	//				...
+	//			}
+	// once you've accessed all the entries, the data will be free'd, and the SteamLeaderboardEntries_t handle will become invalid
+	virtual bool GetDownloadedLeaderboardEntry( SteamLeaderboardEntries_t hSteamLeaderboardEntries, int index, LeaderboardEntry_t *pLeaderboardEntry, int32 *pDetails, int cDetailsMax ) = 0;
+
+	// Uploads a user score to the Steam back-end.
+	// This call is asynchronous, with the result returned in LeaderboardScoreUploaded_t
+	// Details are extra game-defined information regarding how the user got that score
+	// pScoreDetails points to an array of int32's, cScoreDetailsCount is the number of int32's in the list
+	STEAM_CALL_RESULT( LeaderboardScoreUploaded_t )
+	virtual SteamAPICall_t UploadLeaderboardScore( SteamLeaderboard_t hSteamLeaderboard, ELeaderboardUploadScoreMethod eLeaderboardUploadScoreMethod, int32 nScore, const int32 *pScoreDetails, int cScoreDetailsCount ) = 0;
+
+	// Attaches a piece of user generated content the user's entry on a leaderboard.
+	// hContent is a handle to a piece of user generated content that was shared using ISteamUserRemoteStorage::FileShare().
+	// This call is asynchronous, with the result returned in LeaderboardUGCSet_t.
+	STEAM_CALL_RESULT( LeaderboardUGCSet_t )
+	virtual SteamAPICall_t AttachLeaderboardUGC( SteamLeaderboard_t hSteamLeaderboard, UGCHandle_t hUGC ) = 0;
+
+	// Retrieves the number of players currently playing your game (online + offline)
+	// This call is asynchronous, with the result returned in NumberOfCurrentPlayers_t
+	STEAM_CALL_RESULT( NumberOfCurrentPlayers_t )
+	virtual SteamAPICall_t GetNumberOfCurrentPlayers() = 0;
+
+	// Requests that Steam fetch data on the percentage of players who have received each achievement
+	// for the game globally.
+	// This call is asynchronous, with the result returned in GlobalAchievementPercentagesReady_t.
+	STEAM_CALL_RESULT( GlobalAchievementPercentagesReady_t )
+	virtual SteamAPICall_t RequestGlobalAchievementPercentages() = 0;
+
+	// Get the info on the most achieved achievement for the game, returns an iterator index you can use to fetch
+	// the next most achieved afterwards.  Will return -1 if there is no data on achievement 
+	// percentages (ie, you haven't called RequestGlobalAchievementPercentages and waited on the callback).
+	virtual int GetMostAchievedAchievementInfo( char *pchName, uint32 unNameBufLen, float *pflPercent, bool *pbAchieved ) = 0;
+
+	// Get the info on the next most achieved achievement for the game. Call this after GetMostAchievedAchievementInfo or another
+	// GetNextMostAchievedAchievementInfo call passing the iterator from the previous call. Returns -1 after the last
+	// achievement has been iterated.
+	virtual int GetNextMostAchievedAchievementInfo( int iIteratorPrevious, char *pchName, uint32 unNameBufLen, float *pflPercent, bool *pbAchieved ) = 0;
+
+	// Returns the percentage of users who have achieved the specified achievement.
+	virtual bool GetAchievementAchievedPercent( const char *pchName, float *pflPercent ) = 0;
+
+	// Requests global stats data, which is available for stats marked as "aggregated".
+	// This call is asynchronous, with the results returned in GlobalStatsReceived_t.
+	// nHistoryDays specifies how many days of day-by-day history to retrieve in addition
+	// to the overall totals. The limit is 60.
+	STEAM_CALL_RESULT( GlobalStatsReceived_t )
+	virtual SteamAPICall_t RequestGlobalStats( int nHistoryDays ) = 0;
+
+	// Gets the lifetime totals for an aggregated stat
+	STEAM_FLAT_NAME( GetGlobalStatInt64 )
+	virtual bool GetGlobalStat( const char *pchStatName, int64 *pData ) = 0;
+
+	STEAM_FLAT_NAME( GetGlobalStatDouble )
+	virtual bool GetGlobalStat( const char *pchStatName, double *pData ) = 0;
+
+	// Gets history for an aggregated stat. pData will be filled with daily values, starting with today.
+	// So when called, pData[0] will be today, pData[1] will be yesterday, and pData[2] will be two days ago, 
+	// etc. cubData is the size in bytes of the pubData buffer. Returns the number of 
+	// elements actually set.
+
+	STEAM_FLAT_NAME( GetGlobalStatHistoryInt64 )
+	virtual int32 GetGlobalStatHistory( const char *pchStatName, STEAM_ARRAY_COUNT(cubData) int64 *pData, uint32 cubData ) = 0;
+
+	STEAM_FLAT_NAME( GetGlobalStatHistoryDouble )
+	virtual int32 GetGlobalStatHistory( const char *pchStatName, STEAM_ARRAY_COUNT(cubData) double *pData, uint32 cubData ) = 0;
+
+#ifdef _PS3
+	// Call to kick off installation of the PS3 trophies. This call is asynchronous, and the results will be returned in a PS3TrophiesInstalled_t
+	// callback.
+	virtual bool InstallPS3Trophies() = 0;
+
+	// Returns the amount of space required at boot to install trophies. This value can be used when comparing the amount of space needed
+	// by the game to the available space value passed to the game at boot. The value is set during InstallPS3Trophies().
+	virtual uint64 GetTrophySpaceRequiredBeforeInstall() = 0;
+
+	// On PS3, user stats & achievement progress through Steam must be stored with the user's saved game data.
+	// At startup, before calling RequestCurrentStats(), you must pass the user's stats data to Steam via this method.
+	// If you do not have any user data, call this function with pvData = NULL and cubData = 0
+	virtual bool SetUserStatsData( const void *pvData, uint32 cubData ) = 0;
+
+	// Call to get the user's current stats data. You should retrieve this data after receiving successful UserStatsReceived_t & UserStatsStored_t
+	// callbacks, and store the data with the user's save game data. You can call this method with pvData = NULL and cubData = 0 to get the required
+	// buffer size.
+	virtual bool GetUserStatsData( void *pvData, uint32 cubData, uint32 *pcubWritten ) = 0;
+#endif
+};
+
+#define STEAMUSERSTATS_INTERFACE_VERSION "STEAMUSERSTATS_INTERFACE_VERSION011"
+
+// Global interface accessor
+inline ISteamUserStats *SteamUserStats();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamUserStats *, SteamUserStats, STEAMUSERSTATS_INTERFACE_VERSION );
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+
+//-----------------------------------------------------------------------------
+// Purpose: called when the latests stats and achievements have been received
+//			from the server
+//-----------------------------------------------------------------------------
+struct UserStatsReceived_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 1 };
+	uint64		m_nGameID;		// Game these stats are for
+	EResult		m_eResult;		// Success / error fetching the stats
+	CSteamID	m_steamIDUser;	// The user for whom the stats are retrieved for
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: result of a request to store the user stats for a game
+//-----------------------------------------------------------------------------
+struct UserStatsStored_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 2 };
+	uint64		m_nGameID;		// Game these stats are for
+	EResult		m_eResult;		// success / error
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: result of a request to store the achievements for a game, or an 
+//			"indicate progress" call. If both m_nCurProgress and m_nMaxProgress
+//			are zero, that means the achievement has been fully unlocked.
+//-----------------------------------------------------------------------------
+struct UserAchievementStored_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 3 };
+
+	uint64		m_nGameID;				// Game this is for
+	bool		m_bGroupAchievement;	// if this is a "group" achievement
+	char		m_rgchAchievementName[k_cchStatNameMax];		// name of the achievement
+	uint32		m_nCurProgress;			// current progress towards the achievement
+	uint32		m_nMaxProgress;			// "out of" this many
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: call result for finding a leaderboard, returned as a result of FindOrCreateLeaderboard() or FindLeaderboard()
+//			use CCallResult<> to map this async result to a member function
+//-----------------------------------------------------------------------------
+struct LeaderboardFindResult_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 4 };
+	SteamLeaderboard_t m_hSteamLeaderboard;	// handle to the leaderboard serarched for, 0 if no leaderboard found
+	uint8 m_bLeaderboardFound;				// 0 if no leaderboard found
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: call result indicating scores for a leaderboard have been downloaded and are ready to be retrieved, returned as a result of DownloadLeaderboardEntries()
+//			use CCallResult<> to map this async result to a member function
+//-----------------------------------------------------------------------------
+struct LeaderboardScoresDownloaded_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 5 };
+	SteamLeaderboard_t m_hSteamLeaderboard;
+	SteamLeaderboardEntries_t m_hSteamLeaderboardEntries;	// the handle to pass into GetDownloadedLeaderboardEntries()
+	int m_cEntryCount; // the number of entries downloaded
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: call result indicating scores has been uploaded, returned as a result of UploadLeaderboardScore()
+//			use CCallResult<> to map this async result to a member function
+//-----------------------------------------------------------------------------
+struct LeaderboardScoreUploaded_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 6 };
+	uint8 m_bSuccess;			// 1 if the call was successful
+	SteamLeaderboard_t m_hSteamLeaderboard;	// the leaderboard handle that was
+	int32 m_nScore;				// the score that was attempted to set
+	uint8 m_bScoreChanged;		// true if the score in the leaderboard change, false if the existing score was better
+	int m_nGlobalRankNew;		// the new global rank of the user in this leaderboard
+	int m_nGlobalRankPrevious;	// the previous global rank of the user in this leaderboard; 0 if the user had no existing entry in the leaderboard
+};
+
+struct NumberOfCurrentPlayers_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 7 };
+	uint8 m_bSuccess;			// 1 if the call was successful
+	int32 m_cPlayers;			// Number of players currently playing
+};
+
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback indicating that a user's stats have been unloaded.
+//  Call RequestUserStats again to access stats for this user
+//-----------------------------------------------------------------------------
+struct UserStatsUnloaded_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 8 };
+	CSteamID	m_steamIDUser;	// User whose stats have been unloaded
+};
+
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback indicating that an achievement icon has been fetched
+//-----------------------------------------------------------------------------
+struct UserAchievementIconFetched_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 9 };
+
+	CGameID		m_nGameID;				// Game this is for
+	char		m_rgchAchievementName[k_cchStatNameMax];		// name of the achievement
+	bool		m_bAchieved;		// Is the icon for the achieved or not achieved version?
+	int			m_nIconHandle;		// Handle to the image, which can be used in SteamUtils()->GetImageRGBA(), 0 means no image is set for the achievement
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback indicating that global achievement percentages are fetched
+//-----------------------------------------------------------------------------
+struct GlobalAchievementPercentagesReady_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 10 };
+
+	uint64		m_nGameID;				// Game this is for
+	EResult		m_eResult;				// Result of the operation
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: call result indicating UGC has been uploaded, returned as a result of SetLeaderboardUGC()
+//-----------------------------------------------------------------------------
+struct LeaderboardUGCSet_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 11 };
+	EResult m_eResult;				// The result of the operation
+	SteamLeaderboard_t m_hSteamLeaderboard;	// the leaderboard handle that was
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: callback indicating that PS3 trophies have been installed
+//-----------------------------------------------------------------------------
+struct PS3TrophiesInstalled_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 12 };
+	uint64	m_nGameID;				// Game these stats are for
+	EResult m_eResult;				// The result of the operation
+	uint64 m_ulRequiredDiskSpace;	// If m_eResult is k_EResultDiskFull, will contain the amount of space needed to install trophies
+
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: callback indicating global stats have been received.
+//	Returned as a result of RequestGlobalStats()
+//-----------------------------------------------------------------------------
+struct GlobalStatsReceived_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 12 };
+	uint64	m_nGameID;				// Game global stats were requested for
+	EResult	m_eResult;				// The result of the request
+};
+
+#pragma pack( pop )
+
+
+#endif // ISTEAMUSER_H

--- a/lsteamclient/steamworks_sdk_148a/isteamutils.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamutils.h
@@ -1,0 +1,289 @@
+//====== Copyright � 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to utility functions in Steam
+//
+//=============================================================================
+
+#ifndef ISTEAMUTILS_H
+#define ISTEAMUTILS_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+
+
+// Steam API call failure results
+enum ESteamAPICallFailure
+{
+	k_ESteamAPICallFailureNone = -1,			// no failure
+	k_ESteamAPICallFailureSteamGone = 0,		// the local Steam process has gone away
+	k_ESteamAPICallFailureNetworkFailure = 1,	// the network connection to Steam has been broken, or was already broken
+	// SteamServersDisconnected_t callback will be sent around the same time
+	// SteamServersConnected_t will be sent when the client is able to talk to the Steam servers again
+	k_ESteamAPICallFailureInvalidHandle = 2,	// the SteamAPICall_t handle passed in no longer exists
+	k_ESteamAPICallFailureMismatchedCallback = 3,// GetAPICallResult() was called with the wrong callback type for this API call
+};
+
+
+// Input modes for the Big Picture gamepad text entry
+enum EGamepadTextInputMode
+{
+	k_EGamepadTextInputModeNormal = 0,
+	k_EGamepadTextInputModePassword = 1
+};
+
+
+// Controls number of allowed lines for the Big Picture gamepad text entry
+enum EGamepadTextInputLineMode
+{
+	k_EGamepadTextInputLineModeSingleLine = 0,
+	k_EGamepadTextInputLineModeMultipleLines = 1
+};
+
+// function prototype for warning message hook
+#if defined( POSIX )
+#define __cdecl
+#endif
+extern "C" typedef void (__cdecl *SteamAPIWarningMessageHook_t)(int, const char *);
+
+//-----------------------------------------------------------------------------
+// Purpose: interface to user independent utility functions
+//-----------------------------------------------------------------------------
+class ISteamUtils
+{
+public:
+	// return the number of seconds since the user 
+	virtual uint32 GetSecondsSinceAppActive() = 0;
+	virtual uint32 GetSecondsSinceComputerActive() = 0;
+
+	// the universe this client is connecting to
+	virtual EUniverse GetConnectedUniverse() = 0;
+
+	// Steam server time.  Number of seconds since January 1, 1970, GMT (i.e unix time)
+	virtual uint32 GetServerRealTime() = 0;
+
+	// returns the 2 digit ISO 3166-1-alpha-2 format country code this client is running in (as looked up via an IP-to-location database)
+	// e.g "US" or "UK".
+	virtual const char *GetIPCountry() = 0;
+
+	// returns true if the image exists, and valid sizes were filled out
+	virtual bool GetImageSize( int iImage, uint32 *pnWidth, uint32 *pnHeight ) = 0;
+
+	// returns true if the image exists, and the buffer was successfully filled out
+	// results are returned in RGBA format
+	// the destination buffer size should be 4 * height * width * sizeof(char)
+	virtual bool GetImageRGBA( int iImage, uint8 *pubDest, int nDestBufferSize ) = 0;
+
+	// returns the IP of the reporting server for valve - currently only used in Source engine games
+	virtual bool GetCSERIPPort( uint32 *unIP, uint16 *usPort ) = 0;
+
+	// return the amount of battery power left in the current system in % [0..100], 255 for being on AC power
+	virtual uint8 GetCurrentBatteryPower() = 0;
+
+	// returns the appID of the current process
+	virtual uint32 GetAppID() = 0;
+
+	// Sets the position where the overlay instance for the currently calling game should show notifications.
+	// This position is per-game and if this function is called from outside of a game context it will do nothing.
+	virtual void SetOverlayNotificationPosition( ENotificationPosition eNotificationPosition ) = 0;
+
+	// API asynchronous call results
+	// can be used directly, but more commonly used via the callback dispatch API (see steam_api.h)
+	virtual bool IsAPICallCompleted( SteamAPICall_t hSteamAPICall, bool *pbFailed ) = 0;
+	virtual ESteamAPICallFailure GetAPICallFailureReason( SteamAPICall_t hSteamAPICall ) = 0;
+	virtual bool GetAPICallResult( SteamAPICall_t hSteamAPICall, void *pCallback, int cubCallback, int iCallbackExpected, bool *pbFailed ) = 0;
+
+	// Deprecated. Applications should use SteamAPI_RunCallbacks() instead. Game servers do not need to call this function.
+	STEAM_PRIVATE_API( virtual void RunFrame() = 0; )
+
+	// returns the number of IPC calls made since the last time this function was called
+	// Used for perf debugging so you can understand how many IPC calls your game makes per frame
+	// Every IPC call is at minimum a thread context switch if not a process one so you want to rate
+	// control how often you do them.
+	virtual uint32 GetIPCCallCount() = 0;
+
+	// API warning handling
+	// 'int' is the severity; 0 for msg, 1 for warning
+	// 'const char *' is the text of the message
+	// callbacks will occur directly after the API function is called that generated the warning or message
+	virtual void SetWarningMessageHook( SteamAPIWarningMessageHook_t pFunction ) = 0;
+
+	// Returns true if the overlay is running & the user can access it. The overlay process could take a few seconds to
+	// start & hook the game process, so this function will initially return false while the overlay is loading.
+	virtual bool IsOverlayEnabled() = 0;
+
+	// Normally this call is unneeded if your game has a constantly running frame loop that calls the 
+	// D3D Present API, or OGL SwapBuffers API every frame.
+	//
+	// However, if you have a game that only refreshes the screen on an event driven basis then that can break 
+	// the overlay, as it uses your Present/SwapBuffers calls to drive it's internal frame loop and it may also
+	// need to Present() to the screen any time an even needing a notification happens or when the overlay is
+	// brought up over the game by a user.  You can use this API to ask the overlay if it currently need a present
+	// in that case, and then you can check for this periodically (roughly 33hz is desirable) and make sure you
+	// refresh the screen with Present or SwapBuffers to allow the overlay to do it's work.
+	virtual bool BOverlayNeedsPresent() = 0;
+
+	// Asynchronous call to check if an executable file has been signed using the public key set on the signing tab
+	// of the partner site, for example to refuse to load modified executable files.  
+	// The result is returned in CheckFileSignature_t.
+	//   k_ECheckFileSignatureNoSignaturesFoundForThisApp - This app has not been configured on the signing tab of the partner site to enable this function.
+	//   k_ECheckFileSignatureNoSignaturesFoundForThisFile - This file is not listed on the signing tab for the partner site.
+	//   k_ECheckFileSignatureFileNotFound - The file does not exist on disk.
+	//   k_ECheckFileSignatureInvalidSignature - The file exists, and the signing tab has been set for this file, but the file is either not signed or the signature does not match.
+	//   k_ECheckFileSignatureValidSignature - The file is signed and the signature is valid.
+	STEAM_CALL_RESULT( CheckFileSignature_t )
+	virtual SteamAPICall_t CheckFileSignature( const char *szFileName ) = 0;
+
+	// Activates the Big Picture text input dialog which only supports gamepad input
+	virtual bool ShowGamepadTextInput( EGamepadTextInputMode eInputMode, EGamepadTextInputLineMode eLineInputMode, const char *pchDescription, uint32 unCharMax, const char *pchExistingText ) = 0;
+
+	// Returns previously entered text & length
+	virtual uint32 GetEnteredGamepadTextLength() = 0;
+	virtual bool GetEnteredGamepadTextInput( char *pchText, uint32 cchText ) = 0;
+
+	// returns the language the steam client is running in, you probably want ISteamApps::GetCurrentGameLanguage instead, this is for very special usage cases
+	virtual const char *GetSteamUILanguage() = 0;
+
+	// returns true if Steam itself is running in VR mode
+	virtual bool IsSteamRunningInVR() = 0;
+	
+	// Sets the inset of the overlay notification from the corner specified by SetOverlayNotificationPosition.
+	virtual void SetOverlayNotificationInset( int nHorizontalInset, int nVerticalInset ) = 0;
+
+	// returns true if Steam & the Steam Overlay are running in Big Picture mode
+	// Games much be launched through the Steam client to enable the Big Picture overlay. During development,
+	// a game can be added as a non-steam game to the developers library to test this feature
+	virtual bool IsSteamInBigPictureMode() = 0;
+
+	// ask SteamUI to create and render its OpenVR dashboard
+	virtual void StartVRDashboard() = 0;
+
+	// Returns true if the HMD content will be streamed via Steam Remote Play
+	virtual bool IsVRHeadsetStreamingEnabled() = 0;
+
+	// Set whether the HMD content will be streamed via Steam Remote Play
+	// If this is set to true, then the scene in the HMD headset will be streamed, and remote input will not be allowed.
+	// If this is set to false, then the application window will be streamed instead, and remote input will be allowed.
+	// The default is true unless "VRHeadsetStreaming" "0" is in the extended appinfo for a game.
+	// (this is useful for games that have asymmetric multiplayer gameplay)
+	virtual void SetVRHeadsetStreamingEnabled( bool bEnabled ) = 0;
+
+	// Returns whether this steam client is a Steam China specific client, vs the global client.
+	virtual bool IsSteamChinaLauncher() = 0;
+
+	// Initializes text filtering.
+	//   Returns false if filtering is unavailable for the language the user is currently running in.
+	virtual bool InitFilterText() = 0; 
+
+	// Filters the provided input message and places the filtered result into pchOutFilteredText.
+	//   pchOutFilteredText is where the output will be placed, even if no filtering or censoring is performed
+	//   nByteSizeOutFilteredText is the size (in bytes) of pchOutFilteredText
+	//   pchInputText is the input string that should be filtered, which can be ASCII or UTF-8
+	//   bLegalOnly should be false if you want profanity and legally required filtering (where required) and true if you want legally required filtering only
+	//   Returns the number of characters (not bytes) filtered.
+	virtual int FilterText( char* pchOutFilteredText, uint32 nByteSizeOutFilteredText, const char * pchInputMessage, bool bLegalOnly ) = 0;
+
+	// Return what we believe your current ipv6 connectivity to "the internet" is on the specified protocol.
+	// This does NOT tell you if the Steam client is currently connected to Steam via ipv6.
+	virtual ESteamIPv6ConnectivityState GetIPv6ConnectivityState( ESteamIPv6ConnectivityProtocol eProtocol ) = 0;
+};
+
+#define STEAMUTILS_INTERFACE_VERSION "SteamUtils009"
+
+// Global interface accessor
+inline ISteamUtils *SteamUtils();
+STEAM_DEFINE_INTERFACE_ACCESSOR( ISteamUtils *, SteamUtils, SteamInternal_FindOrCreateUserInterface( 0, STEAMUTILS_INTERFACE_VERSION ), "user", STEAMUTILS_INTERFACE_VERSION );
+
+// Global accessor for the gameserver client
+inline ISteamUtils *SteamGameServerUtils();
+STEAM_DEFINE_INTERFACE_ACCESSOR( ISteamUtils *, SteamGameServerUtils, SteamInternal_FindOrCreateGameServerInterface( 0, STEAMUTILS_INTERFACE_VERSION ), "gameserver", STEAMUTILS_INTERFACE_VERSION );
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+
+//-----------------------------------------------------------------------------
+// Purpose: The country of the user changed
+//-----------------------------------------------------------------------------
+struct IPCountry_t
+{
+	enum { k_iCallback = k_iSteamUtilsCallbacks + 1 };
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Fired when running on a laptop and less than 10 minutes of battery is left, fires then every minute
+//-----------------------------------------------------------------------------
+struct LowBatteryPower_t
+{
+	enum { k_iCallback = k_iSteamUtilsCallbacks + 2 };
+	uint8 m_nMinutesBatteryLeft;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: called when a SteamAsyncCall_t has completed (or failed)
+//-----------------------------------------------------------------------------
+struct SteamAPICallCompleted_t
+{
+	enum { k_iCallback = k_iSteamUtilsCallbacks + 3 };
+	SteamAPICall_t m_hAsyncCall;
+	int m_iCallback;
+	uint32 m_cubParam;
+};
+
+
+//-----------------------------------------------------------------------------
+// called when Steam wants to shutdown
+//-----------------------------------------------------------------------------
+struct SteamShutdown_t
+{
+	enum { k_iCallback = k_iSteamUtilsCallbacks + 4 };
+};
+
+//-----------------------------------------------------------------------------
+// results for CheckFileSignature
+//-----------------------------------------------------------------------------
+enum ECheckFileSignature
+{
+	k_ECheckFileSignatureInvalidSignature = 0,
+	k_ECheckFileSignatureValidSignature = 1,
+	k_ECheckFileSignatureFileNotFound = 2,
+	k_ECheckFileSignatureNoSignaturesFoundForThisApp = 3,
+	k_ECheckFileSignatureNoSignaturesFoundForThisFile = 4,
+};
+
+//-----------------------------------------------------------------------------
+// callback for CheckFileSignature
+//-----------------------------------------------------------------------------
+struct CheckFileSignature_t
+{
+	enum { k_iCallback = k_iSteamUtilsCallbacks + 5 };
+	ECheckFileSignature m_eCheckFileSignature;
+};
+
+
+// k_iSteamUtilsCallbacks + 13 is taken
+
+
+//-----------------------------------------------------------------------------
+// Big Picture gamepad text input has been closed
+//-----------------------------------------------------------------------------
+struct GamepadTextInputDismissed_t
+{
+	enum { k_iCallback = k_iSteamUtilsCallbacks + 14 };
+	bool m_bSubmitted;										// true if user entered & accepted text (Call ISteamUtils::GetEnteredGamepadTextInput() for text), false if canceled input
+	uint32 m_unSubmittedText;
+};
+
+// k_iSteamUtilsCallbacks + 15 is taken
+
+#pragma pack( pop )
+
+#endif // ISTEAMUTILS_H

--- a/lsteamclient/steamworks_sdk_148a/isteamvideo.h
+++ b/lsteamclient/steamworks_sdk_148a/isteamvideo.h
@@ -1,0 +1,68 @@
+//====== Copyright © 1996-2014 Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to Steam Video
+//
+//=============================================================================
+
+#ifndef ISTEAMVIDEO_H
+#define ISTEAMVIDEO_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api_common.h"
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif
+
+
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Steam Video API
+//-----------------------------------------------------------------------------
+class ISteamVideo
+{
+public:
+
+	// Get a URL suitable for streaming the given Video app ID's video
+	virtual void GetVideoURL( AppId_t unVideoAppID ) = 0;
+
+	// returns true if user is uploading a live broadcast
+	virtual bool IsBroadcasting( int *pnNumViewers ) = 0;
+
+	// Get the OPF Details for 360 Video Playback
+	STEAM_CALL_BACK( GetOPFSettingsResult_t )
+	virtual void GetOPFSettings( AppId_t unVideoAppID ) = 0;
+	virtual bool GetOPFStringForApp( AppId_t unVideoAppID, char *pchBuffer, int32 *pnBufferSize ) = 0;
+};
+
+#define STEAMVIDEO_INTERFACE_VERSION "STEAMVIDEO_INTERFACE_V002"
+
+// Global interface accessor
+inline ISteamVideo *SteamVideo();
+STEAM_DEFINE_USER_INTERFACE_ACCESSOR( ISteamVideo *, SteamVideo, STEAMVIDEO_INTERFACE_VERSION );
+
+STEAM_CALLBACK_BEGIN( GetVideoURLResult_t, k_iClientVideoCallbacks + 11 )
+	STEAM_CALLBACK_MEMBER( 0, EResult, m_eResult )
+	STEAM_CALLBACK_MEMBER( 1, AppId_t, m_unVideoAppID )
+	STEAM_CALLBACK_MEMBER( 2, char, m_rgchURL[256] )
+STEAM_CALLBACK_END(3)
+
+
+STEAM_CALLBACK_BEGIN( GetOPFSettingsResult_t, k_iClientVideoCallbacks + 24 )
+	STEAM_CALLBACK_MEMBER( 0, EResult, m_eResult )
+	STEAM_CALLBACK_MEMBER( 1, AppId_t, m_unVideoAppID )
+STEAM_CALLBACK_END(2)
+
+
+#pragma pack( pop )
+
+
+#endif // ISTEAMVIDEO_H

--- a/lsteamclient/steamworks_sdk_148a/matchmakingtypes.h
+++ b/lsteamclient/steamworks_sdk_148a/matchmakingtypes.h
@@ -1,0 +1,251 @@
+//========= Copyright � 1996-2008, Valve LLC, All rights reserved. ============
+//
+// Purpose: 
+//
+// $NoKeywords: $
+//=============================================================================
+
+#ifndef MATCHMAKINGTYPES_H
+#define MATCHMAKINGTYPES_H
+
+#ifdef _WIN32
+#pragma once
+#endif
+
+#ifdef POSIX
+#ifndef _snprintf
+#define _snprintf snprintf
+#endif
+#endif
+
+#include <stdio.h>
+#include <string.h>
+
+//
+// Max size (in bytes of UTF-8 data, not in characters) of server fields, including null terminator.
+// WARNING: These cannot be changed easily, without breaking clients using old interfaces.
+//
+const int k_cbMaxGameServerGameDir = 32;
+const int k_cbMaxGameServerMapName = 32;
+const int k_cbMaxGameServerGameDescription = 64;
+const int k_cbMaxGameServerName = 64;
+const int k_cbMaxGameServerTags = 128;
+const int k_cbMaxGameServerGameData = 2048;
+
+/// Store key/value pair used in matchmaking queries.
+///
+/// Actually, the name Key/Value is a bit misleading.  The "key" is better
+/// understood as "filter operation code" and the "value" is the operand to this
+/// filter operation.  The meaning of the operand depends upon the filter.
+struct MatchMakingKeyValuePair_t
+{
+	MatchMakingKeyValuePair_t() { m_szKey[0] = m_szValue[0] = 0; }
+	MatchMakingKeyValuePair_t( const char *pchKey, const char *pchValue )
+	{
+		strncpy( m_szKey, pchKey, sizeof(m_szKey) ); // this is a public header, use basic c library string funcs only!
+		m_szKey[ sizeof( m_szKey ) - 1 ] = '\0';
+		strncpy( m_szValue, pchValue, sizeof(m_szValue) );
+		m_szValue[ sizeof( m_szValue ) - 1 ] = '\0';
+	}
+	char m_szKey[ 256 ];
+	char m_szValue[ 256 ];
+};
+
+
+enum EMatchMakingServerResponse
+{
+	eServerResponded = 0,
+	eServerFailedToRespond,
+	eNoServersListedOnMasterServer // for the Internet query type, returned in response callback if no servers of this type match
+};
+
+// servernetadr_t is all the addressing info the serverbrowser needs to know about a game server,
+// namely: its IP, its connection port, and its query port.
+class servernetadr_t 
+{
+public:
+
+	servernetadr_t() : m_usConnectionPort( 0 ), m_usQueryPort( 0 ), m_unIP( 0 ) {}
+	
+	void	Init( unsigned int ip, uint16 usQueryPort, uint16 usConnectionPort );
+#ifdef NETADR_H
+	netadr_t	GetIPAndQueryPort();
+#endif
+	
+	// Access the query port.
+	uint16	GetQueryPort() const;
+	void	SetQueryPort( uint16 usPort );
+
+	// Access the connection port.
+	uint16	GetConnectionPort() const;
+	void	SetConnectionPort( uint16 usPort );
+
+	// Access the IP
+	uint32 GetIP() const;
+	void SetIP( uint32 unIP );
+
+	// This gets the 'a.b.c.d:port' string with the connection port (instead of the query port).
+	const char *GetConnectionAddressString() const;
+	const char *GetQueryAddressString() const;
+
+	// Comparison operators and functions.
+	bool	operator<(const servernetadr_t &netadr) const;
+	void operator=( const servernetadr_t &that )
+	{
+		m_usConnectionPort = that.m_usConnectionPort;
+		m_usQueryPort = that.m_usQueryPort;
+		m_unIP = that.m_unIP;
+	}
+
+	
+private:
+	const char *ToString( uint32 unIP, uint16 usPort ) const;
+	uint16	m_usConnectionPort;	// (in HOST byte order)
+	uint16	m_usQueryPort;
+	uint32  m_unIP;
+};
+
+
+inline void	servernetadr_t::Init( unsigned int ip, uint16 usQueryPort, uint16 usConnectionPort )
+{
+	m_unIP = ip;
+	m_usQueryPort = usQueryPort;
+	m_usConnectionPort = usConnectionPort;
+}
+
+#ifdef NETADR_H
+inline netadr_t servernetadr_t::GetIPAndQueryPort()
+{
+	return netadr_t( m_unIP, m_usQueryPort );
+}
+#endif
+
+inline uint16 servernetadr_t::GetQueryPort() const
+{
+	return m_usQueryPort;
+}
+
+inline void	servernetadr_t::SetQueryPort( uint16 usPort )
+{
+	m_usQueryPort = usPort;
+}
+
+inline uint16 servernetadr_t::GetConnectionPort() const
+{
+	return m_usConnectionPort;
+}
+
+inline void	servernetadr_t::SetConnectionPort( uint16 usPort )
+{
+	m_usConnectionPort = usPort;
+}
+
+inline uint32 servernetadr_t::GetIP() const
+{
+	return m_unIP;
+}
+
+inline void	servernetadr_t::SetIP( uint32 unIP )
+{
+	m_unIP = unIP;
+}
+
+inline const char *servernetadr_t::ToString( uint32 unIP, uint16 usPort ) const
+{
+	static char s[4][64];
+	static int nBuf = 0;
+	unsigned char *ipByte = (unsigned char *)&unIP;
+#ifdef VALVE_BIG_ENDIAN
+	_snprintf (s[nBuf], sizeof( s[nBuf] ), "%u.%u.%u.%u:%i", (int)(ipByte[0]), (int)(ipByte[1]), (int)(ipByte[2]), (int)(ipByte[3]), usPort );
+#else
+	_snprintf (s[nBuf], sizeof( s[nBuf] ), "%u.%u.%u.%u:%i", (int)(ipByte[3]), (int)(ipByte[2]), (int)(ipByte[1]), (int)(ipByte[0]), usPort );
+#endif
+	const char *pchRet = s[nBuf];
+	++nBuf;
+	nBuf %= ( (sizeof(s)/sizeof(s[0])) );
+	return pchRet;
+}
+
+inline const char* servernetadr_t::GetConnectionAddressString() const
+{
+	return ToString( m_unIP, m_usConnectionPort );
+}
+
+inline const char* servernetadr_t::GetQueryAddressString() const
+{
+	return ToString( m_unIP, m_usQueryPort );	
+}
+
+inline bool servernetadr_t::operator<(const servernetadr_t &netadr) const
+{
+	return ( m_unIP < netadr.m_unIP ) || ( m_unIP == netadr.m_unIP && m_usQueryPort < netadr.m_usQueryPort );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Data describing a single server
+//-----------------------------------------------------------------------------
+class gameserveritem_t
+{
+public:
+	gameserveritem_t();
+
+	const char* GetName() const;
+	void SetName( const char *pName );
+
+public:
+	servernetadr_t m_NetAdr;									///< IP/Query Port/Connection Port for this server
+	int m_nPing;												///< current ping time in milliseconds
+	bool m_bHadSuccessfulResponse;								///< server has responded successfully in the past
+	bool m_bDoNotRefresh;										///< server is marked as not responding and should no longer be refreshed
+	char m_szGameDir[k_cbMaxGameServerGameDir];					///< current game directory
+	char m_szMap[k_cbMaxGameServerMapName];						///< current map
+	char m_szGameDescription[k_cbMaxGameServerGameDescription];	///< game description
+	uint32 m_nAppID;											///< Steam App ID of this server
+	int m_nPlayers;												///< total number of players currently on the server.  INCLUDES BOTS!!
+	int m_nMaxPlayers;											///< Maximum players that can join this server
+	int m_nBotPlayers;											///< Number of bots (i.e simulated players) on this server
+	bool m_bPassword;											///< true if this server needs a password to join
+	bool m_bSecure;												///< Is this server protected by VAC
+	uint32 m_ulTimeLastPlayed;									///< time (in unix time) when this server was last played on (for favorite/history servers)
+	int	m_nServerVersion;										///< server version as reported to Steam
+
+private:
+
+	/// Game server name
+	char m_szServerName[k_cbMaxGameServerName];
+
+	// For data added after SteamMatchMaking001 add it here
+public:
+	/// the tags this server exposes
+	char m_szGameTags[k_cbMaxGameServerTags];
+
+	/// steamID of the game server - invalid if it's doesn't have one (old server, or not connected to Steam)
+	CSteamID m_steamID;
+};
+
+
+inline gameserveritem_t::gameserveritem_t()
+{
+	m_szGameDir[0] = m_szMap[0] = m_szGameDescription[0] = m_szServerName[0] = 0;
+	m_bHadSuccessfulResponse = m_bDoNotRefresh = m_bPassword = m_bSecure = false;
+	m_nPing = m_nAppID = m_nPlayers = m_nMaxPlayers = m_nBotPlayers = m_ulTimeLastPlayed = m_nServerVersion = 0;
+	m_szGameTags[0] = 0;
+}
+
+inline const char* gameserveritem_t::GetName() const
+{
+	// Use the IP address as the name if nothing is set yet.
+	if ( m_szServerName[0] == 0 )
+		return m_NetAdr.GetConnectionAddressString();
+	else
+		return m_szServerName;
+}
+
+inline void gameserveritem_t::SetName( const char *pName )
+{
+	strncpy( m_szServerName, pName, sizeof( m_szServerName ) );
+	m_szServerName[ sizeof( m_szServerName ) - 1 ] = '\0';
+}
+
+
+#endif // MATCHMAKINGTYPES_H

--- a/lsteamclient/steamworks_sdk_148a/steam_api.h
+++ b/lsteamclient/steamworks_sdk_148a/steam_api.h
@@ -1,0 +1,296 @@
+//====== Copyright Valve Corporation, All rights reserved. ====================
+//
+// This header includes *all* of the interfaces and callback structures
+// in the Steamworks SDK, and some high level functions to control the SDK
+// (init, shutdown, etc) that you probably only need in one or two files.
+//
+// To save your compile times, we recommend that you not include this file
+// in header files.  Instead, include the specific headers for the interfaces
+// and callback structures you need.  The one file you might consider including
+// in your precompiled header (e.g. stdafx.h) is steam_api_common.h
+//
+//=============================================================================
+
+#ifndef STEAM_API_H
+#define STEAM_API_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+// Basic stuff
+#include "steam_api_common.h"
+
+// All of the interfaces
+#include "isteamclient.h"
+#include "isteamuser.h"
+#include "isteamfriends.h"
+#include "isteamutils.h"
+#include "isteammatchmaking.h"
+#include "isteamuserstats.h"
+#include "isteamapps.h"
+#include "isteamnetworking.h"
+#include "isteamremotestorage.h"
+#include "isteamscreenshots.h"
+#include "isteammusic.h"
+#include "isteammusicremote.h"
+#include "isteamhttp.h"
+#include "isteamcontroller.h"
+#include "isteamugc.h"
+#include "isteamapplist.h"
+#include "isteamhtmlsurface.h"
+#include "isteaminventory.h"
+#include "isteamvideo.h"
+#include "isteamparentalsettings.h"
+#include "isteaminput.h"
+#include "isteamremoteplay.h"
+#include "isteamnetworkingsockets.h"
+#include "isteamnetworkingutils.h"
+
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+//	Steam API setup & shutdown
+//
+//	These functions manage loading, initializing and shutdown of the steamclient.dll
+//
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+
+
+// SteamAPI_Init must be called before using any other API functions. If it fails, an
+// error message will be output to the debugger (or stderr) with further information.
+S_API bool S_CALLTYPE SteamAPI_Init();
+
+// SteamAPI_Shutdown should be called during process shutdown if possible.
+S_API void S_CALLTYPE SteamAPI_Shutdown();
+
+// SteamAPI_RestartAppIfNecessary ensures that your executable was launched through Steam.
+//
+// Returns true if the current process should terminate. Steam is now re-launching your application.
+//
+// Returns false if no action needs to be taken. This means that your executable was started through
+// the Steam client, or a steam_appid.txt file is present in your game's directory (for development).
+// Your current process should continue if false is returned.
+//
+// NOTE: If you use the Steam DRM wrapper on your primary executable file, this check is unnecessary
+// since the DRM wrapper will ensure that your application was launched properly through Steam.
+S_API bool S_CALLTYPE SteamAPI_RestartAppIfNecessary( uint32 unOwnAppID );
+
+// Many Steam API functions allocate a small amount of thread-local memory for parameter storage.
+// SteamAPI_ReleaseCurrentThreadMemory() will free API memory associated with the calling thread.
+// This function is also called automatically by SteamAPI_RunCallbacks(), so a single-threaded
+// program never needs to explicitly call this function.
+S_API void S_CALLTYPE SteamAPI_ReleaseCurrentThreadMemory();
+
+
+// crash dump recording functions
+S_API void S_CALLTYPE SteamAPI_WriteMiniDump( uint32 uStructuredExceptionCode, void* pvExceptionInfo, uint32 uBuildID );
+S_API void S_CALLTYPE SteamAPI_SetMiniDumpComment( const char *pchMsg );
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+//	steamclient.dll private wrapper functions
+//
+//	The following functions are part of abstracting API access to the steamclient.dll, but should only be used in very specific cases
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+
+// SteamAPI_IsSteamRunning() returns true if Steam is currently running
+S_API bool S_CALLTYPE SteamAPI_IsSteamRunning();
+
+// returns the filename path of the current running Steam process, used if you need to load an explicit steam dll by name.
+// DEPRECATED - implementation is Windows only, and the path returned is a UTF-8 string which must be converted to UTF-16 for use with Win32 APIs
+S_API const char *SteamAPI_GetSteamInstallPath();
+
+// sets whether or not Steam_RunCallbacks() should do a try {} catch (...) {} around calls to issuing callbacks
+// This is ignored if you are using the manual callback dispatch method
+S_API void SteamAPI_SetTryCatchCallbacks( bool bTryCatchCallbacks );
+
+#if defined( VERSION_SAFE_STEAM_API_INTERFACES )
+// exists only for backwards compat with code written against older SDKs
+S_API bool S_CALLTYPE SteamAPI_InitSafe();
+#endif
+
+#if defined(USE_BREAKPAD_HANDLER) || defined(STEAM_API_EXPORTS)
+// this should be called before the game initialized the steam APIs
+// pchDate should be of the format "Mmm dd yyyy" (such as from the __ DATE __ macro )
+// pchTime should be of the format "hh:mm:ss" (such as from the __ TIME __ macro )
+// bFullMemoryDumps (Win32 only) -- writes out a uuid-full.dmp in the client/dumps folder
+// pvContext-- can be NULL, will be the void * context passed into m_pfnPreMinidumpCallback
+// PFNPreMinidumpCallback m_pfnPreMinidumpCallback   -- optional callback which occurs just before a .dmp file is written during a crash.  Applications can hook this to allow adding additional information into the .dmp comment stream.
+S_API void S_CALLTYPE SteamAPI_UseBreakpadCrashHandler( char const *pchVersion, char const *pchDate, char const *pchTime, bool bFullMemoryDumps, void *pvContext, PFNPreMinidumpCallback m_pfnPreMinidumpCallback );
+S_API void S_CALLTYPE SteamAPI_SetBreakpadAppID( uint32 unAppID );
+#endif
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+//
+// Manual callback loop
+//
+// An alternative method for dispatching callbacks.  Similar to a windows message loop.
+//
+// If you use the manual callback dispatch, you must NOT use:
+//
+// - SteamAPI_RunCallbacks or SteamGameServer_RunCallbacks
+// - STEAM_CALLBACK, CCallResult, CCallback, or CCallbackManual
+//
+// Here is the basic template for replacing SteamAPI_RunCallbacks() with manual dispatch
+/*
+
+	HSteamPipe hSteamPipe = SteamAPI_GetHSteamPipe(); // See also SteamGameServer_GetHSteamPipe()
+	SteamAPI_ManualDispatch_RunFrame( hSteamPipe )
+	CallbackMsg_t callback;
+	while ( SteamAPI_ManualDispatch_GetNextCallback( hSteamPipe, &callback ) )
+	{
+		// Check for dispatching API call results
+		if ( callback.m_iCallback == SteamAPICallCompleted_t::k_iCallback )
+		{
+			SteamAPICallCompleted_t *pCallCompleted = (SteamAPICallCompleted_t *)callback.
+			void *pTmpCallResult = malloc( pCallback->m_cubParam );
+			bool bFailed;
+			if ( SteamAPI_ManualDispatch_GetAPICallResult( hSteamPipe, pCallCompleted->m_hAsyncCall, pTmpCallResult, pCallback->m_cubParam, pCallback->m_iCallback, &bFailed ) )
+			{
+				// Dispatch the call result to the registered handler(s) for the
+				// call identified by pCallCompleted->m_hAsyncCall
+			}
+			free( pTmpCallResult );
+		}
+		else
+		{
+			// Look at callback.m_iCallback to see what kind of callback it is,
+			// and dispatch to appropriate handler(s)
+		}
+		SteamAPI_ManualDispatch_FreeLastCallback( hSteamPipe );
+	}
+
+*/
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+
+/// Inform the API that you wish to use manual event dispatch.  This must be called after SteamAPI_Init, but before
+/// you use any of the other manual dispatch functions below.
+S_API void S_CALLTYPE SteamAPI_ManualDispatch_Init();
+
+/// Perform certain periodic actions that need to be performed.
+S_API void S_CALLTYPE SteamAPI_ManualDispatch_RunFrame( HSteamPipe hSteamPipe );
+
+/// Fetch the next pending callback on the given pipe, if any.  If a callback is available, true is returned
+/// and the structure is populated.  In this case, you MUST call SteamAPI_ManualDispatch_FreeLastCallback
+/// (after dispatching the callback) before calling SteamAPI_ManualDispatch_GetNextCallback again.
+S_API bool S_CALLTYPE SteamAPI_ManualDispatch_GetNextCallback( HSteamPipe hSteamPipe, CallbackMsg_t *pCallbackMsg );
+
+/// You must call this after dispatching the callback, if SteamAPI_ManualDispatch_GetNextCallback returns true.
+S_API void S_CALLTYPE SteamAPI_ManualDispatch_FreeLastCallback( HSteamPipe hSteamPipe );
+
+/// Return the call result for the specified call on the specified pipe.  You really should
+/// only call this in a handler for SteamAPICallCompleted_t callback.
+S_API bool S_CALLTYPE SteamAPI_ManualDispatch_GetAPICallResult( HSteamPipe hSteamPipe, SteamAPICall_t hSteamAPICall, void *pCallback, int cubCallback, int iCallbackExpected, bool *pbFailed );
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+//
+// CSteamAPIContext
+//
+// Deprecated!  This is not necessary any more.  Please use the global accessors directly
+//
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+
+#ifndef STEAM_API_EXPORTS
+
+inline bool CSteamAPIContext::Init()
+{
+	m_pSteamClient = ::SteamClient();
+	if ( !m_pSteamClient )
+		return false;
+
+	m_pSteamUser = ::SteamUser();
+	if ( !m_pSteamUser )
+		return false;
+
+	m_pSteamFriends = ::SteamFriends();
+	if ( !m_pSteamFriends )
+		return false;
+
+	m_pSteamUtils = ::SteamUtils();
+	if ( !m_pSteamUtils )
+		return false;
+
+	m_pSteamMatchmaking = ::SteamMatchmaking();
+	if ( !m_pSteamMatchmaking )
+		return false;
+
+	m_pSteamGameSearch = ::SteamGameSearch();
+	if ( !m_pSteamGameSearch )
+		return false;
+
+#if !defined( IOSALL) // Not yet supported on iOS.
+	m_pSteamMatchmakingServers = ::SteamMatchmakingServers();
+	if ( !m_pSteamMatchmakingServers )
+		return false;
+#endif
+
+	m_pSteamUserStats = ::SteamUserStats();
+	if ( !m_pSteamUserStats )
+		return false;
+
+	m_pSteamApps = ::SteamApps();
+	if ( !m_pSteamApps )
+		return false;
+
+	m_pSteamNetworking = ::SteamNetworking();
+	if ( !m_pSteamNetworking )
+		return false;
+
+	m_pSteamRemoteStorage = ::SteamRemoteStorage();
+	if ( !m_pSteamRemoteStorage )
+		return false;
+
+	m_pSteamScreenshots = ::SteamScreenshots();
+	if ( !m_pSteamScreenshots )
+		return false;
+
+	m_pSteamHTTP = ::SteamHTTP();
+	if ( !m_pSteamHTTP )
+		return false;
+
+	m_pController = ::SteamController();
+	if ( !m_pController )
+		return false;
+
+	m_pSteamUGC = ::SteamUGC();
+	if ( !m_pSteamUGC )
+		return false;
+
+	m_pSteamAppList = ::SteamAppList();
+	if ( !m_pSteamAppList )
+		return false;
+
+	m_pSteamMusic = ::SteamMusic();
+	if ( !m_pSteamMusic )
+		return false;
+
+	m_pSteamMusicRemote = ::SteamMusicRemote();
+	if ( !m_pSteamMusicRemote )
+		return false;
+
+#if !defined( ANDROID ) && !defined( IOSALL) // Not yet supported on Android or ios.
+	m_pSteamHTMLSurface = ::SteamHTMLSurface();
+	if ( !m_pSteamHTMLSurface )
+	return false;
+#endif
+
+	m_pSteamInventory = ::SteamInventory();
+	if ( !m_pSteamInventory )
+		return false;
+
+	m_pSteamVideo = ::SteamVideo();
+	if ( !m_pSteamVideo )
+		return false;
+
+	m_pSteamParentalSettings = ::SteamParentalSettings();
+	if ( !m_pSteamParentalSettings )
+		return false;
+
+	m_pSteamInput = ::SteamInput();
+	if ( !m_pSteamInput )
+		return false;
+
+	return true;
+}
+
+#endif
+
+#endif // STEAM_API_H

--- a/lsteamclient/steamworks_sdk_148a/steam_api.json
+++ b/lsteamclient/steamworks_sdk_148a/steam_api.json
@@ -1,0 +1,13077 @@
+{
+  "callback_structs": [
+    {
+      "callback_id": 101,
+      "fields": [],
+      "struct": "SteamServersConnected_t"
+    },
+    {
+      "callback_id": 102,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_bStillRetrying", "fieldtype":"bool" }
+      ],
+      "struct": "SteamServerConnectFailure_t"
+    },
+    {
+      "callback_id": 103,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" }
+      ],
+      "struct": "SteamServersDisconnected_t"
+    },
+    {
+      "callback_id": 113,
+      "fields": [
+        { "fieldname":"m_uAppID", "fieldtype":"uint32" },
+        { "fieldname":"m_unGameServerIP", "fieldtype":"uint32" },
+        { "fieldname":"m_usGameServerPort", "fieldtype":"uint16" },
+        { "fieldname":"m_bSecure", "fieldtype":"uint16" },
+        { "fieldname":"m_uReason", "fieldtype":"uint32" }
+      ],
+      "struct": "ClientGameServerDeny_t"
+    },
+    {
+      "callback_id": 117,
+      "enums": [
+        {
+          "enumname": "EFailureType",
+          "fqname": "IPCFailure_t::EFailureType",
+          "values": [
+            { "name":"k_EFailureFlushedCallbackQueue", "value":"0" },
+            { "name":"k_EFailurePipeFail", "value":"1" }
+          ]
+        }
+      ],
+      "fields": [
+        { "fieldname":"m_eFailureType", "fieldtype":"uint8" }
+      ],
+      "struct": "IPCFailure_t"
+    },
+    {
+      "callback_id": 125,
+      "fields": [],
+      "struct": "LicensesUpdated_t"
+    },
+    {
+      "callback_id": 143,
+      "fields": [
+        { "fieldname":"m_SteamID", "fieldtype":"CSteamID" },
+        { "fieldname":"m_eAuthSessionResponse", "fieldtype":"EAuthSessionResponse" },
+        { "fieldname":"m_OwnerSteamID", "fieldtype":"CSteamID" }
+      ],
+      "struct": "ValidateAuthTicketResponse_t"
+    },
+    {
+      "callback_id": 152,
+      "fields": [
+        { "fieldname":"m_unAppID", "fieldtype":"uint32" },
+        { "fieldname":"m_ulOrderID", "fieldtype":"uint64" },
+        { "fieldname":"m_bAuthorized", "fieldtype":"uint8" }
+      ],
+      "struct": "MicroTxnAuthorizationResponse_t"
+    },
+    {
+      "callback_id": 154,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" }
+      ],
+      "struct": "EncryptedAppTicketResponse_t"
+    },
+    {
+      "callback_id": 163,
+      "fields": [
+        { "fieldname":"m_hAuthTicket", "fieldtype":"HAuthTicket" },
+        { "fieldname":"m_eResult", "fieldtype":"EResult" }
+      ],
+      "struct": "GetAuthSessionTicketResponse_t"
+    },
+    {
+      "callback_id": 164,
+      "fields": [
+        { "fieldname":"m_szURL", "fieldtype":"char [256]" }
+      ],
+      "struct": "GameWebCallback_t"
+    },
+    {
+      "callback_id": 165,
+      "fields": [
+        { "fieldname":"m_szURL", "fieldtype":"char [512]" }
+      ],
+      "struct": "StoreAuthURLResponse_t"
+    },
+    {
+      "callback_id": 166,
+      "fields": [
+        { "fieldname":"m_bAllowed", "fieldtype":"bool" },
+        { "fieldname":"m_eNotAllowedReason", "fieldtype":"EMarketNotAllowedReasonFlags" },
+        { "fieldname":"m_rtAllowedAtTime", "fieldtype":"RTime32" },
+        { "fieldname":"m_cdaySteamGuardRequiredDays", "fieldtype":"int" },
+        { "fieldname":"m_cdayNewDeviceCooldown", "fieldtype":"int" }
+      ],
+      "struct": "MarketEligibilityResponse_t"
+    },
+    {
+      "callback_id": 167,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_appid", "fieldtype":"AppId_t" },
+        { "fieldname":"m_bApplicable", "fieldtype":"bool" },
+        { "fieldname":"m_csecsLast5h", "fieldtype":"int32" },
+        { "fieldname":"m_progress", "fieldtype":"EDurationControlProgress" },
+        { "fieldname":"m_notification", "fieldtype":"EDurationControlNotification" },
+        { "fieldname":"m_csecsToday", "fieldtype":"int32" },
+        { "fieldname":"m_csecsRemaining", "fieldtype":"int32" }
+      ],
+      "struct": "DurationControl_t"
+    },
+    {
+      "callback_id": 304,
+      "fields": [
+        { "fieldname":"m_ulSteamID", "fieldtype":"uint64" },
+        { "fieldname":"m_nChangeFlags", "fieldtype":"int" }
+      ],
+      "struct": "PersonaStateChange_t"
+    },
+    {
+      "callback_id": 331,
+      "fields": [
+        { "fieldname":"m_bActive", "fieldtype":"uint8" }
+      ],
+      "struct": "GameOverlayActivated_t"
+    },
+    {
+      "callback_id": 332,
+      "fields": [
+        { "fieldname":"m_rgchServer", "fieldtype":"char [64]" },
+        { "fieldname":"m_rgchPassword", "fieldtype":"char [64]" }
+      ],
+      "struct": "GameServerChangeRequested_t"
+    },
+    {
+      "callback_id": 333,
+      "fields": [
+        { "fieldname":"m_steamIDLobby", "fieldtype":"CSteamID" },
+        { "fieldname":"m_steamIDFriend", "fieldtype":"CSteamID" }
+      ],
+      "struct": "GameLobbyJoinRequested_t"
+    },
+    {
+      "callback_id": 334,
+      "fields": [
+        { "fieldname":"m_steamID", "fieldtype":"CSteamID" },
+        { "fieldname":"m_iImage", "fieldtype":"int" },
+        { "fieldname":"m_iWide", "fieldtype":"int" },
+        { "fieldname":"m_iTall", "fieldtype":"int" }
+      ],
+      "struct": "AvatarImageLoaded_t"
+    },
+    {
+      "callback_id": 335,
+      "fields": [
+        { "fieldname":"m_steamIDClan", "fieldtype":"CSteamID" },
+        { "fieldname":"m_cOfficers", "fieldtype":"int" },
+        { "fieldname":"m_bSuccess", "fieldtype":"uint8" }
+      ],
+      "struct": "ClanOfficerListResponse_t"
+    },
+    {
+      "callback_id": 336,
+      "fields": [
+        { "fieldname":"m_steamIDFriend", "fieldtype":"CSteamID" },
+        { "fieldname":"m_nAppID", "fieldtype":"AppId_t" }
+      ],
+      "struct": "FriendRichPresenceUpdate_t"
+    },
+    {
+      "callback_id": 337,
+      "fields": [
+        { "fieldname":"m_steamIDFriend", "fieldtype":"CSteamID" },
+        { "fieldname":"m_rgchConnect", "fieldtype":"char [256]" }
+      ],
+      "struct": "GameRichPresenceJoinRequested_t"
+    },
+    {
+      "callback_id": 338,
+      "fields": [
+        { "fieldname":"m_steamIDClanChat", "fieldtype":"CSteamID" },
+        { "fieldname":"m_steamIDUser", "fieldtype":"CSteamID" },
+        { "fieldname":"m_iMessageID", "fieldtype":"int" }
+      ],
+      "struct": "GameConnectedClanChatMsg_t"
+    },
+    {
+      "callback_id": 339,
+      "fields": [
+        { "fieldname":"m_steamIDClanChat", "fieldtype":"CSteamID" },
+        { "fieldname":"m_steamIDUser", "fieldtype":"CSteamID" }
+      ],
+      "struct": "GameConnectedChatJoin_t"
+    },
+    {
+      "callback_id": 340,
+      "fields": [
+        { "fieldname":"m_steamIDClanChat", "fieldtype":"CSteamID" },
+        { "fieldname":"m_steamIDUser", "fieldtype":"CSteamID" },
+        { "fieldname":"m_bKicked", "fieldtype":"bool" },
+        { "fieldname":"m_bDropped", "fieldtype":"bool" }
+      ],
+      "struct": "GameConnectedChatLeave_t"
+    },
+    {
+      "callback_id": 341,
+      "fields": [
+        { "fieldname":"m_bSuccess", "fieldtype":"bool" }
+      ],
+      "struct": "DownloadClanActivityCountsResult_t"
+    },
+    {
+      "callback_id": 342,
+      "fields": [
+        { "fieldname":"m_steamIDClanChat", "fieldtype":"CSteamID" },
+        { "fieldname":"m_eChatRoomEnterResponse", "fieldtype":"EChatRoomEnterResponse" }
+      ],
+      "struct": "JoinClanChatRoomCompletionResult_t"
+    },
+    {
+      "callback_id": 343,
+      "fields": [
+        { "fieldname":"m_steamIDUser", "fieldtype":"CSteamID" },
+        { "fieldname":"m_iMessageID", "fieldtype":"int" }
+      ],
+      "struct": "GameConnectedFriendChatMsg_t"
+    },
+    {
+      "callback_id": 344,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_steamID", "fieldtype":"CSteamID" },
+        { "fieldname":"m_nCount", "fieldtype":"int" }
+      ],
+      "struct": "FriendsGetFollowerCount_t"
+    },
+    {
+      "callback_id": 345,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_steamID", "fieldtype":"CSteamID" },
+        { "fieldname":"m_bIsFollowing", "fieldtype":"bool" }
+      ],
+      "struct": "FriendsIsFollowing_t"
+    },
+    {
+      "callback_id": 346,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_rgSteamID", "fieldtype":"CSteamID [50]" },
+        { "fieldname":"m_nResultsReturned", "fieldtype":"int32" },
+        { "fieldname":"m_nTotalResultCount", "fieldtype":"int32" }
+      ],
+      "struct": "FriendsEnumerateFollowingList_t"
+    },
+    {
+      "callback_id": 347,
+      "fields": [
+        { "fieldname":"m_bSuccess", "fieldtype":"bool" },
+        { "fieldname":"m_bLocalSuccess", "fieldtype":"bool" },
+        { "fieldname":"m_result", "fieldtype":"EResult" }
+      ],
+      "struct": "SetPersonaNameResponse_t"
+    },
+    {
+      "callback_id": 348,
+      "fields": [],
+      "struct": "UnreadChatMessagesChanged_t"
+    },
+    {
+      "callback_id": 701,
+      "fields": [],
+      "struct": "IPCountry_t"
+    },
+    {
+      "callback_id": 702,
+      "fields": [
+        { "fieldname":"m_nMinutesBatteryLeft", "fieldtype":"uint8" }
+      ],
+      "struct": "LowBatteryPower_t"
+    },
+    {
+      "callback_id": 703,
+      "fields": [
+        { "fieldname":"m_hAsyncCall", "fieldtype":"SteamAPICall_t" },
+        { "fieldname":"m_iCallback", "fieldtype":"int" },
+        { "fieldname":"m_cubParam", "fieldtype":"uint32" }
+      ],
+      "struct": "SteamAPICallCompleted_t"
+    },
+    {
+      "callback_id": 704,
+      "fields": [],
+      "struct": "SteamShutdown_t"
+    },
+    {
+      "callback_id": 705,
+      "fields": [
+        { "fieldname":"m_eCheckFileSignature", "fieldtype":"ECheckFileSignature" }
+      ],
+      "struct": "CheckFileSignature_t"
+    },
+    {
+      "callback_id": 714,
+      "fields": [
+        { "fieldname":"m_bSubmitted", "fieldtype":"bool" },
+        { "fieldname":"m_unSubmittedText", "fieldtype":"uint32" }
+      ],
+      "struct": "GamepadTextInputDismissed_t"
+    },
+    {
+      "callback_id": 502,
+      "fields": [
+        { "fieldname":"m_nIP", "fieldtype":"uint32" },
+        { "fieldname":"m_nQueryPort", "fieldtype":"uint32" },
+        { "fieldname":"m_nConnPort", "fieldtype":"uint32" },
+        { "fieldname":"m_nAppID", "fieldtype":"uint32" },
+        { "fieldname":"m_nFlags", "fieldtype":"uint32" },
+        { "fieldname":"m_bAdd", "fieldtype":"bool" },
+        { "fieldname":"m_unAccountId", "fieldtype":"AccountID_t" }
+      ],
+      "struct": "FavoritesListChanged_t"
+    },
+    {
+      "callback_id": 503,
+      "fields": [
+        { "fieldname":"m_ulSteamIDUser", "fieldtype":"uint64" },
+        { "fieldname":"m_ulSteamIDLobby", "fieldtype":"uint64" },
+        { "fieldname":"m_ulGameID", "fieldtype":"uint64" }
+      ],
+      "struct": "LobbyInvite_t"
+    },
+    {
+      "callback_id": 504,
+      "fields": [
+        { "fieldname":"m_ulSteamIDLobby", "fieldtype":"uint64" },
+        { "fieldname":"m_rgfChatPermissions", "fieldtype":"uint32" },
+        { "fieldname":"m_bLocked", "fieldtype":"bool" },
+        { "fieldname":"m_EChatRoomEnterResponse", "fieldtype":"uint32" }
+      ],
+      "struct": "LobbyEnter_t"
+    },
+    {
+      "callback_id": 505,
+      "fields": [
+        { "fieldname":"m_ulSteamIDLobby", "fieldtype":"uint64" },
+        { "fieldname":"m_ulSteamIDMember", "fieldtype":"uint64" },
+        { "fieldname":"m_bSuccess", "fieldtype":"uint8" }
+      ],
+      "struct": "LobbyDataUpdate_t"
+    },
+    {
+      "callback_id": 506,
+      "fields": [
+        { "fieldname":"m_ulSteamIDLobby", "fieldtype":"uint64" },
+        { "fieldname":"m_ulSteamIDUserChanged", "fieldtype":"uint64" },
+        { "fieldname":"m_ulSteamIDMakingChange", "fieldtype":"uint64" },
+        { "fieldname":"m_rgfChatMemberStateChange", "fieldtype":"uint32" }
+      ],
+      "struct": "LobbyChatUpdate_t"
+    },
+    {
+      "callback_id": 507,
+      "fields": [
+        { "fieldname":"m_ulSteamIDLobby", "fieldtype":"uint64" },
+        { "fieldname":"m_ulSteamIDUser", "fieldtype":"uint64" },
+        { "fieldname":"m_eChatEntryType", "fieldtype":"uint8" },
+        { "fieldname":"m_iChatID", "fieldtype":"uint32" }
+      ],
+      "struct": "LobbyChatMsg_t"
+    },
+    {
+      "callback_id": 509,
+      "fields": [
+        { "fieldname":"m_ulSteamIDLobby", "fieldtype":"uint64" },
+        { "fieldname":"m_ulSteamIDGameServer", "fieldtype":"uint64" },
+        { "fieldname":"m_unIP", "fieldtype":"uint32" },
+        { "fieldname":"m_usPort", "fieldtype":"uint16" }
+      ],
+      "struct": "LobbyGameCreated_t"
+    },
+    {
+      "callback_id": 510,
+      "fields": [
+        { "fieldname":"m_nLobbiesMatching", "fieldtype":"uint32" }
+      ],
+      "struct": "LobbyMatchList_t"
+    },
+    {
+      "callback_id": 512,
+      "fields": [
+        { "fieldname":"m_ulSteamIDLobby", "fieldtype":"uint64" },
+        { "fieldname":"m_ulSteamIDAdmin", "fieldtype":"uint64" },
+        { "fieldname":"m_bKickedDueToDisconnect", "fieldtype":"uint8" }
+      ],
+      "struct": "LobbyKicked_t"
+    },
+    {
+      "callback_id": 513,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_ulSteamIDLobby", "fieldtype":"uint64" }
+      ],
+      "struct": "LobbyCreated_t"
+    },
+    {
+      "callback_id": 515,
+      "fields": [
+        { "fieldname":"m_bGameBootInviteExists", "fieldtype":"bool" },
+        { "fieldname":"m_steamIDLobby", "fieldtype":"CSteamID" }
+      ],
+      "struct": "PSNGameBootInviteResult_t"
+    },
+    {
+      "callback_id": 516,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" }
+      ],
+      "struct": "FavoritesListAccountsUpdated_t"
+    },
+    {
+      "callback_id": 5201,
+      "fields": [
+        { "fieldname":"m_ullSearchID", "fieldtype":"uint64" },
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_lobbyID", "fieldtype":"CSteamID" },
+        { "fieldname":"m_steamIDEndedSearch", "fieldtype":"CSteamID" },
+        { "fieldname":"m_nSecondsRemainingEstimate", "fieldtype":"int32" },
+        { "fieldname":"m_cPlayersSearching", "fieldtype":"int32" }
+      ],
+      "struct": "SearchForGameProgressCallback_t"
+    },
+    {
+      "callback_id": 5202,
+      "fields": [
+        { "fieldname":"m_ullSearchID", "fieldtype":"uint64" },
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nCountPlayersInGame", "fieldtype":"int32" },
+        { "fieldname":"m_nCountAcceptedGame", "fieldtype":"int32" },
+        { "fieldname":"m_steamIDHost", "fieldtype":"CSteamID" },
+        { "fieldname":"m_bFinalCallback", "fieldtype":"bool" }
+      ],
+      "struct": "SearchForGameResultCallback_t"
+    },
+    {
+      "callback_id": 5211,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_ullSearchID", "fieldtype":"uint64" }
+      ],
+      "struct": "RequestPlayersForGameProgressCallback_t"
+    },
+    {
+      "callback_id": 5212,
+      "enums": [
+        {
+          "enumname": "PlayerAcceptState_t",
+          "fqname": "RequestPlayersForGameResultCallback_t::PlayerAcceptState_t",
+          "values": [
+            { "name":"k_EStateUnknown", "value":"0" },
+            { "name":"k_EStatePlayerAccepted", "value":"1" },
+            { "name":"k_EStatePlayerDeclined", "value":"2" }
+          ]
+        }
+      ],
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_ullSearchID", "fieldtype":"uint64" },
+        { "fieldname":"m_SteamIDPlayerFound", "fieldtype":"CSteamID" },
+        { "fieldname":"m_SteamIDLobby", "fieldtype":"CSteamID" },
+        { "fieldname":"m_ePlayerAcceptState", "fieldtype":"RequestPlayersForGameResultCallback_t::PlayerAcceptState_t" },
+        { "fieldname":"m_nPlayerIndex", "fieldtype":"int32" },
+        { "fieldname":"m_nTotalPlayersFound", "fieldtype":"int32" },
+        { "fieldname":"m_nTotalPlayersAcceptedGame", "fieldtype":"int32" },
+        { "fieldname":"m_nSuggestedTeamIndex", "fieldtype":"int32" },
+        { "fieldname":"m_ullUniqueGameID", "fieldtype":"uint64" }
+      ],
+      "struct": "RequestPlayersForGameResultCallback_t"
+    },
+    {
+      "callback_id": 5213,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_ullSearchID", "fieldtype":"uint64" },
+        { "fieldname":"m_ullUniqueGameID", "fieldtype":"uint64" }
+      ],
+      "struct": "RequestPlayersForGameFinalResultCallback_t"
+    },
+    {
+      "callback_id": 5214,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"ullUniqueGameID", "fieldtype":"uint64" },
+        { "fieldname":"steamIDPlayer", "fieldtype":"CSteamID" }
+      ],
+      "struct": "SubmitPlayerResultResultCallback_t"
+    },
+    {
+      "callback_id": 5215,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"ullUniqueGameID", "fieldtype":"uint64" }
+      ],
+      "struct": "EndGameResultCallback_t"
+    },
+    {
+      "callback_id": 5301,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_ulBeaconID", "fieldtype":"PartyBeaconID_t" },
+        { "fieldname":"m_SteamIDBeaconOwner", "fieldtype":"CSteamID" },
+        { "fieldname":"m_rgchConnectString", "fieldtype":"char [256]" }
+      ],
+      "struct": "JoinPartyCallback_t"
+    },
+    {
+      "callback_id": 5302,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_ulBeaconID", "fieldtype":"PartyBeaconID_t" }
+      ],
+      "struct": "CreateBeaconCallback_t"
+    },
+    {
+      "callback_id": 5303,
+      "fields": [
+        { "fieldname":"m_ulBeaconID", "fieldtype":"PartyBeaconID_t" },
+        { "fieldname":"m_steamIDJoiner", "fieldtype":"CSteamID" }
+      ],
+      "struct": "ReservationNotificationCallback_t"
+    },
+    {
+      "callback_id": 5304,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" }
+      ],
+      "struct": "ChangeNumOpenSlotsCallback_t"
+    },
+    {
+      "callback_id": 5305,
+      "fields": [],
+      "struct": "AvailableBeaconLocationsUpdated_t"
+    },
+    {
+      "callback_id": 5306,
+      "fields": [],
+      "struct": "ActiveBeaconsUpdated_t"
+    },
+    {
+      "callback_id": 1301,
+      "fields": [
+        { "fieldname":"m_nAppID", "fieldtype":"AppId_t" },
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_unNumDownloads", "fieldtype":"int" }
+      ],
+      "struct": "RemoteStorageAppSyncedClient_t"
+    },
+    {
+      "callback_id": 1302,
+      "fields": [
+        { "fieldname":"m_nAppID", "fieldtype":"AppId_t" },
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_unNumUploads", "fieldtype":"int" }
+      ],
+      "struct": "RemoteStorageAppSyncedServer_t"
+    },
+    {
+      "callback_id": 1303,
+      "fields": [
+        { "fieldname":"m_rgchCurrentFile", "fieldtype":"char [260]" },
+        { "fieldname":"m_nAppID", "fieldtype":"AppId_t" },
+        { "fieldname":"m_uBytesTransferredThisChunk", "fieldtype":"uint32" },
+        { "fieldname":"m_dAppPercentComplete", "fieldtype":"double" },
+        { "fieldname":"m_bUploading", "fieldtype":"bool" }
+      ],
+      "struct": "RemoteStorageAppSyncProgress_t"
+    },
+    {
+      "callback_id": 1305,
+      "fields": [
+        { "fieldname":"m_nAppID", "fieldtype":"AppId_t" },
+        { "fieldname":"m_eResult", "fieldtype":"EResult" }
+      ],
+      "struct": "RemoteStorageAppSyncStatusCheck_t"
+    },
+    {
+      "callback_id": 1307,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_hFile", "fieldtype":"UGCHandle_t" },
+        { "fieldname":"m_rgchFilename", "fieldtype":"char [260]" }
+      ],
+      "struct": "RemoteStorageFileShareResult_t"
+    },
+    {
+      "callback_id": 1309,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" },
+        { "fieldname":"m_bUserNeedsToAcceptWorkshopLegalAgreement", "fieldtype":"bool" }
+      ],
+      "struct": "RemoteStoragePublishFileResult_t"
+    },
+    {
+      "callback_id": 1311,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" }
+      ],
+      "struct": "RemoteStorageDeletePublishedFileResult_t"
+    },
+    {
+      "callback_id": 1312,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nResultsReturned", "fieldtype":"int32" },
+        { "fieldname":"m_nTotalResultCount", "fieldtype":"int32" },
+        { "fieldname":"m_rgPublishedFileId", "fieldtype":"PublishedFileId_t [50]" }
+      ],
+      "struct": "RemoteStorageEnumerateUserPublishedFilesResult_t"
+    },
+    {
+      "callback_id": 1313,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" }
+      ],
+      "struct": "RemoteStorageSubscribePublishedFileResult_t"
+    },
+    {
+      "callback_id": 1314,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nResultsReturned", "fieldtype":"int32" },
+        { "fieldname":"m_nTotalResultCount", "fieldtype":"int32" },
+        { "fieldname":"m_rgPublishedFileId", "fieldtype":"PublishedFileId_t [50]" },
+        { "fieldname":"m_rgRTimeSubscribed", "fieldtype":"uint32 [50]" }
+      ],
+      "struct": "RemoteStorageEnumerateUserSubscribedFilesResult_t"
+    },
+    {
+      "callback_id": 1315,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" }
+      ],
+      "struct": "RemoteStorageUnsubscribePublishedFileResult_t"
+    },
+    {
+      "callback_id": 1316,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" },
+        { "fieldname":"m_bUserNeedsToAcceptWorkshopLegalAgreement", "fieldtype":"bool" }
+      ],
+      "struct": "RemoteStorageUpdatePublishedFileResult_t"
+    },
+    {
+      "callback_id": 1317,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_hFile", "fieldtype":"UGCHandle_t" },
+        { "fieldname":"m_nAppID", "fieldtype":"AppId_t" },
+        { "fieldname":"m_nSizeInBytes", "fieldtype":"int32" },
+        { "fieldname":"m_pchFileName", "fieldtype":"char [260]" },
+        { "fieldname":"m_ulSteamIDOwner", "fieldtype":"uint64" }
+      ],
+      "struct": "RemoteStorageDownloadUGCResult_t"
+    },
+    {
+      "callback_id": 1318,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" },
+        { "fieldname":"m_nCreatorAppID", "fieldtype":"AppId_t" },
+        { "fieldname":"m_nConsumerAppID", "fieldtype":"AppId_t" },
+        { "fieldname":"m_rgchTitle", "fieldtype":"char [129]" },
+        { "fieldname":"m_rgchDescription", "fieldtype":"char [8000]" },
+        { "fieldname":"m_hFile", "fieldtype":"UGCHandle_t" },
+        { "fieldname":"m_hPreviewFile", "fieldtype":"UGCHandle_t" },
+        { "fieldname":"m_ulSteamIDOwner", "fieldtype":"uint64" },
+        { "fieldname":"m_rtimeCreated", "fieldtype":"uint32" },
+        { "fieldname":"m_rtimeUpdated", "fieldtype":"uint32" },
+        { "fieldname":"m_eVisibility", "fieldtype":"ERemoteStoragePublishedFileVisibility" },
+        { "fieldname":"m_bBanned", "fieldtype":"bool" },
+        { "fieldname":"m_rgchTags", "fieldtype":"char [1025]" },
+        { "fieldname":"m_bTagsTruncated", "fieldtype":"bool" },
+        { "fieldname":"m_pchFileName", "fieldtype":"char [260]" },
+        { "fieldname":"m_nFileSize", "fieldtype":"int32" },
+        { "fieldname":"m_nPreviewFileSize", "fieldtype":"int32" },
+        { "fieldname":"m_rgchURL", "fieldtype":"char [256]" },
+        { "fieldname":"m_eFileType", "fieldtype":"EWorkshopFileType" },
+        { "fieldname":"m_bAcceptedForUse", "fieldtype":"bool" }
+      ],
+      "struct": "RemoteStorageGetPublishedFileDetailsResult_t"
+    },
+    {
+      "callback_id": 1319,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nResultsReturned", "fieldtype":"int32" },
+        { "fieldname":"m_nTotalResultCount", "fieldtype":"int32" },
+        { "fieldname":"m_rgPublishedFileId", "fieldtype":"PublishedFileId_t [50]" },
+        { "fieldname":"m_rgScore", "fieldtype":"float [50]" },
+        { "fieldname":"m_nAppId", "fieldtype":"AppId_t" },
+        { "fieldname":"m_unStartIndex", "fieldtype":"uint32" }
+      ],
+      "struct": "RemoteStorageEnumerateWorkshopFilesResult_t"
+    },
+    {
+      "callback_id": 1320,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_unPublishedFileId", "fieldtype":"PublishedFileId_t" },
+        { "fieldname":"m_nVotesFor", "fieldtype":"int32" },
+        { "fieldname":"m_nVotesAgainst", "fieldtype":"int32" },
+        { "fieldname":"m_nReports", "fieldtype":"int32" },
+        { "fieldname":"m_fScore", "fieldtype":"float" }
+      ],
+      "struct": "RemoteStorageGetPublishedItemVoteDetailsResult_t"
+    },
+    {
+      "callback_id": 1321,
+      "fields": [
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" },
+        { "fieldname":"m_nAppID", "fieldtype":"AppId_t" }
+      ],
+      "struct": "RemoteStoragePublishedFileSubscribed_t"
+    },
+    {
+      "callback_id": 1322,
+      "fields": [
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" },
+        { "fieldname":"m_nAppID", "fieldtype":"AppId_t" }
+      ],
+      "struct": "RemoteStoragePublishedFileUnsubscribed_t"
+    },
+    {
+      "callback_id": 1323,
+      "fields": [
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" },
+        { "fieldname":"m_nAppID", "fieldtype":"AppId_t" }
+      ],
+      "struct": "RemoteStoragePublishedFileDeleted_t"
+    },
+    {
+      "callback_id": 1324,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" }
+      ],
+      "struct": "RemoteStorageUpdateUserPublishedItemVoteResult_t"
+    },
+    {
+      "callback_id": 1325,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" },
+        { "fieldname":"m_eVote", "fieldtype":"EWorkshopVote" }
+      ],
+      "struct": "RemoteStorageUserVoteDetails_t"
+    },
+    {
+      "callback_id": 1326,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nResultsReturned", "fieldtype":"int32" },
+        { "fieldname":"m_nTotalResultCount", "fieldtype":"int32" },
+        { "fieldname":"m_rgPublishedFileId", "fieldtype":"PublishedFileId_t [50]" }
+      ],
+      "struct": "RemoteStorageEnumerateUserSharedWorkshopFilesResult_t"
+    },
+    {
+      "callback_id": 1327,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" },
+        { "fieldname":"m_eAction", "fieldtype":"EWorkshopFileAction" }
+      ],
+      "struct": "RemoteStorageSetUserPublishedFileActionResult_t"
+    },
+    {
+      "callback_id": 1328,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_eAction", "fieldtype":"EWorkshopFileAction" },
+        { "fieldname":"m_nResultsReturned", "fieldtype":"int32" },
+        { "fieldname":"m_nTotalResultCount", "fieldtype":"int32" },
+        { "fieldname":"m_rgPublishedFileId", "fieldtype":"PublishedFileId_t [50]" },
+        { "fieldname":"m_rgRTimeUpdated", "fieldtype":"uint32 [50]" }
+      ],
+      "struct": "RemoteStorageEnumeratePublishedFilesByUserActionResult_t"
+    },
+    {
+      "callback_id": 1329,
+      "fields": [
+        { "fieldname":"m_dPercentFile", "fieldtype":"double" },
+        { "fieldname":"m_bPreview", "fieldtype":"bool" }
+      ],
+      "struct": "RemoteStoragePublishFileProgress_t"
+    },
+    {
+      "callback_id": 1330,
+      "fields": [
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" },
+        { "fieldname":"m_nAppID", "fieldtype":"AppId_t" },
+        { "fieldname":"m_ulUnused", "fieldtype":"uint64" }
+      ],
+      "struct": "RemoteStoragePublishedFileUpdated_t"
+    },
+    {
+      "callback_id": 1331,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" }
+      ],
+      "struct": "RemoteStorageFileWriteAsyncComplete_t"
+    },
+    {
+      "callback_id": 1332,
+      "fields": [
+        { "fieldname":"m_hFileReadAsync", "fieldtype":"SteamAPICall_t" },
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nOffset", "fieldtype":"uint32" },
+        { "fieldname":"m_cubRead", "fieldtype":"uint32" }
+      ],
+      "struct": "RemoteStorageFileReadAsyncComplete_t"
+    },
+    {
+      "callback_id": 1101,
+      "fields": [
+        { "fieldname":"m_nGameID", "fieldtype":"uint64" },
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_steamIDUser", "fieldtype":"CSteamID" }
+      ],
+      "struct": "UserStatsReceived_t"
+    },
+    {
+      "callback_id": 1102,
+      "fields": [
+        { "fieldname":"m_nGameID", "fieldtype":"uint64" },
+        { "fieldname":"m_eResult", "fieldtype":"EResult" }
+      ],
+      "struct": "UserStatsStored_t"
+    },
+    {
+      "callback_id": 1103,
+      "fields": [
+        { "fieldname":"m_nGameID", "fieldtype":"uint64" },
+        { "fieldname":"m_bGroupAchievement", "fieldtype":"bool" },
+        { "fieldname":"m_rgchAchievementName", "fieldtype":"char [128]" },
+        { "fieldname":"m_nCurProgress", "fieldtype":"uint32" },
+        { "fieldname":"m_nMaxProgress", "fieldtype":"uint32" }
+      ],
+      "struct": "UserAchievementStored_t"
+    },
+    {
+      "callback_id": 1104,
+      "fields": [
+        { "fieldname":"m_hSteamLeaderboard", "fieldtype":"SteamLeaderboard_t" },
+        { "fieldname":"m_bLeaderboardFound", "fieldtype":"uint8" }
+      ],
+      "struct": "LeaderboardFindResult_t"
+    },
+    {
+      "callback_id": 1105,
+      "fields": [
+        { "fieldname":"m_hSteamLeaderboard", "fieldtype":"SteamLeaderboard_t" },
+        { "fieldname":"m_hSteamLeaderboardEntries", "fieldtype":"SteamLeaderboardEntries_t" },
+        { "fieldname":"m_cEntryCount", "fieldtype":"int" }
+      ],
+      "struct": "LeaderboardScoresDownloaded_t"
+    },
+    {
+      "callback_id": 1106,
+      "fields": [
+        { "fieldname":"m_bSuccess", "fieldtype":"uint8" },
+        { "fieldname":"m_hSteamLeaderboard", "fieldtype":"SteamLeaderboard_t" },
+        { "fieldname":"m_nScore", "fieldtype":"int32" },
+        { "fieldname":"m_bScoreChanged", "fieldtype":"uint8" },
+        { "fieldname":"m_nGlobalRankNew", "fieldtype":"int" },
+        { "fieldname":"m_nGlobalRankPrevious", "fieldtype":"int" }
+      ],
+      "struct": "LeaderboardScoreUploaded_t"
+    },
+    {
+      "callback_id": 1107,
+      "fields": [
+        { "fieldname":"m_bSuccess", "fieldtype":"uint8" },
+        { "fieldname":"m_cPlayers", "fieldtype":"int32" }
+      ],
+      "struct": "NumberOfCurrentPlayers_t"
+    },
+    {
+      "callback_id": 1108,
+      "fields": [
+        { "fieldname":"m_steamIDUser", "fieldtype":"CSteamID" }
+      ],
+      "struct": "UserStatsUnloaded_t"
+    },
+    {
+      "callback_id": 1109,
+      "fields": [
+        { "fieldname":"m_nGameID", "fieldtype":"CGameID" },
+        { "fieldname":"m_rgchAchievementName", "fieldtype":"char [128]" },
+        { "fieldname":"m_bAchieved", "fieldtype":"bool" },
+        { "fieldname":"m_nIconHandle", "fieldtype":"int" }
+      ],
+      "struct": "UserAchievementIconFetched_t"
+    },
+    {
+      "callback_id": 1110,
+      "fields": [
+        { "fieldname":"m_nGameID", "fieldtype":"uint64" },
+        { "fieldname":"m_eResult", "fieldtype":"EResult" }
+      ],
+      "struct": "GlobalAchievementPercentagesReady_t"
+    },
+    {
+      "callback_id": 1111,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_hSteamLeaderboard", "fieldtype":"SteamLeaderboard_t" }
+      ],
+      "struct": "LeaderboardUGCSet_t"
+    },
+    {
+      "callback_id": 1112,
+      "fields": [
+        { "fieldname":"m_nGameID", "fieldtype":"uint64" },
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_ulRequiredDiskSpace", "fieldtype":"uint64" }
+      ],
+      "struct": "PS3TrophiesInstalled_t"
+    },
+    {
+      "callback_id": 1112,
+      "fields": [
+        { "fieldname":"m_nGameID", "fieldtype":"uint64" },
+        { "fieldname":"m_eResult", "fieldtype":"EResult" }
+      ],
+      "struct": "GlobalStatsReceived_t"
+    },
+    {
+      "callback_id": 1005,
+      "fields": [
+        { "fieldname":"m_nAppID", "fieldtype":"AppId_t" }
+      ],
+      "struct": "DlcInstalled_t"
+    },
+    {
+      "callback_id": 1008,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"ERegisterActivationCodeResult" },
+        { "fieldname":"m_unPackageRegistered", "fieldtype":"uint32" }
+      ],
+      "struct": "RegisterActivationCodeResponse_t"
+    },
+    {
+      "callback_id": 1014,
+      "fields": [],
+      "struct": "NewUrlLaunchParameters_t"
+    },
+    {
+      "callback_id": 1021,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nAppID", "fieldtype":"uint32" },
+        { "fieldname":"m_cchKeyLength", "fieldtype":"uint32" },
+        { "fieldname":"m_rgchKey", "fieldtype":"char [240]" }
+      ],
+      "struct": "AppProofOfPurchaseKeyResponse_t"
+    },
+    {
+      "callback_id": 1023,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_ulFileSize", "fieldtype":"uint64" },
+        { "fieldname":"m_FileSHA", "fieldtype":"uint8 [20]" },
+        { "fieldname":"m_unFlags", "fieldtype":"uint32" }
+      ],
+      "struct": "FileDetailsResult_t"
+    },
+    {
+      "callback_id": 1202,
+      "fields": [
+        { "fieldname":"m_steamIDRemote", "fieldtype":"CSteamID" }
+      ],
+      "struct": "P2PSessionRequest_t"
+    },
+    {
+      "callback_id": 1203,
+      "fields": [
+        { "fieldname":"m_steamIDRemote", "fieldtype":"CSteamID" },
+        { "fieldname":"m_eP2PSessionError", "fieldtype":"uint8" }
+      ],
+      "struct": "P2PSessionConnectFail_t"
+    },
+    {
+      "callback_id": 1201,
+      "fields": [
+        { "fieldname":"m_hSocket", "fieldtype":"SNetSocket_t" },
+        { "fieldname":"m_hListenSocket", "fieldtype":"SNetListenSocket_t" },
+        { "fieldname":"m_steamIDRemote", "fieldtype":"CSteamID" },
+        { "fieldname":"m_eSNetSocketState", "fieldtype":"int" }
+      ],
+      "struct": "SocketStatusCallback_t"
+    },
+    {
+      "callback_id": 2301,
+      "fields": [
+        { "fieldname":"m_hLocal", "fieldtype":"ScreenshotHandle" },
+        { "fieldname":"m_eResult", "fieldtype":"EResult" }
+      ],
+      "struct": "ScreenshotReady_t"
+    },
+    {
+      "callback_id": 2302,
+      "fields": [],
+      "struct": "ScreenshotRequested_t"
+    },
+    {
+      "callback_id": 4001,
+      "fields": [],
+      "struct": "PlaybackStatusHasChanged_t"
+    },
+    {
+      "callback_id": 4002,
+      "fields": [
+        { "fieldname":"m_flNewVolume", "fieldtype":"float" }
+      ],
+      "struct": "VolumeHasChanged_t"
+    },
+    {
+      "callback_id": 4101,
+      "fields": [],
+      "struct": "MusicPlayerRemoteWillActivate_t"
+    },
+    {
+      "callback_id": 4102,
+      "fields": [],
+      "struct": "MusicPlayerRemoteWillDeactivate_t"
+    },
+    {
+      "callback_id": 4103,
+      "fields": [],
+      "struct": "MusicPlayerRemoteToFront_t"
+    },
+    {
+      "callback_id": 4104,
+      "fields": [],
+      "struct": "MusicPlayerWillQuit_t"
+    },
+    {
+      "callback_id": 4105,
+      "fields": [],
+      "struct": "MusicPlayerWantsPlay_t"
+    },
+    {
+      "callback_id": 4106,
+      "fields": [],
+      "struct": "MusicPlayerWantsPause_t"
+    },
+    {
+      "callback_id": 4107,
+      "fields": [],
+      "struct": "MusicPlayerWantsPlayPrevious_t"
+    },
+    {
+      "callback_id": 4108,
+      "fields": [],
+      "struct": "MusicPlayerWantsPlayNext_t"
+    },
+    {
+      "callback_id": 4109,
+      "fields": [
+        { "fieldname":"m_bShuffled", "fieldtype":"bool" }
+      ],
+      "struct": "MusicPlayerWantsShuffled_t"
+    },
+    {
+      "callback_id": 4110,
+      "fields": [
+        { "fieldname":"m_bLooped", "fieldtype":"bool" }
+      ],
+      "struct": "MusicPlayerWantsLooped_t"
+    },
+    {
+      "callback_id": 4011,
+      "fields": [
+        { "fieldname":"m_flNewVolume", "fieldtype":"float" }
+      ],
+      "struct": "MusicPlayerWantsVolume_t"
+    },
+    {
+      "callback_id": 4012,
+      "fields": [
+        { "fieldname":"nID", "fieldtype":"int" }
+      ],
+      "struct": "MusicPlayerSelectsQueueEntry_t"
+    },
+    {
+      "callback_id": 4013,
+      "fields": [
+        { "fieldname":"nID", "fieldtype":"int" }
+      ],
+      "struct": "MusicPlayerSelectsPlaylistEntry_t"
+    },
+    {
+      "callback_id": 4114,
+      "fields": [
+        { "fieldname":"m_nPlayingRepeatStatus", "fieldtype":"int" }
+      ],
+      "struct": "MusicPlayerWantsPlayingRepeatStatus_t"
+    },
+    {
+      "callback_id": 2101,
+      "fields": [
+        { "fieldname":"m_hRequest", "fieldtype":"HTTPRequestHandle" },
+        { "fieldname":"m_ulContextValue", "fieldtype":"uint64" },
+        { "fieldname":"m_bRequestSuccessful", "fieldtype":"bool" },
+        { "fieldname":"m_eStatusCode", "fieldtype":"EHTTPStatusCode" },
+        { "fieldname":"m_unBodySize", "fieldtype":"uint32" }
+      ],
+      "struct": "HTTPRequestCompleted_t"
+    },
+    {
+      "callback_id": 2102,
+      "fields": [
+        { "fieldname":"m_hRequest", "fieldtype":"HTTPRequestHandle" },
+        { "fieldname":"m_ulContextValue", "fieldtype":"uint64" }
+      ],
+      "struct": "HTTPRequestHeadersReceived_t"
+    },
+    {
+      "callback_id": 2103,
+      "fields": [
+        { "fieldname":"m_hRequest", "fieldtype":"HTTPRequestHandle" },
+        { "fieldname":"m_ulContextValue", "fieldtype":"uint64" },
+        { "fieldname":"m_cOffset", "fieldtype":"uint32" },
+        { "fieldname":"m_cBytesReceived", "fieldtype":"uint32" }
+      ],
+      "struct": "HTTPRequestDataReceived_t"
+    },
+    {
+      "callback_id": 3401,
+      "fields": [
+        { "fieldname":"m_handle", "fieldtype":"UGCQueryHandle_t" },
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_unNumResultsReturned", "fieldtype":"uint32" },
+        { "fieldname":"m_unTotalMatchingResults", "fieldtype":"uint32" },
+        { "fieldname":"m_bCachedData", "fieldtype":"bool" },
+        { "fieldname":"m_rgchNextCursor", "fieldtype":"char [256]" }
+      ],
+      "struct": "SteamUGCQueryCompleted_t"
+    },
+    {
+      "callback_id": 3402,
+      "fields": [
+        { "fieldname":"m_details", "fieldtype":"SteamUGCDetails_t" },
+        { "fieldname":"m_bCachedData", "fieldtype":"bool" }
+      ],
+      "struct": "SteamUGCRequestUGCDetailsResult_t"
+    },
+    {
+      "callback_id": 3403,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" },
+        { "fieldname":"m_bUserNeedsToAcceptWorkshopLegalAgreement", "fieldtype":"bool" }
+      ],
+      "struct": "CreateItemResult_t"
+    },
+    {
+      "callback_id": 3404,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_bUserNeedsToAcceptWorkshopLegalAgreement", "fieldtype":"bool" },
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" }
+      ],
+      "struct": "SubmitItemUpdateResult_t"
+    },
+    {
+      "callback_id": 3405,
+      "fields": [
+        { "fieldname":"m_unAppID", "fieldtype":"AppId_t" },
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" }
+      ],
+      "struct": "ItemInstalled_t"
+    },
+    {
+      "callback_id": 3406,
+      "fields": [
+        { "fieldname":"m_unAppID", "fieldtype":"AppId_t" },
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" },
+        { "fieldname":"m_eResult", "fieldtype":"EResult" }
+      ],
+      "struct": "DownloadItemResult_t"
+    },
+    {
+      "callback_id": 3407,
+      "fields": [
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" },
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_bWasAddRequest", "fieldtype":"bool" }
+      ],
+      "struct": "UserFavoriteItemsListChanged_t"
+    },
+    {
+      "callback_id": 3408,
+      "fields": [
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" },
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_bVoteUp", "fieldtype":"bool" }
+      ],
+      "struct": "SetUserItemVoteResult_t"
+    },
+    {
+      "callback_id": 3409,
+      "fields": [
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" },
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_bVotedUp", "fieldtype":"bool" },
+        { "fieldname":"m_bVotedDown", "fieldtype":"bool" },
+        { "fieldname":"m_bVoteSkipped", "fieldtype":"bool" }
+      ],
+      "struct": "GetUserItemVoteResult_t"
+    },
+    {
+      "callback_id": 3410,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" }
+      ],
+      "struct": "StartPlaytimeTrackingResult_t"
+    },
+    {
+      "callback_id": 3411,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" }
+      ],
+      "struct": "StopPlaytimeTrackingResult_t"
+    },
+    {
+      "callback_id": 3412,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" },
+        { "fieldname":"m_nChildPublishedFileId", "fieldtype":"PublishedFileId_t" }
+      ],
+      "struct": "AddUGCDependencyResult_t"
+    },
+    {
+      "callback_id": 3413,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" },
+        { "fieldname":"m_nChildPublishedFileId", "fieldtype":"PublishedFileId_t" }
+      ],
+      "struct": "RemoveUGCDependencyResult_t"
+    },
+    {
+      "callback_id": 3414,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" },
+        { "fieldname":"m_nAppID", "fieldtype":"AppId_t" }
+      ],
+      "struct": "AddAppDependencyResult_t"
+    },
+    {
+      "callback_id": 3415,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" },
+        { "fieldname":"m_nAppID", "fieldtype":"AppId_t" }
+      ],
+      "struct": "RemoveAppDependencyResult_t"
+    },
+    {
+      "callback_id": 3416,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" },
+        { "fieldname":"m_rgAppIDs", "fieldtype":"AppId_t [32]" },
+        { "fieldname":"m_nNumAppDependencies", "fieldtype":"uint32" },
+        { "fieldname":"m_nTotalNumAppDependencies", "fieldtype":"uint32" }
+      ],
+      "struct": "GetAppDependenciesResult_t"
+    },
+    {
+      "callback_id": 3417,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" }
+      ],
+      "struct": "DeleteItemResult_t"
+    },
+    {
+      "callback_id": 3901,
+      "fields": [
+        { "fieldname":"m_nAppID", "fieldtype":"AppId_t" }
+      ],
+      "struct": "SteamAppInstalled_t"
+    },
+    {
+      "callback_id": 3902,
+      "fields": [
+        { "fieldname":"m_nAppID", "fieldtype":"AppId_t" }
+      ],
+      "struct": "SteamAppUninstalled_t"
+    },
+    {
+      "callback_id": 4501,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" }
+      ],
+      "struct": "HTML_BrowserReady_t"
+    },
+    {
+      "callback_id": 4502,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" },
+        { "fieldname":"pBGRA", "fieldtype":"const char *" },
+        { "fieldname":"unWide", "fieldtype":"uint32" },
+        { "fieldname":"unTall", "fieldtype":"uint32" },
+        { "fieldname":"unUpdateX", "fieldtype":"uint32" },
+        { "fieldname":"unUpdateY", "fieldtype":"uint32" },
+        { "fieldname":"unUpdateWide", "fieldtype":"uint32" },
+        { "fieldname":"unUpdateTall", "fieldtype":"uint32" },
+        { "fieldname":"unScrollX", "fieldtype":"uint32" },
+        { "fieldname":"unScrollY", "fieldtype":"uint32" },
+        { "fieldname":"flPageScale", "fieldtype":"float" },
+        { "fieldname":"unPageSerial", "fieldtype":"uint32" }
+      ],
+      "struct": "HTML_NeedsPaint_t"
+    },
+    {
+      "callback_id": 4503,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" },
+        { "fieldname":"pchURL", "fieldtype":"const char *" },
+        { "fieldname":"pchTarget", "fieldtype":"const char *" },
+        { "fieldname":"pchPostData", "fieldtype":"const char *" },
+        { "fieldname":"bIsRedirect", "fieldtype":"bool" }
+      ],
+      "struct": "HTML_StartRequest_t"
+    },
+    {
+      "callback_id": 4504,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" }
+      ],
+      "struct": "HTML_CloseBrowser_t"
+    },
+    {
+      "callback_id": 4505,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" },
+        { "fieldname":"pchURL", "fieldtype":"const char *" },
+        { "fieldname":"pchPostData", "fieldtype":"const char *" },
+        { "fieldname":"bIsRedirect", "fieldtype":"bool" },
+        { "fieldname":"pchPageTitle", "fieldtype":"const char *" },
+        { "fieldname":"bNewNavigation", "fieldtype":"bool" }
+      ],
+      "struct": "HTML_URLChanged_t"
+    },
+    {
+      "callback_id": 4506,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" },
+        { "fieldname":"pchURL", "fieldtype":"const char *" },
+        { "fieldname":"pchPageTitle", "fieldtype":"const char *" }
+      ],
+      "struct": "HTML_FinishedRequest_t"
+    },
+    {
+      "callback_id": 4507,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" },
+        { "fieldname":"pchURL", "fieldtype":"const char *" }
+      ],
+      "struct": "HTML_OpenLinkInNewTab_t"
+    },
+    {
+      "callback_id": 4508,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" },
+        { "fieldname":"pchTitle", "fieldtype":"const char *" }
+      ],
+      "struct": "HTML_ChangedTitle_t"
+    },
+    {
+      "callback_id": 4509,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" },
+        { "fieldname":"unResults", "fieldtype":"uint32" },
+        { "fieldname":"unCurrentMatch", "fieldtype":"uint32" }
+      ],
+      "struct": "HTML_SearchResults_t"
+    },
+    {
+      "callback_id": 4510,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" },
+        { "fieldname":"bCanGoBack", "fieldtype":"bool" },
+        { "fieldname":"bCanGoForward", "fieldtype":"bool" }
+      ],
+      "struct": "HTML_CanGoBackAndForward_t"
+    },
+    {
+      "callback_id": 4511,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" },
+        { "fieldname":"unScrollMax", "fieldtype":"uint32" },
+        { "fieldname":"unScrollCurrent", "fieldtype":"uint32" },
+        { "fieldname":"flPageScale", "fieldtype":"float" },
+        { "fieldname":"bVisible", "fieldtype":"bool" },
+        { "fieldname":"unPageSize", "fieldtype":"uint32" }
+      ],
+      "struct": "HTML_HorizontalScroll_t"
+    },
+    {
+      "callback_id": 4512,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" },
+        { "fieldname":"unScrollMax", "fieldtype":"uint32" },
+        { "fieldname":"unScrollCurrent", "fieldtype":"uint32" },
+        { "fieldname":"flPageScale", "fieldtype":"float" },
+        { "fieldname":"bVisible", "fieldtype":"bool" },
+        { "fieldname":"unPageSize", "fieldtype":"uint32" }
+      ],
+      "struct": "HTML_VerticalScroll_t"
+    },
+    {
+      "callback_id": 4513,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" },
+        { "fieldname":"x", "fieldtype":"uint32" },
+        { "fieldname":"y", "fieldtype":"uint32" },
+        { "fieldname":"pchURL", "fieldtype":"const char *" },
+        { "fieldname":"bInput", "fieldtype":"bool" },
+        { "fieldname":"bLiveLink", "fieldtype":"bool" }
+      ],
+      "struct": "HTML_LinkAtPosition_t"
+    },
+    {
+      "callback_id": 4514,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" },
+        { "fieldname":"pchMessage", "fieldtype":"const char *" }
+      ],
+      "struct": "HTML_JSAlert_t"
+    },
+    {
+      "callback_id": 4515,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" },
+        { "fieldname":"pchMessage", "fieldtype":"const char *" }
+      ],
+      "struct": "HTML_JSConfirm_t"
+    },
+    {
+      "callback_id": 4516,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" },
+        { "fieldname":"pchTitle", "fieldtype":"const char *" },
+        { "fieldname":"pchInitialFile", "fieldtype":"const char *" }
+      ],
+      "struct": "HTML_FileOpenDialog_t"
+    },
+    {
+      "callback_id": 4521,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" },
+        { "fieldname":"pchURL", "fieldtype":"const char *" },
+        { "fieldname":"unX", "fieldtype":"uint32" },
+        { "fieldname":"unY", "fieldtype":"uint32" },
+        { "fieldname":"unWide", "fieldtype":"uint32" },
+        { "fieldname":"unTall", "fieldtype":"uint32" },
+        { "fieldname":"unNewWindow_BrowserHandle_IGNORE", "fieldtype":"HHTMLBrowser" }
+      ],
+      "struct": "HTML_NewWindow_t"
+    },
+    {
+      "callback_id": 4522,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" },
+        { "fieldname":"eMouseCursor", "fieldtype":"uint32" }
+      ],
+      "struct": "HTML_SetCursor_t"
+    },
+    {
+      "callback_id": 4523,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" },
+        { "fieldname":"pchMsg", "fieldtype":"const char *" }
+      ],
+      "struct": "HTML_StatusText_t"
+    },
+    {
+      "callback_id": 4524,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" },
+        { "fieldname":"pchMsg", "fieldtype":"const char *" }
+      ],
+      "struct": "HTML_ShowToolTip_t"
+    },
+    {
+      "callback_id": 4525,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" },
+        { "fieldname":"pchMsg", "fieldtype":"const char *" }
+      ],
+      "struct": "HTML_UpdateToolTip_t"
+    },
+    {
+      "callback_id": 4526,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" }
+      ],
+      "struct": "HTML_HideToolTip_t"
+    },
+    {
+      "callback_id": 4527,
+      "fields": [
+        { "fieldname":"unBrowserHandle", "fieldtype":"HHTMLBrowser" },
+        { "fieldname":"unOldBrowserHandle", "fieldtype":"HHTMLBrowser" }
+      ],
+      "struct": "HTML_BrowserRestarted_t"
+    },
+    {
+      "callback_id": 4700,
+      "fields": [
+        { "fieldname":"m_handle", "fieldtype":"SteamInventoryResult_t" },
+        { "fieldname":"m_result", "fieldtype":"EResult" }
+      ],
+      "struct": "SteamInventoryResultReady_t"
+    },
+    {
+      "callback_id": 4701,
+      "fields": [
+        { "fieldname":"m_handle", "fieldtype":"SteamInventoryResult_t" }
+      ],
+      "struct": "SteamInventoryFullUpdate_t"
+    },
+    {
+      "callback_id": 4702,
+      "fields": [],
+      "struct": "SteamInventoryDefinitionUpdate_t"
+    },
+    {
+      "callback_id": 4703,
+      "fields": [
+        { "fieldname":"m_result", "fieldtype":"EResult" },
+        { "fieldname":"m_steamID", "fieldtype":"CSteamID" },
+        { "fieldname":"m_numEligiblePromoItemDefs", "fieldtype":"int" },
+        { "fieldname":"m_bCachedData", "fieldtype":"bool" }
+      ],
+      "struct": "SteamInventoryEligiblePromoItemDefIDs_t"
+    },
+    {
+      "callback_id": 4704,
+      "fields": [
+        { "fieldname":"m_result", "fieldtype":"EResult" },
+        { "fieldname":"m_ulOrderID", "fieldtype":"uint64" },
+        { "fieldname":"m_ulTransID", "fieldtype":"uint64" }
+      ],
+      "struct": "SteamInventoryStartPurchaseResult_t"
+    },
+    {
+      "callback_id": 4705,
+      "fields": [
+        { "fieldname":"m_result", "fieldtype":"EResult" },
+        { "fieldname":"m_rgchCurrency", "fieldtype":"char [4]" }
+      ],
+      "struct": "SteamInventoryRequestPricesResult_t"
+    },
+    {
+      "callback_id": 4611,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_unVideoAppID", "fieldtype":"AppId_t" },
+        { "fieldname":"m_rgchURL", "fieldtype":"char [256]" }
+      ],
+      "struct": "GetVideoURLResult_t"
+    },
+    {
+      "callback_id": 4624,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_unVideoAppID", "fieldtype":"AppId_t" }
+      ],
+      "struct": "GetOPFSettingsResult_t"
+    },
+    {
+      "callback_id": 4604,
+      "fields": [
+        { "fieldname":"m_bIsRTMP", "fieldtype":"bool" }
+      ],
+      "struct": "BroadcastUploadStart_t"
+    },
+    {
+      "callback_id": 4605,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EBroadcastUploadResult" }
+      ],
+      "struct": "BroadcastUploadStop_t"
+    },
+    {
+      "callback_id": 5001,
+      "fields": [],
+      "struct": "SteamParentalSettingsChanged_t"
+    },
+    {
+      "callback_id": 5701,
+      "fields": [
+        { "fieldname":"m_unSessionID", "fieldtype":"RemotePlaySessionID_t" }
+      ],
+      "struct": "SteamRemotePlaySessionConnected_t"
+    },
+    {
+      "callback_id": 5702,
+      "fields": [
+        { "fieldname":"m_unSessionID", "fieldtype":"RemotePlaySessionID_t" }
+      ],
+      "struct": "SteamRemotePlaySessionDisconnected_t"
+    },
+    {
+      "callback_id": 1221,
+      "fields": [
+        { "fieldname":"m_hConn", "fieldtype":"HSteamNetConnection" },
+        { "fieldname":"m_info", "fieldtype":"SteamNetConnectionInfo_t" },
+        { "fieldname":"m_eOldState", "fieldtype":"ESteamNetworkingConnectionState" }
+      ],
+      "struct": "SteamNetConnectionStatusChangedCallback_t"
+    },
+    {
+      "callback_id": 1222,
+      "fields": [
+        { "fieldname":"m_eAvail", "fieldtype":"ESteamNetworkingAvailability" },
+        { "fieldname":"m_debugMsg", "fieldtype":"char [256]" }
+      ],
+      "struct": "SteamNetAuthenticationStatus_t"
+    },
+    {
+      "callback_id": 1281,
+      "fields": [
+        { "fieldname":"m_eAvail", "fieldtype":"ESteamNetworkingAvailability" },
+        { "fieldname":"m_bPingMeasurementInProgress", "fieldtype":"int" },
+        { "fieldname":"m_eAvailNetworkConfig", "fieldtype":"ESteamNetworkingAvailability" },
+        { "fieldname":"m_eAvailAnyRelay", "fieldtype":"ESteamNetworkingAvailability" },
+        { "fieldname":"m_debugMsg", "fieldtype":"char [256]" }
+      ],
+      "struct": "SteamRelayNetworkStatus_t"
+    },
+    {
+      "callback_id": 201,
+      "fields": [
+        { "fieldname":"m_SteamID", "fieldtype":"CSteamID" },
+        { "fieldname":"m_OwnerSteamID", "fieldtype":"CSteamID" }
+      ],
+      "struct": "GSClientApprove_t"
+    },
+    {
+      "callback_id": 202,
+      "fields": [
+        { "fieldname":"m_SteamID", "fieldtype":"CSteamID" },
+        { "fieldname":"m_eDenyReason", "fieldtype":"EDenyReason" },
+        { "fieldname":"m_rgchOptionalText", "fieldtype":"char [128]" }
+      ],
+      "struct": "GSClientDeny_t"
+    },
+    {
+      "callback_id": 203,
+      "fields": [
+        { "fieldname":"m_SteamID", "fieldtype":"CSteamID" },
+        { "fieldname":"m_eDenyReason", "fieldtype":"EDenyReason" }
+      ],
+      "struct": "GSClientKick_t"
+    },
+    {
+      "callback_id": 206,
+      "fields": [
+        { "fieldname":"m_SteamID", "fieldtype":"uint64" },
+        { "fieldname":"m_pchAchievement", "fieldtype":"char [128]" },
+        { "fieldname":"m_bUnlocked", "fieldtype":"bool" }
+      ],
+      "struct": "GSClientAchievementStatus_t"
+    },
+    {
+      "callback_id": 115,
+      "fields": [
+        { "fieldname":"m_bSecure", "fieldtype":"uint8" }
+      ],
+      "struct": "GSPolicyResponse_t"
+    },
+    {
+      "callback_id": 207,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_nRank", "fieldtype":"int32" },
+        { "fieldname":"m_unTotalConnects", "fieldtype":"uint32" },
+        { "fieldname":"m_unTotalMinutesPlayed", "fieldtype":"uint32" }
+      ],
+      "struct": "GSGameplayStats_t"
+    },
+    {
+      "callback_id": 208,
+      "fields": [
+        { "fieldname":"m_SteamIDUser", "fieldtype":"CSteamID" },
+        { "fieldname":"m_SteamIDGroup", "fieldtype":"CSteamID" },
+        { "fieldname":"m_bMember", "fieldtype":"bool" },
+        { "fieldname":"m_bOfficer", "fieldtype":"bool" }
+      ],
+      "struct": "GSClientGroupStatus_t"
+    },
+    {
+      "callback_id": 209,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_unReputationScore", "fieldtype":"uint32" },
+        { "fieldname":"m_bBanned", "fieldtype":"bool" },
+        { "fieldname":"m_unBannedIP", "fieldtype":"uint32" },
+        { "fieldname":"m_usBannedPort", "fieldtype":"uint16" },
+        { "fieldname":"m_ulBannedGameID", "fieldtype":"uint64" },
+        { "fieldname":"m_unBanExpires", "fieldtype":"uint32" }
+      ],
+      "struct": "GSReputation_t"
+    },
+    {
+      "callback_id": 210,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" }
+      ],
+      "struct": "AssociateWithClanResult_t"
+    },
+    {
+      "callback_id": 211,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_cPlayersThatDontLikeCandidate", "fieldtype":"int" },
+        { "fieldname":"m_cPlayersThatCandidateDoesntLike", "fieldtype":"int" },
+        { "fieldname":"m_cClanPlayersThatDontLikeCandidate", "fieldtype":"int" },
+        { "fieldname":"m_SteamIDCandidate", "fieldtype":"CSteamID" }
+      ],
+      "struct": "ComputeNewPlayerCompatibilityResult_t"
+    },
+    {
+      "callback_id": 1800,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_steamIDUser", "fieldtype":"CSteamID" }
+      ],
+      "struct": "GSStatsReceived_t"
+    },
+    {
+      "callback_id": 1801,
+      "fields": [
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_steamIDUser", "fieldtype":"CSteamID" }
+      ],
+      "struct": "GSStatsStored_t"
+    },
+    {
+      "callback_id": 1108,
+      "fields": [
+        { "fieldname":"m_steamIDUser", "fieldtype":"CSteamID" }
+      ],
+      "struct": "GSStatsUnloaded_t"
+    }
+  ],
+  "consts": [
+    { "constname":"k_cubSaltSize", "consttype":"int", "constval":"8" },
+    { "constname":"k_GIDNil", "consttype":"GID_t", "constval":"0xffffffffffffffffull" },
+    { "constname":"k_TxnIDNil", "consttype":"GID_t", "constval":"k_GIDNil" },
+    { "constname":"k_TxnIDUnknown", "consttype":"GID_t", "constval":"0" },
+    { "constname":"k_JobIDNil", "consttype":"JobID_t", "constval":"0xffffffffffffffffull" },
+    { "constname":"k_uPackageIdInvalid", "consttype":"PackageId_t", "constval":"0xFFFFFFFF" },
+    { "constname":"k_uBundleIdInvalid", "consttype":"BundleId_t", "constval":"0" },
+    { "constname":"k_uAppIdInvalid", "consttype":"AppId_t", "constval":"0x0" },
+    { "constname":"k_ulAssetClassIdInvalid", "consttype":"AssetClassId_t", "constval":"0x0" },
+    { "constname":"k_uPhysicalItemIdInvalid", "consttype":"PhysicalItemId_t", "constval":"0x0" },
+    { "constname":"k_uDepotIdInvalid", "consttype":"DepotId_t", "constval":"0x0" },
+    { "constname":"k_uCellIDInvalid", "consttype":"CellID_t", "constval":"0xFFFFFFFF" },
+    { "constname":"k_uAPICallInvalid", "consttype":"SteamAPICall_t", "constval":"0x0" },
+    { "constname":"k_uPartnerIdInvalid", "consttype":"PartnerId_t", "constval":"0" },
+    { "constname":"k_uManifestIdInvalid", "consttype":"ManifestId_t", "constval":"0" },
+    { "constname":"k_ulSiteIdInvalid", "consttype":"SiteId_t", "constval":"0" },
+    { "constname":"k_ulPartyBeaconIdInvalid", "consttype":"PartyBeaconID_t", "constval":"0" },
+    { "constname":"k_HAuthTicketInvalid", "consttype":"HAuthTicket", "constval":"0" },
+    { "constname":"k_unSteamAccountIDMask", "consttype":"unsigned int", "constval":"0xFFFFFFFF" },
+    { "constname":"k_unSteamAccountInstanceMask", "consttype":"unsigned int", "constval":"0x000FFFFF" },
+    { "constname":"k_unSteamUserDefaultInstance", "consttype":"unsigned int", "constval":"1" },
+    { "constname":"k_cchGameExtraInfoMax", "consttype":"int", "constval":"64" },
+    { "constname":"k_cchMaxFriendsGroupName", "consttype":"int", "constval":"64" },
+    { "constname":"k_cFriendsGroupLimit", "consttype":"int", "constval":"100" },
+    { "constname":"k_FriendsGroupID_Invalid", "consttype":"FriendsGroupID_t", "constval":"- 1" },
+    { "constname":"k_cEnumerateFollowersMax", "consttype":"int", "constval":"50" },
+    { "constname":"k_cubChatMetadataMax", "consttype":"uint32", "constval":"8192" },
+    { "constname":"k_cbMaxGameServerGameDir", "consttype":"int", "constval":"32" },
+    { "constname":"k_cbMaxGameServerMapName", "consttype":"int", "constval":"32" },
+    { "constname":"k_cbMaxGameServerGameDescription", "consttype":"int", "constval":"64" },
+    { "constname":"k_cbMaxGameServerName", "consttype":"int", "constval":"64" },
+    { "constname":"k_cbMaxGameServerTags", "consttype":"int", "constval":"128" },
+    { "constname":"k_cbMaxGameServerGameData", "consttype":"int", "constval":"2048" },
+    { "constname":"HSERVERQUERY_INVALID", "consttype":"int", "constval":"0xffffffff" },
+    { "constname":"k_unFavoriteFlagNone", "consttype":"uint32", "constval":"0x00" },
+    { "constname":"k_unFavoriteFlagFavorite", "consttype":"uint32", "constval":"0x01" },
+    { "constname":"k_unFavoriteFlagHistory", "consttype":"uint32", "constval":"0x02" },
+    { "constname":"k_unMaxCloudFileChunkSize", "consttype":"uint32", "constval":"100 * 1024 * 1024" },
+    { "constname":"k_PublishedFileIdInvalid", "consttype":"PublishedFileId_t", "constval":"0" },
+    { "constname":"k_UGCHandleInvalid", "consttype":"UGCHandle_t", "constval":"0xffffffffffffffffull" },
+    { "constname":"k_PublishedFileUpdateHandleInvalid", "consttype":"PublishedFileUpdateHandle_t", "constval":"0xffffffffffffffffull" },
+    { "constname":"k_UGCFileStreamHandleInvalid", "consttype":"UGCFileWriteStreamHandle_t", "constval":"0xffffffffffffffffull" },
+    { "constname":"k_cchPublishedDocumentTitleMax", "consttype":"uint32", "constval":"128 + 1" },
+    { "constname":"k_cchPublishedDocumentDescriptionMax", "consttype":"uint32", "constval":"8000" },
+    { "constname":"k_cchPublishedDocumentChangeDescriptionMax", "consttype":"uint32", "constval":"8000" },
+    { "constname":"k_unEnumeratePublishedFilesMaxResults", "consttype":"uint32", "constval":"50" },
+    { "constname":"k_cchTagListMax", "consttype":"uint32", "constval":"1024 + 1" },
+    { "constname":"k_cchFilenameMax", "consttype":"uint32", "constval":"260" },
+    { "constname":"k_cchPublishedFileURLMax", "consttype":"uint32", "constval":"256" },
+    { "constname":"k_cubAppProofOfPurchaseKeyMax", "consttype":"int", "constval":"240" },
+    { "constname":"k_nScreenshotMaxTaggedUsers", "consttype":"uint32", "constval":"32" },
+    { "constname":"k_nScreenshotMaxTaggedPublishedFiles", "consttype":"uint32", "constval":"32" },
+    { "constname":"k_cubUFSTagTypeMax", "consttype":"int", "constval":"255" },
+    { "constname":"k_cubUFSTagValueMax", "consttype":"int", "constval":"255" },
+    { "constname":"k_ScreenshotThumbWidth", "consttype":"int", "constval":"200" },
+    { "constname":"k_UGCQueryHandleInvalid", "consttype":"UGCQueryHandle_t", "constval":"0xffffffffffffffffull" },
+    { "constname":"k_UGCUpdateHandleInvalid", "consttype":"UGCUpdateHandle_t", "constval":"0xffffffffffffffffull" },
+    { "constname":"kNumUGCResultsPerPage", "consttype":"uint32", "constval":"50" },
+    { "constname":"k_cchDeveloperMetadataMax", "consttype":"uint32", "constval":"5000" },
+    { "constname":"INVALID_HTMLBROWSER", "consttype":"uint32", "constval":"0" },
+    { "constname":"k_SteamItemInstanceIDInvalid", "consttype":"SteamItemInstanceID_t", "constval":"( SteamItemInstanceID_t ) ~ 0" },
+    { "constname":"k_SteamInventoryResultInvalid", "consttype":"SteamInventoryResult_t", "constval":"- 1" },
+    { "constname":"k_SteamInventoryUpdateHandleInvalid", "consttype":"SteamInventoryUpdateHandle_t", "constval":"0xffffffffffffffffull" },
+    { "constname":"k_HSteamNetConnection_Invalid", "consttype":"HSteamNetConnection", "constval":"0" },
+    { "constname":"k_HSteamListenSocket_Invalid", "consttype":"HSteamListenSocket", "constval":"0" },
+    { "constname":"k_HSteamNetPollGroup_Invalid", "consttype":"HSteamNetPollGroup", "constval":"0" },
+    { "constname":"k_cchMaxSteamNetworkingErrMsg", "consttype":"int", "constval":"1024" },
+    { "constname":"k_cchSteamNetworkingMaxConnectionCloseReason", "consttype":"int", "constval":"128" },
+    { "constname":"k_cchSteamNetworkingMaxConnectionDescription", "consttype":"int", "constval":"128" },
+    { "constname":"k_cbMaxSteamNetworkingSocketsMessageSizeSend", "consttype":"int", "constval":"512 * 1024" },
+    { "constname":"k_nSteamNetworkingSend_Unreliable", "consttype":"int", "constval":"0" },
+    { "constname":"k_nSteamNetworkingSend_NoNagle", "consttype":"int", "constval":"1" },
+    { "constname":"k_nSteamNetworkingSend_UnreliableNoNagle", "consttype":"int", "constval":"k_nSteamNetworkingSend_Unreliable | k_nSteamNetworkingSend_NoNagle" },
+    { "constname":"k_nSteamNetworkingSend_NoDelay", "consttype":"int", "constval":"4" },
+    { "constname":"k_nSteamNetworkingSend_UnreliableNoDelay", "consttype":"int", "constval":"k_nSteamNetworkingSend_Unreliable | k_nSteamNetworkingSend_NoDelay | k_nSteamNetworkingSend_NoNagle" },
+    { "constname":"k_nSteamNetworkingSend_Reliable", "consttype":"int", "constval":"8" },
+    { "constname":"k_nSteamNetworkingSend_ReliableNoNagle", "consttype":"int", "constval":"k_nSteamNetworkingSend_Reliable | k_nSteamNetworkingSend_NoNagle" },
+    { "constname":"k_nSteamNetworkingSend_UseCurrentThread", "consttype":"int", "constval":"16" },
+    { "constname":"k_cchMaxSteamNetworkingPingLocationString", "consttype":"int", "constval":"1024" },
+    { "constname":"k_nSteamNetworkingPing_Failed", "consttype":"int", "constval":"- 1" },
+    { "constname":"k_nSteamNetworkingPing_Unknown", "consttype":"int", "constval":"- 2" },
+    { "constname":"k_SteamDatagramPOPID_dev", "consttype":"SteamNetworkingPOPID", "constval":"( ( uint32 ) 'd' << 16U ) | ( ( uint32 ) 'e' << 8U ) | ( uint32 ) 'v'" },
+    { "constname":"k_unServerFlagNone", "consttype":"uint32", "constval":"0x00" },
+    { "constname":"k_unServerFlagActive", "consttype":"uint32", "constval":"0x01" },
+    { "constname":"k_unServerFlagSecure", "consttype":"uint32", "constval":"0x02" },
+    { "constname":"k_unServerFlagDedicated", "consttype":"uint32", "constval":"0x04" },
+    { "constname":"k_unServerFlagLinux", "consttype":"uint32", "constval":"0x08" },
+    { "constname":"k_unServerFlagPassworded", "consttype":"uint32", "constval":"0x10" },
+    { "constname":"k_unServerFlagPrivate", "consttype":"uint32", "constval":"0x20" },
+    { "constname":"k_cbSteamDatagramMaxSerializedTicket", "consttype":"uint32", "constval":"512" },
+    { "constname":"k_cbMaxSteamDatagramGameCoordinatorServerLoginAppData", "consttype":"uint32", "constval":"2048" },
+    { "constname":"k_cbMaxSteamDatagramGameCoordinatorServerLoginSerialized", "consttype":"uint32", "constval":"4096" }
+  ],
+  "enums": [
+    {
+      "enumname": "ESteamIPType",
+      "values": [
+        { "name":"k_ESteamIPTypeIPv4", "value":"0" },
+        { "name":"k_ESteamIPTypeIPv6", "value":"1" }
+      ]
+    },
+    {
+      "enumname": "EUniverse",
+      "values": [
+        { "name":"k_EUniverseInvalid", "value":"0" },
+        { "name":"k_EUniversePublic", "value":"1" },
+        { "name":"k_EUniverseBeta", "value":"2" },
+        { "name":"k_EUniverseInternal", "value":"3" },
+        { "name":"k_EUniverseDev", "value":"4" },
+        { "name":"k_EUniverseMax", "value":"5" }
+      ]
+    },
+    {
+      "enumname": "EResult",
+      "values": [
+        { "name":"k_EResultNone", "value":"0" },
+        { "name":"k_EResultOK", "value":"1" },
+        { "name":"k_EResultFail", "value":"2" },
+        { "name":"k_EResultNoConnection", "value":"3" },
+        { "name":"k_EResultInvalidPassword", "value":"5" },
+        { "name":"k_EResultLoggedInElsewhere", "value":"6" },
+        { "name":"k_EResultInvalidProtocolVer", "value":"7" },
+        { "name":"k_EResultInvalidParam", "value":"8" },
+        { "name":"k_EResultFileNotFound", "value":"9" },
+        { "name":"k_EResultBusy", "value":"10" },
+        { "name":"k_EResultInvalidState", "value":"11" },
+        { "name":"k_EResultInvalidName", "value":"12" },
+        { "name":"k_EResultInvalidEmail", "value":"13" },
+        { "name":"k_EResultDuplicateName", "value":"14" },
+        { "name":"k_EResultAccessDenied", "value":"15" },
+        { "name":"k_EResultTimeout", "value":"16" },
+        { "name":"k_EResultBanned", "value":"17" },
+        { "name":"k_EResultAccountNotFound", "value":"18" },
+        { "name":"k_EResultInvalidSteamID", "value":"19" },
+        { "name":"k_EResultServiceUnavailable", "value":"20" },
+        { "name":"k_EResultNotLoggedOn", "value":"21" },
+        { "name":"k_EResultPending", "value":"22" },
+        { "name":"k_EResultEncryptionFailure", "value":"23" },
+        { "name":"k_EResultInsufficientPrivilege", "value":"24" },
+        { "name":"k_EResultLimitExceeded", "value":"25" },
+        { "name":"k_EResultRevoked", "value":"26" },
+        { "name":"k_EResultExpired", "value":"27" },
+        { "name":"k_EResultAlreadyRedeemed", "value":"28" },
+        { "name":"k_EResultDuplicateRequest", "value":"29" },
+        { "name":"k_EResultAlreadyOwned", "value":"30" },
+        { "name":"k_EResultIPNotFound", "value":"31" },
+        { "name":"k_EResultPersistFailed", "value":"32" },
+        { "name":"k_EResultLockingFailed", "value":"33" },
+        { "name":"k_EResultLogonSessionReplaced", "value":"34" },
+        { "name":"k_EResultConnectFailed", "value":"35" },
+        { "name":"k_EResultHandshakeFailed", "value":"36" },
+        { "name":"k_EResultIOFailure", "value":"37" },
+        { "name":"k_EResultRemoteDisconnect", "value":"38" },
+        { "name":"k_EResultShoppingCartNotFound", "value":"39" },
+        { "name":"k_EResultBlocked", "value":"40" },
+        { "name":"k_EResultIgnored", "value":"41" },
+        { "name":"k_EResultNoMatch", "value":"42" },
+        { "name":"k_EResultAccountDisabled", "value":"43" },
+        { "name":"k_EResultServiceReadOnly", "value":"44" },
+        { "name":"k_EResultAccountNotFeatured", "value":"45" },
+        { "name":"k_EResultAdministratorOK", "value":"46" },
+        { "name":"k_EResultContentVersion", "value":"47" },
+        { "name":"k_EResultTryAnotherCM", "value":"48" },
+        { "name":"k_EResultPasswordRequiredToKickSession", "value":"49" },
+        { "name":"k_EResultAlreadyLoggedInElsewhere", "value":"50" },
+        { "name":"k_EResultSuspended", "value":"51" },
+        { "name":"k_EResultCancelled", "value":"52" },
+        { "name":"k_EResultDataCorruption", "value":"53" },
+        { "name":"k_EResultDiskFull", "value":"54" },
+        { "name":"k_EResultRemoteCallFailed", "value":"55" },
+        { "name":"k_EResultPasswordUnset", "value":"56" },
+        { "name":"k_EResultExternalAccountUnlinked", "value":"57" },
+        { "name":"k_EResultPSNTicketInvalid", "value":"58" },
+        { "name":"k_EResultExternalAccountAlreadyLinked", "value":"59" },
+        { "name":"k_EResultRemoteFileConflict", "value":"60" },
+        { "name":"k_EResultIllegalPassword", "value":"61" },
+        { "name":"k_EResultSameAsPreviousValue", "value":"62" },
+        { "name":"k_EResultAccountLogonDenied", "value":"63" },
+        { "name":"k_EResultCannotUseOldPassword", "value":"64" },
+        { "name":"k_EResultInvalidLoginAuthCode", "value":"65" },
+        { "name":"k_EResultAccountLogonDeniedNoMail", "value":"66" },
+        { "name":"k_EResultHardwareNotCapableOfIPT", "value":"67" },
+        { "name":"k_EResultIPTInitError", "value":"68" },
+        { "name":"k_EResultParentalControlRestricted", "value":"69" },
+        { "name":"k_EResultFacebookQueryError", "value":"70" },
+        { "name":"k_EResultExpiredLoginAuthCode", "value":"71" },
+        { "name":"k_EResultIPLoginRestrictionFailed", "value":"72" },
+        { "name":"k_EResultAccountLockedDown", "value":"73" },
+        { "name":"k_EResultAccountLogonDeniedVerifiedEmailRequired", "value":"74" },
+        { "name":"k_EResultNoMatchingURL", "value":"75" },
+        { "name":"k_EResultBadResponse", "value":"76" },
+        { "name":"k_EResultRequirePasswordReEntry", "value":"77" },
+        { "name":"k_EResultValueOutOfRange", "value":"78" },
+        { "name":"k_EResultUnexpectedError", "value":"79" },
+        { "name":"k_EResultDisabled", "value":"80" },
+        { "name":"k_EResultInvalidCEGSubmission", "value":"81" },
+        { "name":"k_EResultRestrictedDevice", "value":"82" },
+        { "name":"k_EResultRegionLocked", "value":"83" },
+        { "name":"k_EResultRateLimitExceeded", "value":"84" },
+        { "name":"k_EResultAccountLoginDeniedNeedTwoFactor", "value":"85" },
+        { "name":"k_EResultItemDeleted", "value":"86" },
+        { "name":"k_EResultAccountLoginDeniedThrottle", "value":"87" },
+        { "name":"k_EResultTwoFactorCodeMismatch", "value":"88" },
+        { "name":"k_EResultTwoFactorActivationCodeMismatch", "value":"89" },
+        { "name":"k_EResultAccountAssociatedToMultiplePartners", "value":"90" },
+        { "name":"k_EResultNotModified", "value":"91" },
+        { "name":"k_EResultNoMobileDevice", "value":"92" },
+        { "name":"k_EResultTimeNotSynced", "value":"93" },
+        { "name":"k_EResultSmsCodeFailed", "value":"94" },
+        { "name":"k_EResultAccountLimitExceeded", "value":"95" },
+        { "name":"k_EResultAccountActivityLimitExceeded", "value":"96" },
+        { "name":"k_EResultPhoneActivityLimitExceeded", "value":"97" },
+        { "name":"k_EResultRefundToWallet", "value":"98" },
+        { "name":"k_EResultEmailSendFailure", "value":"99" },
+        { "name":"k_EResultNotSettled", "value":"100" },
+        { "name":"k_EResultNeedCaptcha", "value":"101" },
+        { "name":"k_EResultGSLTDenied", "value":"102" },
+        { "name":"k_EResultGSOwnerDenied", "value":"103" },
+        { "name":"k_EResultInvalidItemType", "value":"104" },
+        { "name":"k_EResultIPBanned", "value":"105" },
+        { "name":"k_EResultGSLTExpired", "value":"106" },
+        { "name":"k_EResultInsufficientFunds", "value":"107" },
+        { "name":"k_EResultTooManyPending", "value":"108" },
+        { "name":"k_EResultNoSiteLicensesFound", "value":"109" },
+        { "name":"k_EResultWGNetworkSendExceeded", "value":"110" },
+        { "name":"k_EResultAccountNotFriends", "value":"111" },
+        { "name":"k_EResultLimitedUserAccount", "value":"112" },
+        { "name":"k_EResultCantRemoveItem", "value":"113" },
+        { "name":"k_EResultAccountDeleted", "value":"114" },
+        { "name":"k_EResultExistingUserCancelledLicense", "value":"115" }
+      ]
+    },
+    {
+      "enumname": "EVoiceResult",
+      "values": [
+        { "name":"k_EVoiceResultOK", "value":"0" },
+        { "name":"k_EVoiceResultNotInitialized", "value":"1" },
+        { "name":"k_EVoiceResultNotRecording", "value":"2" },
+        { "name":"k_EVoiceResultNoData", "value":"3" },
+        { "name":"k_EVoiceResultBufferTooSmall", "value":"4" },
+        { "name":"k_EVoiceResultDataCorrupted", "value":"5" },
+        { "name":"k_EVoiceResultRestricted", "value":"6" },
+        { "name":"k_EVoiceResultUnsupportedCodec", "value":"7" },
+        { "name":"k_EVoiceResultReceiverOutOfDate", "value":"8" },
+        { "name":"k_EVoiceResultReceiverDidNotAnswer", "value":"9" }
+      ]
+    },
+    {
+      "enumname": "EDenyReason",
+      "values": [
+        { "name":"k_EDenyInvalid", "value":"0" },
+        { "name":"k_EDenyInvalidVersion", "value":"1" },
+        { "name":"k_EDenyGeneric", "value":"2" },
+        { "name":"k_EDenyNotLoggedOn", "value":"3" },
+        { "name":"k_EDenyNoLicense", "value":"4" },
+        { "name":"k_EDenyCheater", "value":"5" },
+        { "name":"k_EDenyLoggedInElseWhere", "value":"6" },
+        { "name":"k_EDenyUnknownText", "value":"7" },
+        { "name":"k_EDenyIncompatibleAnticheat", "value":"8" },
+        { "name":"k_EDenyMemoryCorruption", "value":"9" },
+        { "name":"k_EDenyIncompatibleSoftware", "value":"10" },
+        { "name":"k_EDenySteamConnectionLost", "value":"11" },
+        { "name":"k_EDenySteamConnectionError", "value":"12" },
+        { "name":"k_EDenySteamResponseTimedOut", "value":"13" },
+        { "name":"k_EDenySteamValidationStalled", "value":"14" },
+        { "name":"k_EDenySteamOwnerLeftGuestUser", "value":"15" }
+      ]
+    },
+    {
+      "enumname": "EBeginAuthSessionResult",
+      "values": [
+        { "name":"k_EBeginAuthSessionResultOK", "value":"0" },
+        { "name":"k_EBeginAuthSessionResultInvalidTicket", "value":"1" },
+        { "name":"k_EBeginAuthSessionResultDuplicateRequest", "value":"2" },
+        { "name":"k_EBeginAuthSessionResultInvalidVersion", "value":"3" },
+        { "name":"k_EBeginAuthSessionResultGameMismatch", "value":"4" },
+        { "name":"k_EBeginAuthSessionResultExpiredTicket", "value":"5" }
+      ]
+    },
+    {
+      "enumname": "EAuthSessionResponse",
+      "values": [
+        { "name":"k_EAuthSessionResponseOK", "value":"0" },
+        { "name":"k_EAuthSessionResponseUserNotConnectedToSteam", "value":"1" },
+        { "name":"k_EAuthSessionResponseNoLicenseOrExpired", "value":"2" },
+        { "name":"k_EAuthSessionResponseVACBanned", "value":"3" },
+        { "name":"k_EAuthSessionResponseLoggedInElseWhere", "value":"4" },
+        { "name":"k_EAuthSessionResponseVACCheckTimedOut", "value":"5" },
+        { "name":"k_EAuthSessionResponseAuthTicketCanceled", "value":"6" },
+        { "name":"k_EAuthSessionResponseAuthTicketInvalidAlreadyUsed", "value":"7" },
+        { "name":"k_EAuthSessionResponseAuthTicketInvalid", "value":"8" },
+        { "name":"k_EAuthSessionResponsePublisherIssuedBan", "value":"9" }
+      ]
+    },
+    {
+      "enumname": "EUserHasLicenseForAppResult",
+      "values": [
+        { "name":"k_EUserHasLicenseResultHasLicense", "value":"0" },
+        { "name":"k_EUserHasLicenseResultDoesNotHaveLicense", "value":"1" },
+        { "name":"k_EUserHasLicenseResultNoAuth", "value":"2" }
+      ]
+    },
+    {
+      "enumname": "EAccountType",
+      "values": [
+        { "name":"k_EAccountTypeInvalid", "value":"0" },
+        { "name":"k_EAccountTypeIndividual", "value":"1" },
+        { "name":"k_EAccountTypeMultiseat", "value":"2" },
+        { "name":"k_EAccountTypeGameServer", "value":"3" },
+        { "name":"k_EAccountTypeAnonGameServer", "value":"4" },
+        { "name":"k_EAccountTypePending", "value":"5" },
+        { "name":"k_EAccountTypeContentServer", "value":"6" },
+        { "name":"k_EAccountTypeClan", "value":"7" },
+        { "name":"k_EAccountTypeChat", "value":"8" },
+        { "name":"k_EAccountTypeConsoleUser", "value":"9" },
+        { "name":"k_EAccountTypeAnonUser", "value":"10" },
+        { "name":"k_EAccountTypeMax", "value":"11" }
+      ]
+    },
+    {
+      "enumname": "EAppReleaseState",
+      "values": [
+        { "name":"k_EAppReleaseState_Unknown", "value":"0" },
+        { "name":"k_EAppReleaseState_Unavailable", "value":"1" },
+        { "name":"k_EAppReleaseState_Prerelease", "value":"2" },
+        { "name":"k_EAppReleaseState_PreloadOnly", "value":"3" },
+        { "name":"k_EAppReleaseState_Released", "value":"4" }
+      ]
+    },
+    {
+      "enumname": "EAppOwnershipFlags",
+      "values": [
+        { "name":"k_EAppOwnershipFlags_None", "value":"0" },
+        { "name":"k_EAppOwnershipFlags_OwnsLicense", "value":"1" },
+        { "name":"k_EAppOwnershipFlags_FreeLicense", "value":"2" },
+        { "name":"k_EAppOwnershipFlags_RegionRestricted", "value":"4" },
+        { "name":"k_EAppOwnershipFlags_LowViolence", "value":"8" },
+        { "name":"k_EAppOwnershipFlags_InvalidPlatform", "value":"16" },
+        { "name":"k_EAppOwnershipFlags_SharedLicense", "value":"32" },
+        { "name":"k_EAppOwnershipFlags_FreeWeekend", "value":"64" },
+        { "name":"k_EAppOwnershipFlags_RetailLicense", "value":"128" },
+        { "name":"k_EAppOwnershipFlags_LicenseLocked", "value":"256" },
+        { "name":"k_EAppOwnershipFlags_LicensePending", "value":"512" },
+        { "name":"k_EAppOwnershipFlags_LicenseExpired", "value":"1024" },
+        { "name":"k_EAppOwnershipFlags_LicensePermanent", "value":"2048" },
+        { "name":"k_EAppOwnershipFlags_LicenseRecurring", "value":"4096" },
+        { "name":"k_EAppOwnershipFlags_LicenseCanceled", "value":"8192" },
+        { "name":"k_EAppOwnershipFlags_AutoGrant", "value":"16384" },
+        { "name":"k_EAppOwnershipFlags_PendingGift", "value":"32768" },
+        { "name":"k_EAppOwnershipFlags_RentalNotActivated", "value":"65536" },
+        { "name":"k_EAppOwnershipFlags_Rental", "value":"131072" },
+        { "name":"k_EAppOwnershipFlags_SiteLicense", "value":"262144" },
+        { "name":"k_EAppOwnershipFlags_LegacyFreeSub", "value":"524288" },
+        { "name":"k_EAppOwnershipFlags_InvalidOSType", "value":"1048576" }
+      ]
+    },
+    {
+      "enumname": "EAppType",
+      "values": [
+        { "name":"k_EAppType_Invalid", "value":"0" },
+        { "name":"k_EAppType_Game", "value":"1" },
+        { "name":"k_EAppType_Application", "value":"2" },
+        { "name":"k_EAppType_Tool", "value":"4" },
+        { "name":"k_EAppType_Demo", "value":"8" },
+        { "name":"k_EAppType_Media_DEPRECATED", "value":"16" },
+        { "name":"k_EAppType_DLC", "value":"32" },
+        { "name":"k_EAppType_Guide", "value":"64" },
+        { "name":"k_EAppType_Driver", "value":"128" },
+        { "name":"k_EAppType_Config", "value":"256" },
+        { "name":"k_EAppType_Hardware", "value":"512" },
+        { "name":"k_EAppType_Franchise", "value":"1024" },
+        { "name":"k_EAppType_Video", "value":"2048" },
+        { "name":"k_EAppType_Plugin", "value":"4096" },
+        { "name":"k_EAppType_MusicAlbum", "value":"8192" },
+        { "name":"k_EAppType_Series", "value":"16384" },
+        { "name":"k_EAppType_Comic_UNUSED", "value":"32768" },
+        { "name":"k_EAppType_Beta", "value":"65536" },
+        { "name":"k_EAppType_Shortcut", "value":"1073741824" },
+        { "name":"k_EAppType_DepotOnly", "value":"-2147483648" }
+      ]
+    },
+    {
+      "enumname": "ESteamUserStatType",
+      "values": [
+        { "name":"k_ESteamUserStatTypeINVALID", "value":"0" },
+        { "name":"k_ESteamUserStatTypeINT", "value":"1" },
+        { "name":"k_ESteamUserStatTypeFLOAT", "value":"2" },
+        { "name":"k_ESteamUserStatTypeAVGRATE", "value":"3" },
+        { "name":"k_ESteamUserStatTypeACHIEVEMENTS", "value":"4" },
+        { "name":"k_ESteamUserStatTypeGROUPACHIEVEMENTS", "value":"5" },
+        { "name":"k_ESteamUserStatTypeMAX", "value":"6" }
+      ]
+    },
+    {
+      "enumname": "EChatEntryType",
+      "values": [
+        { "name":"k_EChatEntryTypeInvalid", "value":"0" },
+        { "name":"k_EChatEntryTypeChatMsg", "value":"1" },
+        { "name":"k_EChatEntryTypeTyping", "value":"2" },
+        { "name":"k_EChatEntryTypeInviteGame", "value":"3" },
+        { "name":"k_EChatEntryTypeEmote", "value":"4" },
+        { "name":"k_EChatEntryTypeLeftConversation", "value":"6" },
+        { "name":"k_EChatEntryTypeEntered", "value":"7" },
+        { "name":"k_EChatEntryTypeWasKicked", "value":"8" },
+        { "name":"k_EChatEntryTypeWasBanned", "value":"9" },
+        { "name":"k_EChatEntryTypeDisconnected", "value":"10" },
+        { "name":"k_EChatEntryTypeHistoricalChat", "value":"11" },
+        { "name":"k_EChatEntryTypeLinkBlocked", "value":"14" }
+      ]
+    },
+    {
+      "enumname": "EChatRoomEnterResponse",
+      "values": [
+        { "name":"k_EChatRoomEnterResponseSuccess", "value":"1" },
+        { "name":"k_EChatRoomEnterResponseDoesntExist", "value":"2" },
+        { "name":"k_EChatRoomEnterResponseNotAllowed", "value":"3" },
+        { "name":"k_EChatRoomEnterResponseFull", "value":"4" },
+        { "name":"k_EChatRoomEnterResponseError", "value":"5" },
+        { "name":"k_EChatRoomEnterResponseBanned", "value":"6" },
+        { "name":"k_EChatRoomEnterResponseLimited", "value":"7" },
+        { "name":"k_EChatRoomEnterResponseClanDisabled", "value":"8" },
+        { "name":"k_EChatRoomEnterResponseCommunityBan", "value":"9" },
+        { "name":"k_EChatRoomEnterResponseMemberBlockedYou", "value":"10" },
+        { "name":"k_EChatRoomEnterResponseYouBlockedMember", "value":"11" },
+        { "name":"k_EChatRoomEnterResponseRatelimitExceeded", "value":"15" }
+      ]
+    },
+    {
+      "enumname": "EChatSteamIDInstanceFlags",
+      "values": [
+        { "name":"k_EChatAccountInstanceMask", "value":"4095" },
+        { "name":"k_EChatInstanceFlagClan", "value":"524288" },
+        { "name":"k_EChatInstanceFlagLobby", "value":"262144" },
+        { "name":"k_EChatInstanceFlagMMSLobby", "value":"131072" }
+      ]
+    },
+    {
+      "enumname": "EMarketingMessageFlags",
+      "values": [
+        { "name":"k_EMarketingMessageFlagsNone", "value":"0" },
+        { "name":"k_EMarketingMessageFlagsHighPriority", "value":"1" },
+        { "name":"k_EMarketingMessageFlagsPlatformWindows", "value":"2" },
+        { "name":"k_EMarketingMessageFlagsPlatformMac", "value":"4" },
+        { "name":"k_EMarketingMessageFlagsPlatformLinux", "value":"8" },
+        { "name":"k_EMarketingMessageFlagsPlatformRestrictions", "value":"14" }
+      ]
+    },
+    {
+      "enumname": "ENotificationPosition",
+      "values": [
+        { "name":"k_EPositionTopLeft", "value":"0" },
+        { "name":"k_EPositionTopRight", "value":"1" },
+        { "name":"k_EPositionBottomLeft", "value":"2" },
+        { "name":"k_EPositionBottomRight", "value":"3" }
+      ]
+    },
+    {
+      "enumname": "EBroadcastUploadResult",
+      "values": [
+        { "name":"k_EBroadcastUploadResultNone", "value":"0" },
+        { "name":"k_EBroadcastUploadResultOK", "value":"1" },
+        { "name":"k_EBroadcastUploadResultInitFailed", "value":"2" },
+        { "name":"k_EBroadcastUploadResultFrameFailed", "value":"3" },
+        { "name":"k_EBroadcastUploadResultTimeout", "value":"4" },
+        { "name":"k_EBroadcastUploadResultBandwidthExceeded", "value":"5" },
+        { "name":"k_EBroadcastUploadResultLowFPS", "value":"6" },
+        { "name":"k_EBroadcastUploadResultMissingKeyFrames", "value":"7" },
+        { "name":"k_EBroadcastUploadResultNoConnection", "value":"8" },
+        { "name":"k_EBroadcastUploadResultRelayFailed", "value":"9" },
+        { "name":"k_EBroadcastUploadResultSettingsChanged", "value":"10" },
+        { "name":"k_EBroadcastUploadResultMissingAudio", "value":"11" },
+        { "name":"k_EBroadcastUploadResultTooFarBehind", "value":"12" },
+        { "name":"k_EBroadcastUploadResultTranscodeBehind", "value":"13" },
+        { "name":"k_EBroadcastUploadResultNotAllowedToPlay", "value":"14" },
+        { "name":"k_EBroadcastUploadResultBusy", "value":"15" },
+        { "name":"k_EBroadcastUploadResultBanned", "value":"16" },
+        { "name":"k_EBroadcastUploadResultAlreadyActive", "value":"17" },
+        { "name":"k_EBroadcastUploadResultForcedOff", "value":"18" },
+        { "name":"k_EBroadcastUploadResultAudioBehind", "value":"19" },
+        { "name":"k_EBroadcastUploadResultShutdown", "value":"20" },
+        { "name":"k_EBroadcastUploadResultDisconnect", "value":"21" },
+        { "name":"k_EBroadcastUploadResultVideoInitFailed", "value":"22" },
+        { "name":"k_EBroadcastUploadResultAudioInitFailed", "value":"23" }
+      ]
+    },
+    {
+      "enumname": "ELaunchOptionType",
+      "values": [
+        { "name":"k_ELaunchOptionType_None", "value":"0" },
+        { "name":"k_ELaunchOptionType_Default", "value":"1" },
+        { "name":"k_ELaunchOptionType_SafeMode", "value":"2" },
+        { "name":"k_ELaunchOptionType_Multiplayer", "value":"3" },
+        { "name":"k_ELaunchOptionType_Config", "value":"4" },
+        { "name":"k_ELaunchOptionType_OpenVR", "value":"5" },
+        { "name":"k_ELaunchOptionType_Server", "value":"6" },
+        { "name":"k_ELaunchOptionType_Editor", "value":"7" },
+        { "name":"k_ELaunchOptionType_Manual", "value":"8" },
+        { "name":"k_ELaunchOptionType_Benchmark", "value":"9" },
+        { "name":"k_ELaunchOptionType_Option1", "value":"10" },
+        { "name":"k_ELaunchOptionType_Option2", "value":"11" },
+        { "name":"k_ELaunchOptionType_Option3", "value":"12" },
+        { "name":"k_ELaunchOptionType_OculusVR", "value":"13" },
+        { "name":"k_ELaunchOptionType_OpenVROverlay", "value":"14" },
+        { "name":"k_ELaunchOptionType_OSVR", "value":"15" },
+        { "name":"k_ELaunchOptionType_Dialog", "value":"1000" }
+      ]
+    },
+    {
+      "enumname": "EVRHMDType",
+      "values": [
+        { "name":"k_eEVRHMDType_None", "value":"-1" },
+        { "name":"k_eEVRHMDType_Unknown", "value":"0" },
+        { "name":"k_eEVRHMDType_HTC_Dev", "value":"1" },
+        { "name":"k_eEVRHMDType_HTC_VivePre", "value":"2" },
+        { "name":"k_eEVRHMDType_HTC_Vive", "value":"3" },
+        { "name":"k_eEVRHMDType_HTC_VivePro", "value":"4" },
+        { "name":"k_eEVRHMDType_HTC_ViveCosmos", "value":"5" },
+        { "name":"k_eEVRHMDType_HTC_Unknown", "value":"20" },
+        { "name":"k_eEVRHMDType_Oculus_DK1", "value":"21" },
+        { "name":"k_eEVRHMDType_Oculus_DK2", "value":"22" },
+        { "name":"k_eEVRHMDType_Oculus_Rift", "value":"23" },
+        { "name":"k_eEVRHMDType_Oculus_RiftS", "value":"24" },
+        { "name":"k_eEVRHMDType_Oculus_Quest", "value":"25" },
+        { "name":"k_eEVRHMDType_Oculus_Unknown", "value":"40" },
+        { "name":"k_eEVRHMDType_Acer_Unknown", "value":"50" },
+        { "name":"k_eEVRHMDType_Acer_WindowsMR", "value":"51" },
+        { "name":"k_eEVRHMDType_Dell_Unknown", "value":"60" },
+        { "name":"k_eEVRHMDType_Dell_Visor", "value":"61" },
+        { "name":"k_eEVRHMDType_Lenovo_Unknown", "value":"70" },
+        { "name":"k_eEVRHMDType_Lenovo_Explorer", "value":"71" },
+        { "name":"k_eEVRHMDType_HP_Unknown", "value":"80" },
+        { "name":"k_eEVRHMDType_HP_WindowsMR", "value":"81" },
+        { "name":"k_eEVRHMDType_HP_Reverb", "value":"82" },
+        { "name":"k_eEVRHMDType_Samsung_Unknown", "value":"90" },
+        { "name":"k_eEVRHMDType_Samsung_Odyssey", "value":"91" },
+        { "name":"k_eEVRHMDType_Unannounced_Unknown", "value":"100" },
+        { "name":"k_eEVRHMDType_Unannounced_WindowsMR", "value":"101" },
+        { "name":"k_eEVRHMDType_vridge", "value":"110" },
+        { "name":"k_eEVRHMDType_Huawei_Unknown", "value":"120" },
+        { "name":"k_eEVRHMDType_Huawei_VR2", "value":"121" },
+        { "name":"k_eEVRHMDType_Huawei_EndOfRange", "value":"129" },
+        { "name":"k_eEVRHmdType_Valve_Unknown", "value":"130" },
+        { "name":"k_eEVRHmdType_Valve_Index", "value":"131" }
+      ]
+    },
+    {
+      "enumname": "EMarketNotAllowedReasonFlags",
+      "values": [
+        { "name":"k_EMarketNotAllowedReason_None", "value":"0" },
+        { "name":"k_EMarketNotAllowedReason_TemporaryFailure", "value":"1" },
+        { "name":"k_EMarketNotAllowedReason_AccountDisabled", "value":"2" },
+        { "name":"k_EMarketNotAllowedReason_AccountLockedDown", "value":"4" },
+        { "name":"k_EMarketNotAllowedReason_AccountLimited", "value":"8" },
+        { "name":"k_EMarketNotAllowedReason_TradeBanned", "value":"16" },
+        { "name":"k_EMarketNotAllowedReason_AccountNotTrusted", "value":"32" },
+        { "name":"k_EMarketNotAllowedReason_SteamGuardNotEnabled", "value":"64" },
+        { "name":"k_EMarketNotAllowedReason_SteamGuardOnlyRecentlyEnabled", "value":"128" },
+        { "name":"k_EMarketNotAllowedReason_RecentPasswordReset", "value":"256" },
+        { "name":"k_EMarketNotAllowedReason_NewPaymentMethod", "value":"512" },
+        { "name":"k_EMarketNotAllowedReason_InvalidCookie", "value":"1024" },
+        { "name":"k_EMarketNotAllowedReason_UsingNewDevice", "value":"2048" },
+        { "name":"k_EMarketNotAllowedReason_RecentSelfRefund", "value":"4096" },
+        { "name":"k_EMarketNotAllowedReason_NewPaymentMethodCannotBeVerified", "value":"8192" },
+        { "name":"k_EMarketNotAllowedReason_NoRecentPurchases", "value":"16384" },
+        { "name":"k_EMarketNotAllowedReason_AcceptedWalletGift", "value":"32768" }
+      ]
+    },
+    {
+      "enumname": "EDurationControlProgress",
+      "values": [
+        { "name":"k_EDurationControlProgress_Full", "value":"0" },
+        { "name":"k_EDurationControlProgress_Half", "value":"1" },
+        { "name":"k_EDurationControlProgress_None", "value":"2" },
+        { "name":"k_EDurationControl_ExitSoon_3h", "value":"3" },
+        { "name":"k_EDurationControl_ExitSoon_5h", "value":"4" },
+        { "name":"k_EDurationControl_ExitSoon_Night", "value":"5" }
+      ]
+    },
+    {
+      "enumname": "EDurationControlNotification",
+      "values": [
+        { "name":"k_EDurationControlNotification_None", "value":"0" },
+        { "name":"k_EDurationControlNotification_1Hour", "value":"1" },
+        { "name":"k_EDurationControlNotification_3Hours", "value":"2" },
+        { "name":"k_EDurationControlNotification_HalfProgress", "value":"3" },
+        { "name":"k_EDurationControlNotification_NoProgress", "value":"4" },
+        { "name":"k_EDurationControlNotification_ExitSoon_3h", "value":"5" },
+        { "name":"k_EDurationControlNotification_ExitSoon_5h", "value":"6" },
+        { "name":"k_EDurationControlNotification_ExitSoon_Night", "value":"7" }
+      ]
+    },
+    {
+      "enumname": "EGameSearchErrorCode_t",
+      "values": [
+        { "name":"k_EGameSearchErrorCode_OK", "value":"1" },
+        { "name":"k_EGameSearchErrorCode_Failed_Search_Already_In_Progress", "value":"2" },
+        { "name":"k_EGameSearchErrorCode_Failed_No_Search_In_Progress", "value":"3" },
+        { "name":"k_EGameSearchErrorCode_Failed_Not_Lobby_Leader", "value":"4" },
+        { "name":"k_EGameSearchErrorCode_Failed_No_Host_Available", "value":"5" },
+        { "name":"k_EGameSearchErrorCode_Failed_Search_Params_Invalid", "value":"6" },
+        { "name":"k_EGameSearchErrorCode_Failed_Offline", "value":"7" },
+        { "name":"k_EGameSearchErrorCode_Failed_NotAuthorized", "value":"8" },
+        { "name":"k_EGameSearchErrorCode_Failed_Unknown_Error", "value":"9" }
+      ]
+    },
+    {
+      "enumname": "EPlayerResult_t",
+      "values": [
+        { "name":"k_EPlayerResultFailedToConnect", "value":"1" },
+        { "name":"k_EPlayerResultAbandoned", "value":"2" },
+        { "name":"k_EPlayerResultKicked", "value":"3" },
+        { "name":"k_EPlayerResultIncomplete", "value":"4" },
+        { "name":"k_EPlayerResultCompleted", "value":"5" }
+      ]
+    },
+    {
+      "enumname": "ESteamIPv6ConnectivityProtocol",
+      "values": [
+        { "name":"k_ESteamIPv6ConnectivityProtocol_Invalid", "value":"0" },
+        { "name":"k_ESteamIPv6ConnectivityProtocol_HTTP", "value":"1" },
+        { "name":"k_ESteamIPv6ConnectivityProtocol_UDP", "value":"2" }
+      ]
+    },
+    {
+      "enumname": "ESteamIPv6ConnectivityState",
+      "values": [
+        { "name":"k_ESteamIPv6ConnectivityState_Unknown", "value":"0" },
+        { "name":"k_ESteamIPv6ConnectivityState_Good", "value":"1" },
+        { "name":"k_ESteamIPv6ConnectivityState_Bad", "value":"2" }
+      ]
+    },
+    {
+      "enumname": "EFriendRelationship",
+      "values": [
+        { "name":"k_EFriendRelationshipNone", "value":"0" },
+        { "name":"k_EFriendRelationshipBlocked", "value":"1" },
+        { "name":"k_EFriendRelationshipRequestRecipient", "value":"2" },
+        { "name":"k_EFriendRelationshipFriend", "value":"3" },
+        { "name":"k_EFriendRelationshipRequestInitiator", "value":"4" },
+        { "name":"k_EFriendRelationshipIgnored", "value":"5" },
+        { "name":"k_EFriendRelationshipIgnoredFriend", "value":"6" },
+        { "name":"k_EFriendRelationshipSuggested_DEPRECATED", "value":"7" },
+        { "name":"k_EFriendRelationshipMax", "value":"8" }
+      ]
+    },
+    {
+      "enumname": "EPersonaState",
+      "values": [
+        { "name":"k_EPersonaStateOffline", "value":"0" },
+        { "name":"k_EPersonaStateOnline", "value":"1" },
+        { "name":"k_EPersonaStateBusy", "value":"2" },
+        { "name":"k_EPersonaStateAway", "value":"3" },
+        { "name":"k_EPersonaStateSnooze", "value":"4" },
+        { "name":"k_EPersonaStateLookingToTrade", "value":"5" },
+        { "name":"k_EPersonaStateLookingToPlay", "value":"6" },
+        { "name":"k_EPersonaStateInvisible", "value":"7" },
+        { "name":"k_EPersonaStateMax", "value":"8" }
+      ]
+    },
+    {
+      "enumname": "EFriendFlags",
+      "values": [
+        { "name":"k_EFriendFlagNone", "value":"0" },
+        { "name":"k_EFriendFlagBlocked", "value":"1" },
+        { "name":"k_EFriendFlagFriendshipRequested", "value":"2" },
+        { "name":"k_EFriendFlagImmediate", "value":"4" },
+        { "name":"k_EFriendFlagClanMember", "value":"8" },
+        { "name":"k_EFriendFlagOnGameServer", "value":"16" },
+        { "name":"k_EFriendFlagRequestingFriendship", "value":"128" },
+        { "name":"k_EFriendFlagRequestingInfo", "value":"256" },
+        { "name":"k_EFriendFlagIgnored", "value":"512" },
+        { "name":"k_EFriendFlagIgnoredFriend", "value":"1024" },
+        { "name":"k_EFriendFlagChatMember", "value":"4096" },
+        { "name":"k_EFriendFlagAll", "value":"65535" }
+      ]
+    },
+    {
+      "enumname": "EUserRestriction",
+      "values": [
+        { "name":"k_nUserRestrictionNone", "value":"0" },
+        { "name":"k_nUserRestrictionUnknown", "value":"1" },
+        { "name":"k_nUserRestrictionAnyChat", "value":"2" },
+        { "name":"k_nUserRestrictionVoiceChat", "value":"4" },
+        { "name":"k_nUserRestrictionGroupChat", "value":"8" },
+        { "name":"k_nUserRestrictionRating", "value":"16" },
+        { "name":"k_nUserRestrictionGameInvites", "value":"32" },
+        { "name":"k_nUserRestrictionTrading", "value":"64" }
+      ]
+    },
+    {
+      "enumname": "EOverlayToStoreFlag",
+      "values": [
+        { "name":"k_EOverlayToStoreFlag_None", "value":"0" },
+        { "name":"k_EOverlayToStoreFlag_AddToCart", "value":"1" },
+        { "name":"k_EOverlayToStoreFlag_AddToCartAndShow", "value":"2" }
+      ]
+    },
+    {
+      "enumname": "EActivateGameOverlayToWebPageMode",
+      "values": [
+        { "name":"k_EActivateGameOverlayToWebPageMode_Default", "value":"0" },
+        { "name":"k_EActivateGameOverlayToWebPageMode_Modal", "value":"1" }
+      ]
+    },
+    {
+      "enumname": "EPersonaChange",
+      "values": [
+        { "name":"k_EPersonaChangeName", "value":"1" },
+        { "name":"k_EPersonaChangeStatus", "value":"2" },
+        { "name":"k_EPersonaChangeComeOnline", "value":"4" },
+        { "name":"k_EPersonaChangeGoneOffline", "value":"8" },
+        { "name":"k_EPersonaChangeGamePlayed", "value":"16" },
+        { "name":"k_EPersonaChangeGameServer", "value":"32" },
+        { "name":"k_EPersonaChangeAvatar", "value":"64" },
+        { "name":"k_EPersonaChangeJoinedSource", "value":"128" },
+        { "name":"k_EPersonaChangeLeftSource", "value":"256" },
+        { "name":"k_EPersonaChangeRelationshipChanged", "value":"512" },
+        { "name":"k_EPersonaChangeNameFirstSet", "value":"1024" },
+        { "name":"k_EPersonaChangeBroadcast", "value":"2048" },
+        { "name":"k_EPersonaChangeNickname", "value":"4096" },
+        { "name":"k_EPersonaChangeSteamLevel", "value":"8192" },
+        { "name":"k_EPersonaChangeRichPresence", "value":"16384" }
+      ]
+    },
+    {
+      "enumname": "ESteamAPICallFailure",
+      "values": [
+        { "name":"k_ESteamAPICallFailureNone", "value":"-1" },
+        { "name":"k_ESteamAPICallFailureSteamGone", "value":"0" },
+        { "name":"k_ESteamAPICallFailureNetworkFailure", "value":"1" },
+        { "name":"k_ESteamAPICallFailureInvalidHandle", "value":"2" },
+        { "name":"k_ESteamAPICallFailureMismatchedCallback", "value":"3" }
+      ]
+    },
+    {
+      "enumname": "EGamepadTextInputMode",
+      "values": [
+        { "name":"k_EGamepadTextInputModeNormal", "value":"0" },
+        { "name":"k_EGamepadTextInputModePassword", "value":"1" }
+      ]
+    },
+    {
+      "enumname": "EGamepadTextInputLineMode",
+      "values": [
+        { "name":"k_EGamepadTextInputLineModeSingleLine", "value":"0" },
+        { "name":"k_EGamepadTextInputLineModeMultipleLines", "value":"1" }
+      ]
+    },
+    {
+      "enumname": "ECheckFileSignature",
+      "values": [
+        { "name":"k_ECheckFileSignatureInvalidSignature", "value":"0" },
+        { "name":"k_ECheckFileSignatureValidSignature", "value":"1" },
+        { "name":"k_ECheckFileSignatureFileNotFound", "value":"2" },
+        { "name":"k_ECheckFileSignatureNoSignaturesFoundForThisApp", "value":"3" },
+        { "name":"k_ECheckFileSignatureNoSignaturesFoundForThisFile", "value":"4" }
+      ]
+    },
+    {
+      "enumname": "EMatchMakingServerResponse",
+      "values": [
+        { "name":"eServerResponded", "value":"0" },
+        { "name":"eServerFailedToRespond", "value":"1" },
+        { "name":"eNoServersListedOnMasterServer", "value":"2" }
+      ]
+    },
+    {
+      "enumname": "ELobbyType",
+      "values": [
+        { "name":"k_ELobbyTypePrivate", "value":"0" },
+        { "name":"k_ELobbyTypeFriendsOnly", "value":"1" },
+        { "name":"k_ELobbyTypePublic", "value":"2" },
+        { "name":"k_ELobbyTypeInvisible", "value":"3" },
+        { "name":"k_ELobbyTypePrivateUnique", "value":"4" }
+      ]
+    },
+    {
+      "enumname": "ELobbyComparison",
+      "values": [
+        { "name":"k_ELobbyComparisonEqualToOrLessThan", "value":"-2" },
+        { "name":"k_ELobbyComparisonLessThan", "value":"-1" },
+        { "name":"k_ELobbyComparisonEqual", "value":"0" },
+        { "name":"k_ELobbyComparisonGreaterThan", "value":"1" },
+        { "name":"k_ELobbyComparisonEqualToOrGreaterThan", "value":"2" },
+        { "name":"k_ELobbyComparisonNotEqual", "value":"3" }
+      ]
+    },
+    {
+      "enumname": "ELobbyDistanceFilter",
+      "values": [
+        { "name":"k_ELobbyDistanceFilterClose", "value":"0" },
+        { "name":"k_ELobbyDistanceFilterDefault", "value":"1" },
+        { "name":"k_ELobbyDistanceFilterFar", "value":"2" },
+        { "name":"k_ELobbyDistanceFilterWorldwide", "value":"3" }
+      ]
+    },
+    {
+      "enumname": "EChatMemberStateChange",
+      "values": [
+        { "name":"k_EChatMemberStateChangeEntered", "value":"1" },
+        { "name":"k_EChatMemberStateChangeLeft", "value":"2" },
+        { "name":"k_EChatMemberStateChangeDisconnected", "value":"4" },
+        { "name":"k_EChatMemberStateChangeKicked", "value":"8" },
+        { "name":"k_EChatMemberStateChangeBanned", "value":"16" }
+      ]
+    },
+    {
+      "enumname": "ESteamPartyBeaconLocationType",
+      "values": [
+        { "name":"k_ESteamPartyBeaconLocationType_Invalid", "value":"0" },
+        { "name":"k_ESteamPartyBeaconLocationType_ChatGroup", "value":"1" },
+        { "name":"k_ESteamPartyBeaconLocationType_Max", "value":"2" }
+      ]
+    },
+    {
+      "enumname": "ESteamPartyBeaconLocationData",
+      "values": [
+        { "name":"k_ESteamPartyBeaconLocationDataInvalid", "value":"0" },
+        { "name":"k_ESteamPartyBeaconLocationDataName", "value":"1" },
+        { "name":"k_ESteamPartyBeaconLocationDataIconURLSmall", "value":"2" },
+        { "name":"k_ESteamPartyBeaconLocationDataIconURLMedium", "value":"3" },
+        { "name":"k_ESteamPartyBeaconLocationDataIconURLLarge", "value":"4" }
+      ]
+    },
+    {
+      "enumname": "ERemoteStoragePlatform",
+      "values": [
+        { "name":"k_ERemoteStoragePlatformNone", "value":"0" },
+        { "name":"k_ERemoteStoragePlatformWindows", "value":"1" },
+        { "name":"k_ERemoteStoragePlatformOSX", "value":"2" },
+        { "name":"k_ERemoteStoragePlatformPS3", "value":"4" },
+        { "name":"k_ERemoteStoragePlatformLinux", "value":"8" },
+        { "name":"k_ERemoteStoragePlatformSwitch", "value":"16" },
+        { "name":"k_ERemoteStoragePlatformAndroid", "value":"32" },
+        { "name":"k_ERemoteStoragePlatformIOS", "value":"64" },
+        { "name":"k_ERemoteStoragePlatformAll", "value":"-1" }
+      ]
+    },
+    {
+      "enumname": "ERemoteStoragePublishedFileVisibility",
+      "values": [
+        { "name":"k_ERemoteStoragePublishedFileVisibilityPublic", "value":"0" },
+        { "name":"k_ERemoteStoragePublishedFileVisibilityFriendsOnly", "value":"1" },
+        { "name":"k_ERemoteStoragePublishedFileVisibilityPrivate", "value":"2" },
+        { "name":"k_ERemoteStoragePublishedFileVisibilityUnlisted", "value":"3" }
+      ]
+    },
+    {
+      "enumname": "EWorkshopFileType",
+      "values": [
+        { "name":"k_EWorkshopFileTypeFirst", "value":"0" },
+        { "name":"k_EWorkshopFileTypeCommunity", "value":"0" },
+        { "name":"k_EWorkshopFileTypeMicrotransaction", "value":"1" },
+        { "name":"k_EWorkshopFileTypeCollection", "value":"2" },
+        { "name":"k_EWorkshopFileTypeArt", "value":"3" },
+        { "name":"k_EWorkshopFileTypeVideo", "value":"4" },
+        { "name":"k_EWorkshopFileTypeScreenshot", "value":"5" },
+        { "name":"k_EWorkshopFileTypeGame", "value":"6" },
+        { "name":"k_EWorkshopFileTypeSoftware", "value":"7" },
+        { "name":"k_EWorkshopFileTypeConcept", "value":"8" },
+        { "name":"k_EWorkshopFileTypeWebGuide", "value":"9" },
+        { "name":"k_EWorkshopFileTypeIntegratedGuide", "value":"10" },
+        { "name":"k_EWorkshopFileTypeMerch", "value":"11" },
+        { "name":"k_EWorkshopFileTypeControllerBinding", "value":"12" },
+        { "name":"k_EWorkshopFileTypeSteamworksAccessInvite", "value":"13" },
+        { "name":"k_EWorkshopFileTypeSteamVideo", "value":"14" },
+        { "name":"k_EWorkshopFileTypeGameManagedItem", "value":"15" },
+        { "name":"k_EWorkshopFileTypeMax", "value":"16" }
+      ]
+    },
+    {
+      "enumname": "EWorkshopVote",
+      "values": [
+        { "name":"k_EWorkshopVoteUnvoted", "value":"0" },
+        { "name":"k_EWorkshopVoteFor", "value":"1" },
+        { "name":"k_EWorkshopVoteAgainst", "value":"2" },
+        { "name":"k_EWorkshopVoteLater", "value":"3" }
+      ]
+    },
+    {
+      "enumname": "EWorkshopFileAction",
+      "values": [
+        { "name":"k_EWorkshopFileActionPlayed", "value":"0" },
+        { "name":"k_EWorkshopFileActionCompleted", "value":"1" }
+      ]
+    },
+    {
+      "enumname": "EWorkshopEnumerationType",
+      "values": [
+        { "name":"k_EWorkshopEnumerationTypeRankedByVote", "value":"0" },
+        { "name":"k_EWorkshopEnumerationTypeRecent", "value":"1" },
+        { "name":"k_EWorkshopEnumerationTypeTrending", "value":"2" },
+        { "name":"k_EWorkshopEnumerationTypeFavoritesOfFriends", "value":"3" },
+        { "name":"k_EWorkshopEnumerationTypeVotedByFriends", "value":"4" },
+        { "name":"k_EWorkshopEnumerationTypeContentByFriends", "value":"5" },
+        { "name":"k_EWorkshopEnumerationTypeRecentFromFollowedUsers", "value":"6" }
+      ]
+    },
+    {
+      "enumname": "EWorkshopVideoProvider",
+      "values": [
+        { "name":"k_EWorkshopVideoProviderNone", "value":"0" },
+        { "name":"k_EWorkshopVideoProviderYoutube", "value":"1" }
+      ]
+    },
+    {
+      "enumname": "EUGCReadAction",
+      "values": [
+        { "name":"k_EUGCRead_ContinueReadingUntilFinished", "value":"0" },
+        { "name":"k_EUGCRead_ContinueReading", "value":"1" },
+        { "name":"k_EUGCRead_Close", "value":"2" }
+      ]
+    },
+    {
+      "enumname": "ELeaderboardDataRequest",
+      "values": [
+        { "name":"k_ELeaderboardDataRequestGlobal", "value":"0" },
+        { "name":"k_ELeaderboardDataRequestGlobalAroundUser", "value":"1" },
+        { "name":"k_ELeaderboardDataRequestFriends", "value":"2" },
+        { "name":"k_ELeaderboardDataRequestUsers", "value":"3" }
+      ]
+    },
+    {
+      "enumname": "ELeaderboardSortMethod",
+      "values": [
+        { "name":"k_ELeaderboardSortMethodNone", "value":"0" },
+        { "name":"k_ELeaderboardSortMethodAscending", "value":"1" },
+        { "name":"k_ELeaderboardSortMethodDescending", "value":"2" }
+      ]
+    },
+    {
+      "enumname": "ELeaderboardDisplayType",
+      "values": [
+        { "name":"k_ELeaderboardDisplayTypeNone", "value":"0" },
+        { "name":"k_ELeaderboardDisplayTypeNumeric", "value":"1" },
+        { "name":"k_ELeaderboardDisplayTypeTimeSeconds", "value":"2" },
+        { "name":"k_ELeaderboardDisplayTypeTimeMilliSeconds", "value":"3" }
+      ]
+    },
+    {
+      "enumname": "ELeaderboardUploadScoreMethod",
+      "values": [
+        { "name":"k_ELeaderboardUploadScoreMethodNone", "value":"0" },
+        { "name":"k_ELeaderboardUploadScoreMethodKeepBest", "value":"1" },
+        { "name":"k_ELeaderboardUploadScoreMethodForceUpdate", "value":"2" }
+      ]
+    },
+    {
+      "enumname": "ERegisterActivationCodeResult",
+      "values": [
+        { "name":"k_ERegisterActivationCodeResultOK", "value":"0" },
+        { "name":"k_ERegisterActivationCodeResultFail", "value":"1" },
+        { "name":"k_ERegisterActivationCodeResultAlreadyRegistered", "value":"2" },
+        { "name":"k_ERegisterActivationCodeResultTimeout", "value":"3" },
+        { "name":"k_ERegisterActivationCodeAlreadyOwned", "value":"4" }
+      ]
+    },
+    {
+      "enumname": "EP2PSessionError",
+      "values": [
+        { "name":"k_EP2PSessionErrorNone", "value":"0" },
+        { "name":"k_EP2PSessionErrorNotRunningApp", "value":"1" },
+        { "name":"k_EP2PSessionErrorNoRightsToApp", "value":"2" },
+        { "name":"k_EP2PSessionErrorDestinationNotLoggedIn", "value":"3" },
+        { "name":"k_EP2PSessionErrorTimeout", "value":"4" },
+        { "name":"k_EP2PSessionErrorMax", "value":"5" }
+      ]
+    },
+    {
+      "enumname": "EP2PSend",
+      "values": [
+        { "name":"k_EP2PSendUnreliable", "value":"0" },
+        { "name":"k_EP2PSendUnreliableNoDelay", "value":"1" },
+        { "name":"k_EP2PSendReliable", "value":"2" },
+        { "name":"k_EP2PSendReliableWithBuffering", "value":"3" }
+      ]
+    },
+    {
+      "enumname": "ESNetSocketState",
+      "values": [
+        { "name":"k_ESNetSocketStateInvalid", "value":"0" },
+        { "name":"k_ESNetSocketStateConnected", "value":"1" },
+        { "name":"k_ESNetSocketStateInitiated", "value":"10" },
+        { "name":"k_ESNetSocketStateLocalCandidatesFound", "value":"11" },
+        { "name":"k_ESNetSocketStateReceivedRemoteCandidates", "value":"12" },
+        { "name":"k_ESNetSocketStateChallengeHandshake", "value":"15" },
+        { "name":"k_ESNetSocketStateDisconnecting", "value":"21" },
+        { "name":"k_ESNetSocketStateLocalDisconnect", "value":"22" },
+        { "name":"k_ESNetSocketStateTimeoutDuringConnect", "value":"23" },
+        { "name":"k_ESNetSocketStateRemoteEndDisconnected", "value":"24" },
+        { "name":"k_ESNetSocketStateConnectionBroken", "value":"25" }
+      ]
+    },
+    {
+      "enumname": "ESNetSocketConnectionType",
+      "values": [
+        { "name":"k_ESNetSocketConnectionTypeNotConnected", "value":"0" },
+        { "name":"k_ESNetSocketConnectionTypeUDP", "value":"1" },
+        { "name":"k_ESNetSocketConnectionTypeUDPRelay", "value":"2" }
+      ]
+    },
+    {
+      "enumname": "EVRScreenshotType",
+      "values": [
+        { "name":"k_EVRScreenshotType_None", "value":"0" },
+        { "name":"k_EVRScreenshotType_Mono", "value":"1" },
+        { "name":"k_EVRScreenshotType_Stereo", "value":"2" },
+        { "name":"k_EVRScreenshotType_MonoCubemap", "value":"3" },
+        { "name":"k_EVRScreenshotType_MonoPanorama", "value":"4" },
+        { "name":"k_EVRScreenshotType_StereoPanorama", "value":"5" }
+      ]
+    },
+    {
+      "enumname": "AudioPlayback_Status",
+      "values": [
+        { "name":"AudioPlayback_Undefined", "value":"0" },
+        { "name":"AudioPlayback_Playing", "value":"1" },
+        { "name":"AudioPlayback_Paused", "value":"2" },
+        { "name":"AudioPlayback_Idle", "value":"3" }
+      ]
+    },
+    {
+      "enumname": "EHTTPMethod",
+      "values": [
+        { "name":"k_EHTTPMethodInvalid", "value":"0" },
+        { "name":"k_EHTTPMethodGET", "value":"1" },
+        { "name":"k_EHTTPMethodHEAD", "value":"2" },
+        { "name":"k_EHTTPMethodPOST", "value":"3" },
+        { "name":"k_EHTTPMethodPUT", "value":"4" },
+        { "name":"k_EHTTPMethodDELETE", "value":"5" },
+        { "name":"k_EHTTPMethodOPTIONS", "value":"6" },
+        { "name":"k_EHTTPMethodPATCH", "value":"7" }
+      ]
+    },
+    {
+      "enumname": "EHTTPStatusCode",
+      "values": [
+        { "name":"k_EHTTPStatusCodeInvalid", "value":"0" },
+        { "name":"k_EHTTPStatusCode100Continue", "value":"100" },
+        { "name":"k_EHTTPStatusCode101SwitchingProtocols", "value":"101" },
+        { "name":"k_EHTTPStatusCode200OK", "value":"200" },
+        { "name":"k_EHTTPStatusCode201Created", "value":"201" },
+        { "name":"k_EHTTPStatusCode202Accepted", "value":"202" },
+        { "name":"k_EHTTPStatusCode203NonAuthoritative", "value":"203" },
+        { "name":"k_EHTTPStatusCode204NoContent", "value":"204" },
+        { "name":"k_EHTTPStatusCode205ResetContent", "value":"205" },
+        { "name":"k_EHTTPStatusCode206PartialContent", "value":"206" },
+        { "name":"k_EHTTPStatusCode300MultipleChoices", "value":"300" },
+        { "name":"k_EHTTPStatusCode301MovedPermanently", "value":"301" },
+        { "name":"k_EHTTPStatusCode302Found", "value":"302" },
+        { "name":"k_EHTTPStatusCode303SeeOther", "value":"303" },
+        { "name":"k_EHTTPStatusCode304NotModified", "value":"304" },
+        { "name":"k_EHTTPStatusCode305UseProxy", "value":"305" },
+        { "name":"k_EHTTPStatusCode307TemporaryRedirect", "value":"307" },
+        { "name":"k_EHTTPStatusCode400BadRequest", "value":"400" },
+        { "name":"k_EHTTPStatusCode401Unauthorized", "value":"401" },
+        { "name":"k_EHTTPStatusCode402PaymentRequired", "value":"402" },
+        { "name":"k_EHTTPStatusCode403Forbidden", "value":"403" },
+        { "name":"k_EHTTPStatusCode404NotFound", "value":"404" },
+        { "name":"k_EHTTPStatusCode405MethodNotAllowed", "value":"405" },
+        { "name":"k_EHTTPStatusCode406NotAcceptable", "value":"406" },
+        { "name":"k_EHTTPStatusCode407ProxyAuthRequired", "value":"407" },
+        { "name":"k_EHTTPStatusCode408RequestTimeout", "value":"408" },
+        { "name":"k_EHTTPStatusCode409Conflict", "value":"409" },
+        { "name":"k_EHTTPStatusCode410Gone", "value":"410" },
+        { "name":"k_EHTTPStatusCode411LengthRequired", "value":"411" },
+        { "name":"k_EHTTPStatusCode412PreconditionFailed", "value":"412" },
+        { "name":"k_EHTTPStatusCode413RequestEntityTooLarge", "value":"413" },
+        { "name":"k_EHTTPStatusCode414RequestURITooLong", "value":"414" },
+        { "name":"k_EHTTPStatusCode415UnsupportedMediaType", "value":"415" },
+        { "name":"k_EHTTPStatusCode416RequestedRangeNotSatisfiable", "value":"416" },
+        { "name":"k_EHTTPStatusCode417ExpectationFailed", "value":"417" },
+        { "name":"k_EHTTPStatusCode4xxUnknown", "value":"418" },
+        { "name":"k_EHTTPStatusCode429TooManyRequests", "value":"429" },
+        { "name":"k_EHTTPStatusCode500InternalServerError", "value":"500" },
+        { "name":"k_EHTTPStatusCode501NotImplemented", "value":"501" },
+        { "name":"k_EHTTPStatusCode502BadGateway", "value":"502" },
+        { "name":"k_EHTTPStatusCode503ServiceUnavailable", "value":"503" },
+        { "name":"k_EHTTPStatusCode504GatewayTimeout", "value":"504" },
+        { "name":"k_EHTTPStatusCode505HTTPVersionNotSupported", "value":"505" },
+        { "name":"k_EHTTPStatusCode5xxUnknown", "value":"599" }
+      ]
+    },
+    {
+      "enumname": "EInputSourceMode",
+      "values": [
+        { "name":"k_EInputSourceMode_None", "value":"0" },
+        { "name":"k_EInputSourceMode_Dpad", "value":"1" },
+        { "name":"k_EInputSourceMode_Buttons", "value":"2" },
+        { "name":"k_EInputSourceMode_FourButtons", "value":"3" },
+        { "name":"k_EInputSourceMode_AbsoluteMouse", "value":"4" },
+        { "name":"k_EInputSourceMode_RelativeMouse", "value":"5" },
+        { "name":"k_EInputSourceMode_JoystickMove", "value":"6" },
+        { "name":"k_EInputSourceMode_JoystickMouse", "value":"7" },
+        { "name":"k_EInputSourceMode_JoystickCamera", "value":"8" },
+        { "name":"k_EInputSourceMode_ScrollWheel", "value":"9" },
+        { "name":"k_EInputSourceMode_Trigger", "value":"10" },
+        { "name":"k_EInputSourceMode_TouchMenu", "value":"11" },
+        { "name":"k_EInputSourceMode_MouseJoystick", "value":"12" },
+        { "name":"k_EInputSourceMode_MouseRegion", "value":"13" },
+        { "name":"k_EInputSourceMode_RadialMenu", "value":"14" },
+        { "name":"k_EInputSourceMode_SingleButton", "value":"15" },
+        { "name":"k_EInputSourceMode_Switches", "value":"16" }
+      ]
+    },
+    {
+      "enumname": "EInputActionOrigin",
+      "values": [
+        { "name":"k_EInputActionOrigin_None", "value":"0" },
+        { "name":"k_EInputActionOrigin_SteamController_A", "value":"1" },
+        { "name":"k_EInputActionOrigin_SteamController_B", "value":"2" },
+        { "name":"k_EInputActionOrigin_SteamController_X", "value":"3" },
+        { "name":"k_EInputActionOrigin_SteamController_Y", "value":"4" },
+        { "name":"k_EInputActionOrigin_SteamController_LeftBumper", "value":"5" },
+        { "name":"k_EInputActionOrigin_SteamController_RightBumper", "value":"6" },
+        { "name":"k_EInputActionOrigin_SteamController_LeftGrip", "value":"7" },
+        { "name":"k_EInputActionOrigin_SteamController_RightGrip", "value":"8" },
+        { "name":"k_EInputActionOrigin_SteamController_Start", "value":"9" },
+        { "name":"k_EInputActionOrigin_SteamController_Back", "value":"10" },
+        { "name":"k_EInputActionOrigin_SteamController_LeftPad_Touch", "value":"11" },
+        { "name":"k_EInputActionOrigin_SteamController_LeftPad_Swipe", "value":"12" },
+        { "name":"k_EInputActionOrigin_SteamController_LeftPad_Click", "value":"13" },
+        { "name":"k_EInputActionOrigin_SteamController_LeftPad_DPadNorth", "value":"14" },
+        { "name":"k_EInputActionOrigin_SteamController_LeftPad_DPadSouth", "value":"15" },
+        { "name":"k_EInputActionOrigin_SteamController_LeftPad_DPadWest", "value":"16" },
+        { "name":"k_EInputActionOrigin_SteamController_LeftPad_DPadEast", "value":"17" },
+        { "name":"k_EInputActionOrigin_SteamController_RightPad_Touch", "value":"18" },
+        { "name":"k_EInputActionOrigin_SteamController_RightPad_Swipe", "value":"19" },
+        { "name":"k_EInputActionOrigin_SteamController_RightPad_Click", "value":"20" },
+        { "name":"k_EInputActionOrigin_SteamController_RightPad_DPadNorth", "value":"21" },
+        { "name":"k_EInputActionOrigin_SteamController_RightPad_DPadSouth", "value":"22" },
+        { "name":"k_EInputActionOrigin_SteamController_RightPad_DPadWest", "value":"23" },
+        { "name":"k_EInputActionOrigin_SteamController_RightPad_DPadEast", "value":"24" },
+        { "name":"k_EInputActionOrigin_SteamController_LeftTrigger_Pull", "value":"25" },
+        { "name":"k_EInputActionOrigin_SteamController_LeftTrigger_Click", "value":"26" },
+        { "name":"k_EInputActionOrigin_SteamController_RightTrigger_Pull", "value":"27" },
+        { "name":"k_EInputActionOrigin_SteamController_RightTrigger_Click", "value":"28" },
+        { "name":"k_EInputActionOrigin_SteamController_LeftStick_Move", "value":"29" },
+        { "name":"k_EInputActionOrigin_SteamController_LeftStick_Click", "value":"30" },
+        { "name":"k_EInputActionOrigin_SteamController_LeftStick_DPadNorth", "value":"31" },
+        { "name":"k_EInputActionOrigin_SteamController_LeftStick_DPadSouth", "value":"32" },
+        { "name":"k_EInputActionOrigin_SteamController_LeftStick_DPadWest", "value":"33" },
+        { "name":"k_EInputActionOrigin_SteamController_LeftStick_DPadEast", "value":"34" },
+        { "name":"k_EInputActionOrigin_SteamController_Gyro_Move", "value":"35" },
+        { "name":"k_EInputActionOrigin_SteamController_Gyro_Pitch", "value":"36" },
+        { "name":"k_EInputActionOrigin_SteamController_Gyro_Yaw", "value":"37" },
+        { "name":"k_EInputActionOrigin_SteamController_Gyro_Roll", "value":"38" },
+        { "name":"k_EInputActionOrigin_SteamController_Reserved0", "value":"39" },
+        { "name":"k_EInputActionOrigin_SteamController_Reserved1", "value":"40" },
+        { "name":"k_EInputActionOrigin_SteamController_Reserved2", "value":"41" },
+        { "name":"k_EInputActionOrigin_SteamController_Reserved3", "value":"42" },
+        { "name":"k_EInputActionOrigin_SteamController_Reserved4", "value":"43" },
+        { "name":"k_EInputActionOrigin_SteamController_Reserved5", "value":"44" },
+        { "name":"k_EInputActionOrigin_SteamController_Reserved6", "value":"45" },
+        { "name":"k_EInputActionOrigin_SteamController_Reserved7", "value":"46" },
+        { "name":"k_EInputActionOrigin_SteamController_Reserved8", "value":"47" },
+        { "name":"k_EInputActionOrigin_SteamController_Reserved9", "value":"48" },
+        { "name":"k_EInputActionOrigin_SteamController_Reserved10", "value":"49" },
+        { "name":"k_EInputActionOrigin_PS4_X", "value":"50" },
+        { "name":"k_EInputActionOrigin_PS4_Circle", "value":"51" },
+        { "name":"k_EInputActionOrigin_PS4_Triangle", "value":"52" },
+        { "name":"k_EInputActionOrigin_PS4_Square", "value":"53" },
+        { "name":"k_EInputActionOrigin_PS4_LeftBumper", "value":"54" },
+        { "name":"k_EInputActionOrigin_PS4_RightBumper", "value":"55" },
+        { "name":"k_EInputActionOrigin_PS4_Options", "value":"56" },
+        { "name":"k_EInputActionOrigin_PS4_Share", "value":"57" },
+        { "name":"k_EInputActionOrigin_PS4_LeftPad_Touch", "value":"58" },
+        { "name":"k_EInputActionOrigin_PS4_LeftPad_Swipe", "value":"59" },
+        { "name":"k_EInputActionOrigin_PS4_LeftPad_Click", "value":"60" },
+        { "name":"k_EInputActionOrigin_PS4_LeftPad_DPadNorth", "value":"61" },
+        { "name":"k_EInputActionOrigin_PS4_LeftPad_DPadSouth", "value":"62" },
+        { "name":"k_EInputActionOrigin_PS4_LeftPad_DPadWest", "value":"63" },
+        { "name":"k_EInputActionOrigin_PS4_LeftPad_DPadEast", "value":"64" },
+        { "name":"k_EInputActionOrigin_PS4_RightPad_Touch", "value":"65" },
+        { "name":"k_EInputActionOrigin_PS4_RightPad_Swipe", "value":"66" },
+        { "name":"k_EInputActionOrigin_PS4_RightPad_Click", "value":"67" },
+        { "name":"k_EInputActionOrigin_PS4_RightPad_DPadNorth", "value":"68" },
+        { "name":"k_EInputActionOrigin_PS4_RightPad_DPadSouth", "value":"69" },
+        { "name":"k_EInputActionOrigin_PS4_RightPad_DPadWest", "value":"70" },
+        { "name":"k_EInputActionOrigin_PS4_RightPad_DPadEast", "value":"71" },
+        { "name":"k_EInputActionOrigin_PS4_CenterPad_Touch", "value":"72" },
+        { "name":"k_EInputActionOrigin_PS4_CenterPad_Swipe", "value":"73" },
+        { "name":"k_EInputActionOrigin_PS4_CenterPad_Click", "value":"74" },
+        { "name":"k_EInputActionOrigin_PS4_CenterPad_DPadNorth", "value":"75" },
+        { "name":"k_EInputActionOrigin_PS4_CenterPad_DPadSouth", "value":"76" },
+        { "name":"k_EInputActionOrigin_PS4_CenterPad_DPadWest", "value":"77" },
+        { "name":"k_EInputActionOrigin_PS4_CenterPad_DPadEast", "value":"78" },
+        { "name":"k_EInputActionOrigin_PS4_LeftTrigger_Pull", "value":"79" },
+        { "name":"k_EInputActionOrigin_PS4_LeftTrigger_Click", "value":"80" },
+        { "name":"k_EInputActionOrigin_PS4_RightTrigger_Pull", "value":"81" },
+        { "name":"k_EInputActionOrigin_PS4_RightTrigger_Click", "value":"82" },
+        { "name":"k_EInputActionOrigin_PS4_LeftStick_Move", "value":"83" },
+        { "name":"k_EInputActionOrigin_PS4_LeftStick_Click", "value":"84" },
+        { "name":"k_EInputActionOrigin_PS4_LeftStick_DPadNorth", "value":"85" },
+        { "name":"k_EInputActionOrigin_PS4_LeftStick_DPadSouth", "value":"86" },
+        { "name":"k_EInputActionOrigin_PS4_LeftStick_DPadWest", "value":"87" },
+        { "name":"k_EInputActionOrigin_PS4_LeftStick_DPadEast", "value":"88" },
+        { "name":"k_EInputActionOrigin_PS4_RightStick_Move", "value":"89" },
+        { "name":"k_EInputActionOrigin_PS4_RightStick_Click", "value":"90" },
+        { "name":"k_EInputActionOrigin_PS4_RightStick_DPadNorth", "value":"91" },
+        { "name":"k_EInputActionOrigin_PS4_RightStick_DPadSouth", "value":"92" },
+        { "name":"k_EInputActionOrigin_PS4_RightStick_DPadWest", "value":"93" },
+        { "name":"k_EInputActionOrigin_PS4_RightStick_DPadEast", "value":"94" },
+        { "name":"k_EInputActionOrigin_PS4_DPad_North", "value":"95" },
+        { "name":"k_EInputActionOrigin_PS4_DPad_South", "value":"96" },
+        { "name":"k_EInputActionOrigin_PS4_DPad_West", "value":"97" },
+        { "name":"k_EInputActionOrigin_PS4_DPad_East", "value":"98" },
+        { "name":"k_EInputActionOrigin_PS4_Gyro_Move", "value":"99" },
+        { "name":"k_EInputActionOrigin_PS4_Gyro_Pitch", "value":"100" },
+        { "name":"k_EInputActionOrigin_PS4_Gyro_Yaw", "value":"101" },
+        { "name":"k_EInputActionOrigin_PS4_Gyro_Roll", "value":"102" },
+        { "name":"k_EInputActionOrigin_PS4_DPad_Move", "value":"103" },
+        { "name":"k_EInputActionOrigin_PS4_Reserved1", "value":"104" },
+        { "name":"k_EInputActionOrigin_PS4_Reserved2", "value":"105" },
+        { "name":"k_EInputActionOrigin_PS4_Reserved3", "value":"106" },
+        { "name":"k_EInputActionOrigin_PS4_Reserved4", "value":"107" },
+        { "name":"k_EInputActionOrigin_PS4_Reserved5", "value":"108" },
+        { "name":"k_EInputActionOrigin_PS4_Reserved6", "value":"109" },
+        { "name":"k_EInputActionOrigin_PS4_Reserved7", "value":"110" },
+        { "name":"k_EInputActionOrigin_PS4_Reserved8", "value":"111" },
+        { "name":"k_EInputActionOrigin_PS4_Reserved9", "value":"112" },
+        { "name":"k_EInputActionOrigin_PS4_Reserved10", "value":"113" },
+        { "name":"k_EInputActionOrigin_XBoxOne_A", "value":"114" },
+        { "name":"k_EInputActionOrigin_XBoxOne_B", "value":"115" },
+        { "name":"k_EInputActionOrigin_XBoxOne_X", "value":"116" },
+        { "name":"k_EInputActionOrigin_XBoxOne_Y", "value":"117" },
+        { "name":"k_EInputActionOrigin_XBoxOne_LeftBumper", "value":"118" },
+        { "name":"k_EInputActionOrigin_XBoxOne_RightBumper", "value":"119" },
+        { "name":"k_EInputActionOrigin_XBoxOne_Menu", "value":"120" },
+        { "name":"k_EInputActionOrigin_XBoxOne_View", "value":"121" },
+        { "name":"k_EInputActionOrigin_XBoxOne_LeftTrigger_Pull", "value":"122" },
+        { "name":"k_EInputActionOrigin_XBoxOne_LeftTrigger_Click", "value":"123" },
+        { "name":"k_EInputActionOrigin_XBoxOne_RightTrigger_Pull", "value":"124" },
+        { "name":"k_EInputActionOrigin_XBoxOne_RightTrigger_Click", "value":"125" },
+        { "name":"k_EInputActionOrigin_XBoxOne_LeftStick_Move", "value":"126" },
+        { "name":"k_EInputActionOrigin_XBoxOne_LeftStick_Click", "value":"127" },
+        { "name":"k_EInputActionOrigin_XBoxOne_LeftStick_DPadNorth", "value":"128" },
+        { "name":"k_EInputActionOrigin_XBoxOne_LeftStick_DPadSouth", "value":"129" },
+        { "name":"k_EInputActionOrigin_XBoxOne_LeftStick_DPadWest", "value":"130" },
+        { "name":"k_EInputActionOrigin_XBoxOne_LeftStick_DPadEast", "value":"131" },
+        { "name":"k_EInputActionOrigin_XBoxOne_RightStick_Move", "value":"132" },
+        { "name":"k_EInputActionOrigin_XBoxOne_RightStick_Click", "value":"133" },
+        { "name":"k_EInputActionOrigin_XBoxOne_RightStick_DPadNorth", "value":"134" },
+        { "name":"k_EInputActionOrigin_XBoxOne_RightStick_DPadSouth", "value":"135" },
+        { "name":"k_EInputActionOrigin_XBoxOne_RightStick_DPadWest", "value":"136" },
+        { "name":"k_EInputActionOrigin_XBoxOne_RightStick_DPadEast", "value":"137" },
+        { "name":"k_EInputActionOrigin_XBoxOne_DPad_North", "value":"138" },
+        { "name":"k_EInputActionOrigin_XBoxOne_DPad_South", "value":"139" },
+        { "name":"k_EInputActionOrigin_XBoxOne_DPad_West", "value":"140" },
+        { "name":"k_EInputActionOrigin_XBoxOne_DPad_East", "value":"141" },
+        { "name":"k_EInputActionOrigin_XBoxOne_DPad_Move", "value":"142" },
+        { "name":"k_EInputActionOrigin_XBoxOne_Reserved1", "value":"143" },
+        { "name":"k_EInputActionOrigin_XBoxOne_Reserved2", "value":"144" },
+        { "name":"k_EInputActionOrigin_XBoxOne_Reserved3", "value":"145" },
+        { "name":"k_EInputActionOrigin_XBoxOne_Reserved4", "value":"146" },
+        { "name":"k_EInputActionOrigin_XBoxOne_Reserved5", "value":"147" },
+        { "name":"k_EInputActionOrigin_XBoxOne_Reserved6", "value":"148" },
+        { "name":"k_EInputActionOrigin_XBoxOne_Reserved7", "value":"149" },
+        { "name":"k_EInputActionOrigin_XBoxOne_Reserved8", "value":"150" },
+        { "name":"k_EInputActionOrigin_XBoxOne_Reserved9", "value":"151" },
+        { "name":"k_EInputActionOrigin_XBoxOne_Reserved10", "value":"152" },
+        { "name":"k_EInputActionOrigin_XBox360_A", "value":"153" },
+        { "name":"k_EInputActionOrigin_XBox360_B", "value":"154" },
+        { "name":"k_EInputActionOrigin_XBox360_X", "value":"155" },
+        { "name":"k_EInputActionOrigin_XBox360_Y", "value":"156" },
+        { "name":"k_EInputActionOrigin_XBox360_LeftBumper", "value":"157" },
+        { "name":"k_EInputActionOrigin_XBox360_RightBumper", "value":"158" },
+        { "name":"k_EInputActionOrigin_XBox360_Start", "value":"159" },
+        { "name":"k_EInputActionOrigin_XBox360_Back", "value":"160" },
+        { "name":"k_EInputActionOrigin_XBox360_LeftTrigger_Pull", "value":"161" },
+        { "name":"k_EInputActionOrigin_XBox360_LeftTrigger_Click", "value":"162" },
+        { "name":"k_EInputActionOrigin_XBox360_RightTrigger_Pull", "value":"163" },
+        { "name":"k_EInputActionOrigin_XBox360_RightTrigger_Click", "value":"164" },
+        { "name":"k_EInputActionOrigin_XBox360_LeftStick_Move", "value":"165" },
+        { "name":"k_EInputActionOrigin_XBox360_LeftStick_Click", "value":"166" },
+        { "name":"k_EInputActionOrigin_XBox360_LeftStick_DPadNorth", "value":"167" },
+        { "name":"k_EInputActionOrigin_XBox360_LeftStick_DPadSouth", "value":"168" },
+        { "name":"k_EInputActionOrigin_XBox360_LeftStick_DPadWest", "value":"169" },
+        { "name":"k_EInputActionOrigin_XBox360_LeftStick_DPadEast", "value":"170" },
+        { "name":"k_EInputActionOrigin_XBox360_RightStick_Move", "value":"171" },
+        { "name":"k_EInputActionOrigin_XBox360_RightStick_Click", "value":"172" },
+        { "name":"k_EInputActionOrigin_XBox360_RightStick_DPadNorth", "value":"173" },
+        { "name":"k_EInputActionOrigin_XBox360_RightStick_DPadSouth", "value":"174" },
+        { "name":"k_EInputActionOrigin_XBox360_RightStick_DPadWest", "value":"175" },
+        { "name":"k_EInputActionOrigin_XBox360_RightStick_DPadEast", "value":"176" },
+        { "name":"k_EInputActionOrigin_XBox360_DPad_North", "value":"177" },
+        { "name":"k_EInputActionOrigin_XBox360_DPad_South", "value":"178" },
+        { "name":"k_EInputActionOrigin_XBox360_DPad_West", "value":"179" },
+        { "name":"k_EInputActionOrigin_XBox360_DPad_East", "value":"180" },
+        { "name":"k_EInputActionOrigin_XBox360_DPad_Move", "value":"181" },
+        { "name":"k_EInputActionOrigin_XBox360_Reserved1", "value":"182" },
+        { "name":"k_EInputActionOrigin_XBox360_Reserved2", "value":"183" },
+        { "name":"k_EInputActionOrigin_XBox360_Reserved3", "value":"184" },
+        { "name":"k_EInputActionOrigin_XBox360_Reserved4", "value":"185" },
+        { "name":"k_EInputActionOrigin_XBox360_Reserved5", "value":"186" },
+        { "name":"k_EInputActionOrigin_XBox360_Reserved6", "value":"187" },
+        { "name":"k_EInputActionOrigin_XBox360_Reserved7", "value":"188" },
+        { "name":"k_EInputActionOrigin_XBox360_Reserved8", "value":"189" },
+        { "name":"k_EInputActionOrigin_XBox360_Reserved9", "value":"190" },
+        { "name":"k_EInputActionOrigin_XBox360_Reserved10", "value":"191" },
+        { "name":"k_EInputActionOrigin_Switch_A", "value":"192" },
+        { "name":"k_EInputActionOrigin_Switch_B", "value":"193" },
+        { "name":"k_EInputActionOrigin_Switch_X", "value":"194" },
+        { "name":"k_EInputActionOrigin_Switch_Y", "value":"195" },
+        { "name":"k_EInputActionOrigin_Switch_LeftBumper", "value":"196" },
+        { "name":"k_EInputActionOrigin_Switch_RightBumper", "value":"197" },
+        { "name":"k_EInputActionOrigin_Switch_Plus", "value":"198" },
+        { "name":"k_EInputActionOrigin_Switch_Minus", "value":"199" },
+        { "name":"k_EInputActionOrigin_Switch_Capture", "value":"200" },
+        { "name":"k_EInputActionOrigin_Switch_LeftTrigger_Pull", "value":"201" },
+        { "name":"k_EInputActionOrigin_Switch_LeftTrigger_Click", "value":"202" },
+        { "name":"k_EInputActionOrigin_Switch_RightTrigger_Pull", "value":"203" },
+        { "name":"k_EInputActionOrigin_Switch_RightTrigger_Click", "value":"204" },
+        { "name":"k_EInputActionOrigin_Switch_LeftStick_Move", "value":"205" },
+        { "name":"k_EInputActionOrigin_Switch_LeftStick_Click", "value":"206" },
+        { "name":"k_EInputActionOrigin_Switch_LeftStick_DPadNorth", "value":"207" },
+        { "name":"k_EInputActionOrigin_Switch_LeftStick_DPadSouth", "value":"208" },
+        { "name":"k_EInputActionOrigin_Switch_LeftStick_DPadWest", "value":"209" },
+        { "name":"k_EInputActionOrigin_Switch_LeftStick_DPadEast", "value":"210" },
+        { "name":"k_EInputActionOrigin_Switch_RightStick_Move", "value":"211" },
+        { "name":"k_EInputActionOrigin_Switch_RightStick_Click", "value":"212" },
+        { "name":"k_EInputActionOrigin_Switch_RightStick_DPadNorth", "value":"213" },
+        { "name":"k_EInputActionOrigin_Switch_RightStick_DPadSouth", "value":"214" },
+        { "name":"k_EInputActionOrigin_Switch_RightStick_DPadWest", "value":"215" },
+        { "name":"k_EInputActionOrigin_Switch_RightStick_DPadEast", "value":"216" },
+        { "name":"k_EInputActionOrigin_Switch_DPad_North", "value":"217" },
+        { "name":"k_EInputActionOrigin_Switch_DPad_South", "value":"218" },
+        { "name":"k_EInputActionOrigin_Switch_DPad_West", "value":"219" },
+        { "name":"k_EInputActionOrigin_Switch_DPad_East", "value":"220" },
+        { "name":"k_EInputActionOrigin_Switch_ProGyro_Move", "value":"221" },
+        { "name":"k_EInputActionOrigin_Switch_ProGyro_Pitch", "value":"222" },
+        { "name":"k_EInputActionOrigin_Switch_ProGyro_Yaw", "value":"223" },
+        { "name":"k_EInputActionOrigin_Switch_ProGyro_Roll", "value":"224" },
+        { "name":"k_EInputActionOrigin_Switch_DPad_Move", "value":"225" },
+        { "name":"k_EInputActionOrigin_Switch_Reserved1", "value":"226" },
+        { "name":"k_EInputActionOrigin_Switch_Reserved2", "value":"227" },
+        { "name":"k_EInputActionOrigin_Switch_Reserved3", "value":"228" },
+        { "name":"k_EInputActionOrigin_Switch_Reserved4", "value":"229" },
+        { "name":"k_EInputActionOrigin_Switch_Reserved5", "value":"230" },
+        { "name":"k_EInputActionOrigin_Switch_Reserved6", "value":"231" },
+        { "name":"k_EInputActionOrigin_Switch_Reserved7", "value":"232" },
+        { "name":"k_EInputActionOrigin_Switch_Reserved8", "value":"233" },
+        { "name":"k_EInputActionOrigin_Switch_Reserved9", "value":"234" },
+        { "name":"k_EInputActionOrigin_Switch_Reserved10", "value":"235" },
+        { "name":"k_EInputActionOrigin_Switch_RightGyro_Move", "value":"236" },
+        { "name":"k_EInputActionOrigin_Switch_RightGyro_Pitch", "value":"237" },
+        { "name":"k_EInputActionOrigin_Switch_RightGyro_Yaw", "value":"238" },
+        { "name":"k_EInputActionOrigin_Switch_RightGyro_Roll", "value":"239" },
+        { "name":"k_EInputActionOrigin_Switch_LeftGyro_Move", "value":"240" },
+        { "name":"k_EInputActionOrigin_Switch_LeftGyro_Pitch", "value":"241" },
+        { "name":"k_EInputActionOrigin_Switch_LeftGyro_Yaw", "value":"242" },
+        { "name":"k_EInputActionOrigin_Switch_LeftGyro_Roll", "value":"243" },
+        { "name":"k_EInputActionOrigin_Switch_LeftGrip_Lower", "value":"244" },
+        { "name":"k_EInputActionOrigin_Switch_LeftGrip_Upper", "value":"245" },
+        { "name":"k_EInputActionOrigin_Switch_RightGrip_Lower", "value":"246" },
+        { "name":"k_EInputActionOrigin_Switch_RightGrip_Upper", "value":"247" },
+        { "name":"k_EInputActionOrigin_Switch_Reserved11", "value":"248" },
+        { "name":"k_EInputActionOrigin_Switch_Reserved12", "value":"249" },
+        { "name":"k_EInputActionOrigin_Switch_Reserved13", "value":"250" },
+        { "name":"k_EInputActionOrigin_Switch_Reserved14", "value":"251" },
+        { "name":"k_EInputActionOrigin_Switch_Reserved15", "value":"252" },
+        { "name":"k_EInputActionOrigin_Switch_Reserved16", "value":"253" },
+        { "name":"k_EInputActionOrigin_Switch_Reserved17", "value":"254" },
+        { "name":"k_EInputActionOrigin_Switch_Reserved18", "value":"255" },
+        { "name":"k_EInputActionOrigin_Switch_Reserved19", "value":"256" },
+        { "name":"k_EInputActionOrigin_Switch_Reserved20", "value":"257" },
+        { "name":"k_EInputActionOrigin_Count", "value":"258" },
+        { "name":"k_EInputActionOrigin_MaximumPossibleValue", "value":"32767" }
+      ]
+    },
+    {
+      "enumname": "EXboxOrigin",
+      "values": [
+        { "name":"k_EXboxOrigin_A", "value":"0" },
+        { "name":"k_EXboxOrigin_B", "value":"1" },
+        { "name":"k_EXboxOrigin_X", "value":"2" },
+        { "name":"k_EXboxOrigin_Y", "value":"3" },
+        { "name":"k_EXboxOrigin_LeftBumper", "value":"4" },
+        { "name":"k_EXboxOrigin_RightBumper", "value":"5" },
+        { "name":"k_EXboxOrigin_Menu", "value":"6" },
+        { "name":"k_EXboxOrigin_View", "value":"7" },
+        { "name":"k_EXboxOrigin_LeftTrigger_Pull", "value":"8" },
+        { "name":"k_EXboxOrigin_LeftTrigger_Click", "value":"9" },
+        { "name":"k_EXboxOrigin_RightTrigger_Pull", "value":"10" },
+        { "name":"k_EXboxOrigin_RightTrigger_Click", "value":"11" },
+        { "name":"k_EXboxOrigin_LeftStick_Move", "value":"12" },
+        { "name":"k_EXboxOrigin_LeftStick_Click", "value":"13" },
+        { "name":"k_EXboxOrigin_LeftStick_DPadNorth", "value":"14" },
+        { "name":"k_EXboxOrigin_LeftStick_DPadSouth", "value":"15" },
+        { "name":"k_EXboxOrigin_LeftStick_DPadWest", "value":"16" },
+        { "name":"k_EXboxOrigin_LeftStick_DPadEast", "value":"17" },
+        { "name":"k_EXboxOrigin_RightStick_Move", "value":"18" },
+        { "name":"k_EXboxOrigin_RightStick_Click", "value":"19" },
+        { "name":"k_EXboxOrigin_RightStick_DPadNorth", "value":"20" },
+        { "name":"k_EXboxOrigin_RightStick_DPadSouth", "value":"21" },
+        { "name":"k_EXboxOrigin_RightStick_DPadWest", "value":"22" },
+        { "name":"k_EXboxOrigin_RightStick_DPadEast", "value":"23" },
+        { "name":"k_EXboxOrigin_DPad_North", "value":"24" },
+        { "name":"k_EXboxOrigin_DPad_South", "value":"25" },
+        { "name":"k_EXboxOrigin_DPad_West", "value":"26" },
+        { "name":"k_EXboxOrigin_DPad_East", "value":"27" },
+        { "name":"k_EXboxOrigin_Count", "value":"28" }
+      ]
+    },
+    {
+      "enumname": "ESteamControllerPad",
+      "values": [
+        { "name":"k_ESteamControllerPad_Left", "value":"0" },
+        { "name":"k_ESteamControllerPad_Right", "value":"1" }
+      ]
+    },
+    {
+      "enumname": "ESteamInputType",
+      "values": [
+        { "name":"k_ESteamInputType_Unknown", "value":"0" },
+        { "name":"k_ESteamInputType_SteamController", "value":"1" },
+        { "name":"k_ESteamInputType_XBox360Controller", "value":"2" },
+        { "name":"k_ESteamInputType_XBoxOneController", "value":"3" },
+        { "name":"k_ESteamInputType_GenericGamepad", "value":"4" },
+        { "name":"k_ESteamInputType_PS4Controller", "value":"5" },
+        { "name":"k_ESteamInputType_AppleMFiController", "value":"6" },
+        { "name":"k_ESteamInputType_AndroidController", "value":"7" },
+        { "name":"k_ESteamInputType_SwitchJoyConPair", "value":"8" },
+        { "name":"k_ESteamInputType_SwitchJoyConSingle", "value":"9" },
+        { "name":"k_ESteamInputType_SwitchProController", "value":"10" },
+        { "name":"k_ESteamInputType_MobileTouch", "value":"11" },
+        { "name":"k_ESteamInputType_PS3Controller", "value":"12" },
+        { "name":"k_ESteamInputType_Count", "value":"13" },
+        { "name":"k_ESteamInputType_MaximumPossibleValue", "value":"255" }
+      ]
+    },
+    {
+      "enumname": "ESteamInputLEDFlag",
+      "values": [
+        { "name":"k_ESteamInputLEDFlag_SetColor", "value":"0" },
+        { "name":"k_ESteamInputLEDFlag_RestoreUserDefault", "value":"1" }
+      ]
+    },
+    {
+      "enumname": "EControllerActionOrigin",
+      "values": [
+        { "name":"k_EControllerActionOrigin_None", "value":"0" },
+        { "name":"k_EControllerActionOrigin_A", "value":"1" },
+        { "name":"k_EControllerActionOrigin_B", "value":"2" },
+        { "name":"k_EControllerActionOrigin_X", "value":"3" },
+        { "name":"k_EControllerActionOrigin_Y", "value":"4" },
+        { "name":"k_EControllerActionOrigin_LeftBumper", "value":"5" },
+        { "name":"k_EControllerActionOrigin_RightBumper", "value":"6" },
+        { "name":"k_EControllerActionOrigin_LeftGrip", "value":"7" },
+        { "name":"k_EControllerActionOrigin_RightGrip", "value":"8" },
+        { "name":"k_EControllerActionOrigin_Start", "value":"9" },
+        { "name":"k_EControllerActionOrigin_Back", "value":"10" },
+        { "name":"k_EControllerActionOrigin_LeftPad_Touch", "value":"11" },
+        { "name":"k_EControllerActionOrigin_LeftPad_Swipe", "value":"12" },
+        { "name":"k_EControllerActionOrigin_LeftPad_Click", "value":"13" },
+        { "name":"k_EControllerActionOrigin_LeftPad_DPadNorth", "value":"14" },
+        { "name":"k_EControllerActionOrigin_LeftPad_DPadSouth", "value":"15" },
+        { "name":"k_EControllerActionOrigin_LeftPad_DPadWest", "value":"16" },
+        { "name":"k_EControllerActionOrigin_LeftPad_DPadEast", "value":"17" },
+        { "name":"k_EControllerActionOrigin_RightPad_Touch", "value":"18" },
+        { "name":"k_EControllerActionOrigin_RightPad_Swipe", "value":"19" },
+        { "name":"k_EControllerActionOrigin_RightPad_Click", "value":"20" },
+        { "name":"k_EControllerActionOrigin_RightPad_DPadNorth", "value":"21" },
+        { "name":"k_EControllerActionOrigin_RightPad_DPadSouth", "value":"22" },
+        { "name":"k_EControllerActionOrigin_RightPad_DPadWest", "value":"23" },
+        { "name":"k_EControllerActionOrigin_RightPad_DPadEast", "value":"24" },
+        { "name":"k_EControllerActionOrigin_LeftTrigger_Pull", "value":"25" },
+        { "name":"k_EControllerActionOrigin_LeftTrigger_Click", "value":"26" },
+        { "name":"k_EControllerActionOrigin_RightTrigger_Pull", "value":"27" },
+        { "name":"k_EControllerActionOrigin_RightTrigger_Click", "value":"28" },
+        { "name":"k_EControllerActionOrigin_LeftStick_Move", "value":"29" },
+        { "name":"k_EControllerActionOrigin_LeftStick_Click", "value":"30" },
+        { "name":"k_EControllerActionOrigin_LeftStick_DPadNorth", "value":"31" },
+        { "name":"k_EControllerActionOrigin_LeftStick_DPadSouth", "value":"32" },
+        { "name":"k_EControllerActionOrigin_LeftStick_DPadWest", "value":"33" },
+        { "name":"k_EControllerActionOrigin_LeftStick_DPadEast", "value":"34" },
+        { "name":"k_EControllerActionOrigin_Gyro_Move", "value":"35" },
+        { "name":"k_EControllerActionOrigin_Gyro_Pitch", "value":"36" },
+        { "name":"k_EControllerActionOrigin_Gyro_Yaw", "value":"37" },
+        { "name":"k_EControllerActionOrigin_Gyro_Roll", "value":"38" },
+        { "name":"k_EControllerActionOrigin_PS4_X", "value":"39" },
+        { "name":"k_EControllerActionOrigin_PS4_Circle", "value":"40" },
+        { "name":"k_EControllerActionOrigin_PS4_Triangle", "value":"41" },
+        { "name":"k_EControllerActionOrigin_PS4_Square", "value":"42" },
+        { "name":"k_EControllerActionOrigin_PS4_LeftBumper", "value":"43" },
+        { "name":"k_EControllerActionOrigin_PS4_RightBumper", "value":"44" },
+        { "name":"k_EControllerActionOrigin_PS4_Options", "value":"45" },
+        { "name":"k_EControllerActionOrigin_PS4_Share", "value":"46" },
+        { "name":"k_EControllerActionOrigin_PS4_LeftPad_Touch", "value":"47" },
+        { "name":"k_EControllerActionOrigin_PS4_LeftPad_Swipe", "value":"48" },
+        { "name":"k_EControllerActionOrigin_PS4_LeftPad_Click", "value":"49" },
+        { "name":"k_EControllerActionOrigin_PS4_LeftPad_DPadNorth", "value":"50" },
+        { "name":"k_EControllerActionOrigin_PS4_LeftPad_DPadSouth", "value":"51" },
+        { "name":"k_EControllerActionOrigin_PS4_LeftPad_DPadWest", "value":"52" },
+        { "name":"k_EControllerActionOrigin_PS4_LeftPad_DPadEast", "value":"53" },
+        { "name":"k_EControllerActionOrigin_PS4_RightPad_Touch", "value":"54" },
+        { "name":"k_EControllerActionOrigin_PS4_RightPad_Swipe", "value":"55" },
+        { "name":"k_EControllerActionOrigin_PS4_RightPad_Click", "value":"56" },
+        { "name":"k_EControllerActionOrigin_PS4_RightPad_DPadNorth", "value":"57" },
+        { "name":"k_EControllerActionOrigin_PS4_RightPad_DPadSouth", "value":"58" },
+        { "name":"k_EControllerActionOrigin_PS4_RightPad_DPadWest", "value":"59" },
+        { "name":"k_EControllerActionOrigin_PS4_RightPad_DPadEast", "value":"60" },
+        { "name":"k_EControllerActionOrigin_PS4_CenterPad_Touch", "value":"61" },
+        { "name":"k_EControllerActionOrigin_PS4_CenterPad_Swipe", "value":"62" },
+        { "name":"k_EControllerActionOrigin_PS4_CenterPad_Click", "value":"63" },
+        { "name":"k_EControllerActionOrigin_PS4_CenterPad_DPadNorth", "value":"64" },
+        { "name":"k_EControllerActionOrigin_PS4_CenterPad_DPadSouth", "value":"65" },
+        { "name":"k_EControllerActionOrigin_PS4_CenterPad_DPadWest", "value":"66" },
+        { "name":"k_EControllerActionOrigin_PS4_CenterPad_DPadEast", "value":"67" },
+        { "name":"k_EControllerActionOrigin_PS4_LeftTrigger_Pull", "value":"68" },
+        { "name":"k_EControllerActionOrigin_PS4_LeftTrigger_Click", "value":"69" },
+        { "name":"k_EControllerActionOrigin_PS4_RightTrigger_Pull", "value":"70" },
+        { "name":"k_EControllerActionOrigin_PS4_RightTrigger_Click", "value":"71" },
+        { "name":"k_EControllerActionOrigin_PS4_LeftStick_Move", "value":"72" },
+        { "name":"k_EControllerActionOrigin_PS4_LeftStick_Click", "value":"73" },
+        { "name":"k_EControllerActionOrigin_PS4_LeftStick_DPadNorth", "value":"74" },
+        { "name":"k_EControllerActionOrigin_PS4_LeftStick_DPadSouth", "value":"75" },
+        { "name":"k_EControllerActionOrigin_PS4_LeftStick_DPadWest", "value":"76" },
+        { "name":"k_EControllerActionOrigin_PS4_LeftStick_DPadEast", "value":"77" },
+        { "name":"k_EControllerActionOrigin_PS4_RightStick_Move", "value":"78" },
+        { "name":"k_EControllerActionOrigin_PS4_RightStick_Click", "value":"79" },
+        { "name":"k_EControllerActionOrigin_PS4_RightStick_DPadNorth", "value":"80" },
+        { "name":"k_EControllerActionOrigin_PS4_RightStick_DPadSouth", "value":"81" },
+        { "name":"k_EControllerActionOrigin_PS4_RightStick_DPadWest", "value":"82" },
+        { "name":"k_EControllerActionOrigin_PS4_RightStick_DPadEast", "value":"83" },
+        { "name":"k_EControllerActionOrigin_PS4_DPad_North", "value":"84" },
+        { "name":"k_EControllerActionOrigin_PS4_DPad_South", "value":"85" },
+        { "name":"k_EControllerActionOrigin_PS4_DPad_West", "value":"86" },
+        { "name":"k_EControllerActionOrigin_PS4_DPad_East", "value":"87" },
+        { "name":"k_EControllerActionOrigin_PS4_Gyro_Move", "value":"88" },
+        { "name":"k_EControllerActionOrigin_PS4_Gyro_Pitch", "value":"89" },
+        { "name":"k_EControllerActionOrigin_PS4_Gyro_Yaw", "value":"90" },
+        { "name":"k_EControllerActionOrigin_PS4_Gyro_Roll", "value":"91" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_A", "value":"92" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_B", "value":"93" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_X", "value":"94" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_Y", "value":"95" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_LeftBumper", "value":"96" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_RightBumper", "value":"97" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_Menu", "value":"98" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_View", "value":"99" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_LeftTrigger_Pull", "value":"100" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_LeftTrigger_Click", "value":"101" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_RightTrigger_Pull", "value":"102" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_RightTrigger_Click", "value":"103" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_LeftStick_Move", "value":"104" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_LeftStick_Click", "value":"105" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_LeftStick_DPadNorth", "value":"106" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_LeftStick_DPadSouth", "value":"107" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_LeftStick_DPadWest", "value":"108" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_LeftStick_DPadEast", "value":"109" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_RightStick_Move", "value":"110" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_RightStick_Click", "value":"111" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_RightStick_DPadNorth", "value":"112" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_RightStick_DPadSouth", "value":"113" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_RightStick_DPadWest", "value":"114" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_RightStick_DPadEast", "value":"115" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_DPad_North", "value":"116" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_DPad_South", "value":"117" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_DPad_West", "value":"118" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_DPad_East", "value":"119" },
+        { "name":"k_EControllerActionOrigin_XBox360_A", "value":"120" },
+        { "name":"k_EControllerActionOrigin_XBox360_B", "value":"121" },
+        { "name":"k_EControllerActionOrigin_XBox360_X", "value":"122" },
+        { "name":"k_EControllerActionOrigin_XBox360_Y", "value":"123" },
+        { "name":"k_EControllerActionOrigin_XBox360_LeftBumper", "value":"124" },
+        { "name":"k_EControllerActionOrigin_XBox360_RightBumper", "value":"125" },
+        { "name":"k_EControllerActionOrigin_XBox360_Start", "value":"126" },
+        { "name":"k_EControllerActionOrigin_XBox360_Back", "value":"127" },
+        { "name":"k_EControllerActionOrigin_XBox360_LeftTrigger_Pull", "value":"128" },
+        { "name":"k_EControllerActionOrigin_XBox360_LeftTrigger_Click", "value":"129" },
+        { "name":"k_EControllerActionOrigin_XBox360_RightTrigger_Pull", "value":"130" },
+        { "name":"k_EControllerActionOrigin_XBox360_RightTrigger_Click", "value":"131" },
+        { "name":"k_EControllerActionOrigin_XBox360_LeftStick_Move", "value":"132" },
+        { "name":"k_EControllerActionOrigin_XBox360_LeftStick_Click", "value":"133" },
+        { "name":"k_EControllerActionOrigin_XBox360_LeftStick_DPadNorth", "value":"134" },
+        { "name":"k_EControllerActionOrigin_XBox360_LeftStick_DPadSouth", "value":"135" },
+        { "name":"k_EControllerActionOrigin_XBox360_LeftStick_DPadWest", "value":"136" },
+        { "name":"k_EControllerActionOrigin_XBox360_LeftStick_DPadEast", "value":"137" },
+        { "name":"k_EControllerActionOrigin_XBox360_RightStick_Move", "value":"138" },
+        { "name":"k_EControllerActionOrigin_XBox360_RightStick_Click", "value":"139" },
+        { "name":"k_EControllerActionOrigin_XBox360_RightStick_DPadNorth", "value":"140" },
+        { "name":"k_EControllerActionOrigin_XBox360_RightStick_DPadSouth", "value":"141" },
+        { "name":"k_EControllerActionOrigin_XBox360_RightStick_DPadWest", "value":"142" },
+        { "name":"k_EControllerActionOrigin_XBox360_RightStick_DPadEast", "value":"143" },
+        { "name":"k_EControllerActionOrigin_XBox360_DPad_North", "value":"144" },
+        { "name":"k_EControllerActionOrigin_XBox360_DPad_South", "value":"145" },
+        { "name":"k_EControllerActionOrigin_XBox360_DPad_West", "value":"146" },
+        { "name":"k_EControllerActionOrigin_XBox360_DPad_East", "value":"147" },
+        { "name":"k_EControllerActionOrigin_SteamV2_A", "value":"148" },
+        { "name":"k_EControllerActionOrigin_SteamV2_B", "value":"149" },
+        { "name":"k_EControllerActionOrigin_SteamV2_X", "value":"150" },
+        { "name":"k_EControllerActionOrigin_SteamV2_Y", "value":"151" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftBumper", "value":"152" },
+        { "name":"k_EControllerActionOrigin_SteamV2_RightBumper", "value":"153" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftGrip_Lower", "value":"154" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftGrip_Upper", "value":"155" },
+        { "name":"k_EControllerActionOrigin_SteamV2_RightGrip_Lower", "value":"156" },
+        { "name":"k_EControllerActionOrigin_SteamV2_RightGrip_Upper", "value":"157" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftBumper_Pressure", "value":"158" },
+        { "name":"k_EControllerActionOrigin_SteamV2_RightBumper_Pressure", "value":"159" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftGrip_Pressure", "value":"160" },
+        { "name":"k_EControllerActionOrigin_SteamV2_RightGrip_Pressure", "value":"161" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftGrip_Upper_Pressure", "value":"162" },
+        { "name":"k_EControllerActionOrigin_SteamV2_RightGrip_Upper_Pressure", "value":"163" },
+        { "name":"k_EControllerActionOrigin_SteamV2_Start", "value":"164" },
+        { "name":"k_EControllerActionOrigin_SteamV2_Back", "value":"165" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftPad_Touch", "value":"166" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftPad_Swipe", "value":"167" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftPad_Click", "value":"168" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftPad_Pressure", "value":"169" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftPad_DPadNorth", "value":"170" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftPad_DPadSouth", "value":"171" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftPad_DPadWest", "value":"172" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftPad_DPadEast", "value":"173" },
+        { "name":"k_EControllerActionOrigin_SteamV2_RightPad_Touch", "value":"174" },
+        { "name":"k_EControllerActionOrigin_SteamV2_RightPad_Swipe", "value":"175" },
+        { "name":"k_EControllerActionOrigin_SteamV2_RightPad_Click", "value":"176" },
+        { "name":"k_EControllerActionOrigin_SteamV2_RightPad_Pressure", "value":"177" },
+        { "name":"k_EControllerActionOrigin_SteamV2_RightPad_DPadNorth", "value":"178" },
+        { "name":"k_EControllerActionOrigin_SteamV2_RightPad_DPadSouth", "value":"179" },
+        { "name":"k_EControllerActionOrigin_SteamV2_RightPad_DPadWest", "value":"180" },
+        { "name":"k_EControllerActionOrigin_SteamV2_RightPad_DPadEast", "value":"181" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftTrigger_Pull", "value":"182" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftTrigger_Click", "value":"183" },
+        { "name":"k_EControllerActionOrigin_SteamV2_RightTrigger_Pull", "value":"184" },
+        { "name":"k_EControllerActionOrigin_SteamV2_RightTrigger_Click", "value":"185" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftStick_Move", "value":"186" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftStick_Click", "value":"187" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftStick_DPadNorth", "value":"188" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftStick_DPadSouth", "value":"189" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftStick_DPadWest", "value":"190" },
+        { "name":"k_EControllerActionOrigin_SteamV2_LeftStick_DPadEast", "value":"191" },
+        { "name":"k_EControllerActionOrigin_SteamV2_Gyro_Move", "value":"192" },
+        { "name":"k_EControllerActionOrigin_SteamV2_Gyro_Pitch", "value":"193" },
+        { "name":"k_EControllerActionOrigin_SteamV2_Gyro_Yaw", "value":"194" },
+        { "name":"k_EControllerActionOrigin_SteamV2_Gyro_Roll", "value":"195" },
+        { "name":"k_EControllerActionOrigin_Switch_A", "value":"196" },
+        { "name":"k_EControllerActionOrigin_Switch_B", "value":"197" },
+        { "name":"k_EControllerActionOrigin_Switch_X", "value":"198" },
+        { "name":"k_EControllerActionOrigin_Switch_Y", "value":"199" },
+        { "name":"k_EControllerActionOrigin_Switch_LeftBumper", "value":"200" },
+        { "name":"k_EControllerActionOrigin_Switch_RightBumper", "value":"201" },
+        { "name":"k_EControllerActionOrigin_Switch_Plus", "value":"202" },
+        { "name":"k_EControllerActionOrigin_Switch_Minus", "value":"203" },
+        { "name":"k_EControllerActionOrigin_Switch_Capture", "value":"204" },
+        { "name":"k_EControllerActionOrigin_Switch_LeftTrigger_Pull", "value":"205" },
+        { "name":"k_EControllerActionOrigin_Switch_LeftTrigger_Click", "value":"206" },
+        { "name":"k_EControllerActionOrigin_Switch_RightTrigger_Pull", "value":"207" },
+        { "name":"k_EControllerActionOrigin_Switch_RightTrigger_Click", "value":"208" },
+        { "name":"k_EControllerActionOrigin_Switch_LeftStick_Move", "value":"209" },
+        { "name":"k_EControllerActionOrigin_Switch_LeftStick_Click", "value":"210" },
+        { "name":"k_EControllerActionOrigin_Switch_LeftStick_DPadNorth", "value":"211" },
+        { "name":"k_EControllerActionOrigin_Switch_LeftStick_DPadSouth", "value":"212" },
+        { "name":"k_EControllerActionOrigin_Switch_LeftStick_DPadWest", "value":"213" },
+        { "name":"k_EControllerActionOrigin_Switch_LeftStick_DPadEast", "value":"214" },
+        { "name":"k_EControllerActionOrigin_Switch_RightStick_Move", "value":"215" },
+        { "name":"k_EControllerActionOrigin_Switch_RightStick_Click", "value":"216" },
+        { "name":"k_EControllerActionOrigin_Switch_RightStick_DPadNorth", "value":"217" },
+        { "name":"k_EControllerActionOrigin_Switch_RightStick_DPadSouth", "value":"218" },
+        { "name":"k_EControllerActionOrigin_Switch_RightStick_DPadWest", "value":"219" },
+        { "name":"k_EControllerActionOrigin_Switch_RightStick_DPadEast", "value":"220" },
+        { "name":"k_EControllerActionOrigin_Switch_DPad_North", "value":"221" },
+        { "name":"k_EControllerActionOrigin_Switch_DPad_South", "value":"222" },
+        { "name":"k_EControllerActionOrigin_Switch_DPad_West", "value":"223" },
+        { "name":"k_EControllerActionOrigin_Switch_DPad_East", "value":"224" },
+        { "name":"k_EControllerActionOrigin_Switch_ProGyro_Move", "value":"225" },
+        { "name":"k_EControllerActionOrigin_Switch_ProGyro_Pitch", "value":"226" },
+        { "name":"k_EControllerActionOrigin_Switch_ProGyro_Yaw", "value":"227" },
+        { "name":"k_EControllerActionOrigin_Switch_ProGyro_Roll", "value":"228" },
+        { "name":"k_EControllerActionOrigin_Switch_RightGyro_Move", "value":"229" },
+        { "name":"k_EControllerActionOrigin_Switch_RightGyro_Pitch", "value":"230" },
+        { "name":"k_EControllerActionOrigin_Switch_RightGyro_Yaw", "value":"231" },
+        { "name":"k_EControllerActionOrigin_Switch_RightGyro_Roll", "value":"232" },
+        { "name":"k_EControllerActionOrigin_Switch_LeftGyro_Move", "value":"233" },
+        { "name":"k_EControllerActionOrigin_Switch_LeftGyro_Pitch", "value":"234" },
+        { "name":"k_EControllerActionOrigin_Switch_LeftGyro_Yaw", "value":"235" },
+        { "name":"k_EControllerActionOrigin_Switch_LeftGyro_Roll", "value":"236" },
+        { "name":"k_EControllerActionOrigin_Switch_LeftGrip_Lower", "value":"237" },
+        { "name":"k_EControllerActionOrigin_Switch_LeftGrip_Upper", "value":"238" },
+        { "name":"k_EControllerActionOrigin_Switch_RightGrip_Lower", "value":"239" },
+        { "name":"k_EControllerActionOrigin_Switch_RightGrip_Upper", "value":"240" },
+        { "name":"k_EControllerActionOrigin_PS4_DPad_Move", "value":"241" },
+        { "name":"k_EControllerActionOrigin_XBoxOne_DPad_Move", "value":"242" },
+        { "name":"k_EControllerActionOrigin_XBox360_DPad_Move", "value":"243" },
+        { "name":"k_EControllerActionOrigin_Switch_DPad_Move", "value":"244" },
+        { "name":"k_EControllerActionOrigin_Count", "value":"245" },
+        { "name":"k_EControllerActionOrigin_MaximumPossibleValue", "value":"32767" }
+      ]
+    },
+    {
+      "enumname": "ESteamControllerLEDFlag",
+      "values": [
+        { "name":"k_ESteamControllerLEDFlag_SetColor", "value":"0" },
+        { "name":"k_ESteamControllerLEDFlag_RestoreUserDefault", "value":"1" }
+      ]
+    },
+    {
+      "enumname": "EUGCMatchingUGCType",
+      "values": [
+        { "name":"k_EUGCMatchingUGCType_Items", "value":"0" },
+        { "name":"k_EUGCMatchingUGCType_Items_Mtx", "value":"1" },
+        { "name":"k_EUGCMatchingUGCType_Items_ReadyToUse", "value":"2" },
+        { "name":"k_EUGCMatchingUGCType_Collections", "value":"3" },
+        { "name":"k_EUGCMatchingUGCType_Artwork", "value":"4" },
+        { "name":"k_EUGCMatchingUGCType_Videos", "value":"5" },
+        { "name":"k_EUGCMatchingUGCType_Screenshots", "value":"6" },
+        { "name":"k_EUGCMatchingUGCType_AllGuides", "value":"7" },
+        { "name":"k_EUGCMatchingUGCType_WebGuides", "value":"8" },
+        { "name":"k_EUGCMatchingUGCType_IntegratedGuides", "value":"9" },
+        { "name":"k_EUGCMatchingUGCType_UsableInGame", "value":"10" },
+        { "name":"k_EUGCMatchingUGCType_ControllerBindings", "value":"11" },
+        { "name":"k_EUGCMatchingUGCType_GameManagedItems", "value":"12" },
+        { "name":"k_EUGCMatchingUGCType_All", "value":"-1" }
+      ]
+    },
+    {
+      "enumname": "EUserUGCList",
+      "values": [
+        { "name":"k_EUserUGCList_Published", "value":"0" },
+        { "name":"k_EUserUGCList_VotedOn", "value":"1" },
+        { "name":"k_EUserUGCList_VotedUp", "value":"2" },
+        { "name":"k_EUserUGCList_VotedDown", "value":"3" },
+        { "name":"k_EUserUGCList_WillVoteLater", "value":"4" },
+        { "name":"k_EUserUGCList_Favorited", "value":"5" },
+        { "name":"k_EUserUGCList_Subscribed", "value":"6" },
+        { "name":"k_EUserUGCList_UsedOrPlayed", "value":"7" },
+        { "name":"k_EUserUGCList_Followed", "value":"8" }
+      ]
+    },
+    {
+      "enumname": "EUserUGCListSortOrder",
+      "values": [
+        { "name":"k_EUserUGCListSortOrder_CreationOrderDesc", "value":"0" },
+        { "name":"k_EUserUGCListSortOrder_CreationOrderAsc", "value":"1" },
+        { "name":"k_EUserUGCListSortOrder_TitleAsc", "value":"2" },
+        { "name":"k_EUserUGCListSortOrder_LastUpdatedDesc", "value":"3" },
+        { "name":"k_EUserUGCListSortOrder_SubscriptionDateDesc", "value":"4" },
+        { "name":"k_EUserUGCListSortOrder_VoteScoreDesc", "value":"5" },
+        { "name":"k_EUserUGCListSortOrder_ForModeration", "value":"6" }
+      ]
+    },
+    {
+      "enumname": "EUGCQuery",
+      "values": [
+        { "name":"k_EUGCQuery_RankedByVote", "value":"0" },
+        { "name":"k_EUGCQuery_RankedByPublicationDate", "value":"1" },
+        { "name":"k_EUGCQuery_AcceptedForGameRankedByAcceptanceDate", "value":"2" },
+        { "name":"k_EUGCQuery_RankedByTrend", "value":"3" },
+        { "name":"k_EUGCQuery_FavoritedByFriendsRankedByPublicationDate", "value":"4" },
+        { "name":"k_EUGCQuery_CreatedByFriendsRankedByPublicationDate", "value":"5" },
+        { "name":"k_EUGCQuery_RankedByNumTimesReported", "value":"6" },
+        { "name":"k_EUGCQuery_CreatedByFollowedUsersRankedByPublicationDate", "value":"7" },
+        { "name":"k_EUGCQuery_NotYetRated", "value":"8" },
+        { "name":"k_EUGCQuery_RankedByTotalVotesAsc", "value":"9" },
+        { "name":"k_EUGCQuery_RankedByVotesUp", "value":"10" },
+        { "name":"k_EUGCQuery_RankedByTextSearch", "value":"11" },
+        { "name":"k_EUGCQuery_RankedByTotalUniqueSubscriptions", "value":"12" },
+        { "name":"k_EUGCQuery_RankedByPlaytimeTrend", "value":"13" },
+        { "name":"k_EUGCQuery_RankedByTotalPlaytime", "value":"14" },
+        { "name":"k_EUGCQuery_RankedByAveragePlaytimeTrend", "value":"15" },
+        { "name":"k_EUGCQuery_RankedByLifetimeAveragePlaytime", "value":"16" },
+        { "name":"k_EUGCQuery_RankedByPlaytimeSessionsTrend", "value":"17" },
+        { "name":"k_EUGCQuery_RankedByLifetimePlaytimeSessions", "value":"18" }
+      ]
+    },
+    {
+      "enumname": "EItemUpdateStatus",
+      "values": [
+        { "name":"k_EItemUpdateStatusInvalid", "value":"0" },
+        { "name":"k_EItemUpdateStatusPreparingConfig", "value":"1" },
+        { "name":"k_EItemUpdateStatusPreparingContent", "value":"2" },
+        { "name":"k_EItemUpdateStatusUploadingContent", "value":"3" },
+        { "name":"k_EItemUpdateStatusUploadingPreviewFile", "value":"4" },
+        { "name":"k_EItemUpdateStatusCommittingChanges", "value":"5" }
+      ]
+    },
+    {
+      "enumname": "EItemState",
+      "values": [
+        { "name":"k_EItemStateNone", "value":"0" },
+        { "name":"k_EItemStateSubscribed", "value":"1" },
+        { "name":"k_EItemStateLegacyItem", "value":"2" },
+        { "name":"k_EItemStateInstalled", "value":"4" },
+        { "name":"k_EItemStateNeedsUpdate", "value":"8" },
+        { "name":"k_EItemStateDownloading", "value":"16" },
+        { "name":"k_EItemStateDownloadPending", "value":"32" }
+      ]
+    },
+    {
+      "enumname": "EItemStatistic",
+      "values": [
+        { "name":"k_EItemStatistic_NumSubscriptions", "value":"0" },
+        { "name":"k_EItemStatistic_NumFavorites", "value":"1" },
+        { "name":"k_EItemStatistic_NumFollowers", "value":"2" },
+        { "name":"k_EItemStatistic_NumUniqueSubscriptions", "value":"3" },
+        { "name":"k_EItemStatistic_NumUniqueFavorites", "value":"4" },
+        { "name":"k_EItemStatistic_NumUniqueFollowers", "value":"5" },
+        { "name":"k_EItemStatistic_NumUniqueWebsiteViews", "value":"6" },
+        { "name":"k_EItemStatistic_ReportScore", "value":"7" },
+        { "name":"k_EItemStatistic_NumSecondsPlayed", "value":"8" },
+        { "name":"k_EItemStatistic_NumPlaytimeSessions", "value":"9" },
+        { "name":"k_EItemStatistic_NumComments", "value":"10" },
+        { "name":"k_EItemStatistic_NumSecondsPlayedDuringTimePeriod", "value":"11" },
+        { "name":"k_EItemStatistic_NumPlaytimeSessionsDuringTimePeriod", "value":"12" }
+      ]
+    },
+    {
+      "enumname": "EItemPreviewType",
+      "values": [
+        { "name":"k_EItemPreviewType_Image", "value":"0" },
+        { "name":"k_EItemPreviewType_YouTubeVideo", "value":"1" },
+        { "name":"k_EItemPreviewType_Sketchfab", "value":"2" },
+        { "name":"k_EItemPreviewType_EnvironmentMap_HorizontalCross", "value":"3" },
+        { "name":"k_EItemPreviewType_EnvironmentMap_LatLong", "value":"4" },
+        { "name":"k_EItemPreviewType_ReservedMax", "value":"255" }
+      ]
+    },
+    {
+      "enumname": "ESteamItemFlags",
+      "values": [
+        { "name":"k_ESteamItemNoTrade", "value":"1" },
+        { "name":"k_ESteamItemRemoved", "value":"256" },
+        { "name":"k_ESteamItemConsumed", "value":"512" }
+      ]
+    },
+    {
+      "enumname": "ESteamTVRegionBehavior",
+      "values": [
+        { "name":"k_ESteamVideoRegionBehaviorInvalid", "value":"-1" },
+        { "name":"k_ESteamVideoRegionBehaviorHover", "value":"0" },
+        { "name":"k_ESteamVideoRegionBehaviorClickPopup", "value":"1" },
+        { "name":"k_ESteamVideoRegionBehaviorClickSurroundingRegion", "value":"2" }
+      ]
+    },
+    {
+      "enumname": "EParentalFeature",
+      "values": [
+        { "name":"k_EFeatureInvalid", "value":"0" },
+        { "name":"k_EFeatureStore", "value":"1" },
+        { "name":"k_EFeatureCommunity", "value":"2" },
+        { "name":"k_EFeatureProfile", "value":"3" },
+        { "name":"k_EFeatureFriends", "value":"4" },
+        { "name":"k_EFeatureNews", "value":"5" },
+        { "name":"k_EFeatureTrading", "value":"6" },
+        { "name":"k_EFeatureSettings", "value":"7" },
+        { "name":"k_EFeatureConsole", "value":"8" },
+        { "name":"k_EFeatureBrowser", "value":"9" },
+        { "name":"k_EFeatureParentalSetup", "value":"10" },
+        { "name":"k_EFeatureLibrary", "value":"11" },
+        { "name":"k_EFeatureTest", "value":"12" },
+        { "name":"k_EFeatureSiteLicense", "value":"13" },
+        { "name":"k_EFeatureMax", "value":"14" }
+      ]
+    },
+    {
+      "enumname": "ESteamDeviceFormFactor",
+      "values": [
+        { "name":"k_ESteamDeviceFormFactorUnknown", "value":"0" },
+        { "name":"k_ESteamDeviceFormFactorPhone", "value":"1" },
+        { "name":"k_ESteamDeviceFormFactorTablet", "value":"2" },
+        { "name":"k_ESteamDeviceFormFactorComputer", "value":"3" },
+        { "name":"k_ESteamDeviceFormFactorTV", "value":"4" }
+      ]
+    },
+    {
+      "enumname": "ESteamNetworkingAvailability",
+      "values": [
+        { "name":"k_ESteamNetworkingAvailability_CannotTry", "value":"-102" },
+        { "name":"k_ESteamNetworkingAvailability_Failed", "value":"-101" },
+        { "name":"k_ESteamNetworkingAvailability_Previously", "value":"-100" },
+        { "name":"k_ESteamNetworkingAvailability_Retrying", "value":"-10" },
+        { "name":"k_ESteamNetworkingAvailability_NeverTried", "value":"1" },
+        { "name":"k_ESteamNetworkingAvailability_Waiting", "value":"2" },
+        { "name":"k_ESteamNetworkingAvailability_Attempting", "value":"3" },
+        { "name":"k_ESteamNetworkingAvailability_Current", "value":"100" },
+        { "name":"k_ESteamNetworkingAvailability_Unknown", "value":"0" },
+        { "name":"k_ESteamNetworkingAvailability__Force32bit", "value":"2147483647" }
+      ]
+    },
+    {
+      "enumname": "ESteamNetworkingIdentityType",
+      "values": [
+        { "name":"k_ESteamNetworkingIdentityType_Invalid", "value":"0" },
+        { "name":"k_ESteamNetworkingIdentityType_SteamID", "value":"16" },
+        { "name":"k_ESteamNetworkingIdentityType_XboxPairwiseID", "value":"17" },
+        { "name":"k_ESteamNetworkingIdentityType_IPAddress", "value":"1" },
+        { "name":"k_ESteamNetworkingIdentityType_GenericString", "value":"2" },
+        { "name":"k_ESteamNetworkingIdentityType_GenericBytes", "value":"3" },
+        { "name":"k_ESteamNetworkingIdentityType_UnknownType", "value":"4" },
+        { "name":"k_ESteamNetworkingIdentityType__Force32bit", "value":"2147483647" }
+      ]
+    },
+    {
+      "enumname": "ESteamNetworkingConnectionState",
+      "values": [
+        { "name":"k_ESteamNetworkingConnectionState_None", "value":"0" },
+        { "name":"k_ESteamNetworkingConnectionState_Connecting", "value":"1" },
+        { "name":"k_ESteamNetworkingConnectionState_FindingRoute", "value":"2" },
+        { "name":"k_ESteamNetworkingConnectionState_Connected", "value":"3" },
+        { "name":"k_ESteamNetworkingConnectionState_ClosedByPeer", "value":"4" },
+        { "name":"k_ESteamNetworkingConnectionState_ProblemDetectedLocally", "value":"5" },
+        { "name":"k_ESteamNetworkingConnectionState_FinWait", "value":"-1" },
+        { "name":"k_ESteamNetworkingConnectionState_Linger", "value":"-2" },
+        { "name":"k_ESteamNetworkingConnectionState_Dead", "value":"-3" },
+        { "name":"k_ESteamNetworkingConnectionState__Force32Bit", "value":"2147483647" }
+      ]
+    },
+    {
+      "enumname": "ESteamNetConnectionEnd",
+      "values": [
+        { "name":"k_ESteamNetConnectionEnd_Invalid", "value":"0" },
+        { "name":"k_ESteamNetConnectionEnd_App_Min", "value":"1000" },
+        { "name":"k_ESteamNetConnectionEnd_App_Generic", "value":"1000" },
+        { "name":"k_ESteamNetConnectionEnd_App_Max", "value":"1999" },
+        { "name":"k_ESteamNetConnectionEnd_AppException_Min", "value":"2000" },
+        { "name":"k_ESteamNetConnectionEnd_AppException_Generic", "value":"2000" },
+        { "name":"k_ESteamNetConnectionEnd_AppException_Max", "value":"2999" },
+        { "name":"k_ESteamNetConnectionEnd_Local_Min", "value":"3000" },
+        { "name":"k_ESteamNetConnectionEnd_Local_OfflineMode", "value":"3001" },
+        { "name":"k_ESteamNetConnectionEnd_Local_ManyRelayConnectivity", "value":"3002" },
+        { "name":"k_ESteamNetConnectionEnd_Local_HostedServerPrimaryRelay", "value":"3003" },
+        { "name":"k_ESteamNetConnectionEnd_Local_NetworkConfig", "value":"3004" },
+        { "name":"k_ESteamNetConnectionEnd_Local_Rights", "value":"3005" },
+        { "name":"k_ESteamNetConnectionEnd_Local_Max", "value":"3999" },
+        { "name":"k_ESteamNetConnectionEnd_Remote_Min", "value":"4000" },
+        { "name":"k_ESteamNetConnectionEnd_Remote_Timeout", "value":"4001" },
+        { "name":"k_ESteamNetConnectionEnd_Remote_BadCrypt", "value":"4002" },
+        { "name":"k_ESteamNetConnectionEnd_Remote_BadCert", "value":"4003" },
+        { "name":"k_ESteamNetConnectionEnd_Remote_NotLoggedIn", "value":"4004" },
+        { "name":"k_ESteamNetConnectionEnd_Remote_NotRunningApp", "value":"4005" },
+        { "name":"k_ESteamNetConnectionEnd_Remote_BadProtocolVersion", "value":"4006" },
+        { "name":"k_ESteamNetConnectionEnd_Remote_Max", "value":"4999" },
+        { "name":"k_ESteamNetConnectionEnd_Misc_Min", "value":"5000" },
+        { "name":"k_ESteamNetConnectionEnd_Misc_Generic", "value":"5001" },
+        { "name":"k_ESteamNetConnectionEnd_Misc_InternalError", "value":"5002" },
+        { "name":"k_ESteamNetConnectionEnd_Misc_Timeout", "value":"5003" },
+        { "name":"k_ESteamNetConnectionEnd_Misc_RelayConnectivity", "value":"5004" },
+        { "name":"k_ESteamNetConnectionEnd_Misc_SteamConnectivity", "value":"5005" },
+        { "name":"k_ESteamNetConnectionEnd_Misc_NoRelaySessionsToClient", "value":"5006" },
+        { "name":"k_ESteamNetConnectionEnd_Misc_Max", "value":"5999" },
+        { "name":"k_ESteamNetConnectionEnd__Force32Bit", "value":"2147483647" }
+      ]
+    },
+    {
+      "enumname": "ESteamNetworkingConfigScope",
+      "values": [
+        { "name":"k_ESteamNetworkingConfig_Global", "value":"1" },
+        { "name":"k_ESteamNetworkingConfig_SocketsInterface", "value":"2" },
+        { "name":"k_ESteamNetworkingConfig_ListenSocket", "value":"3" },
+        { "name":"k_ESteamNetworkingConfig_Connection", "value":"4" },
+        { "name":"k_ESteamNetworkingConfigScope__Force32Bit", "value":"2147483647" }
+      ]
+    },
+    {
+      "enumname": "ESteamNetworkingConfigDataType",
+      "values": [
+        { "name":"k_ESteamNetworkingConfig_Int32", "value":"1" },
+        { "name":"k_ESteamNetworkingConfig_Int64", "value":"2" },
+        { "name":"k_ESteamNetworkingConfig_Float", "value":"3" },
+        { "name":"k_ESteamNetworkingConfig_String", "value":"4" },
+        { "name":"k_ESteamNetworkingConfig_FunctionPtr", "value":"5" },
+        { "name":"k_ESteamNetworkingConfigDataType__Force32Bit", "value":"2147483647" }
+      ]
+    },
+    {
+      "enumname": "ESteamNetworkingConfigValue",
+      "values": [
+        { "name":"k_ESteamNetworkingConfig_Invalid", "value":"0" },
+        { "name":"k_ESteamNetworkingConfig_FakePacketLoss_Send", "value":"2" },
+        { "name":"k_ESteamNetworkingConfig_FakePacketLoss_Recv", "value":"3" },
+        { "name":"k_ESteamNetworkingConfig_FakePacketLag_Send", "value":"4" },
+        { "name":"k_ESteamNetworkingConfig_FakePacketLag_Recv", "value":"5" },
+        { "name":"k_ESteamNetworkingConfig_FakePacketReorder_Send", "value":"6" },
+        { "name":"k_ESteamNetworkingConfig_FakePacketReorder_Recv", "value":"7" },
+        { "name":"k_ESteamNetworkingConfig_FakePacketReorder_Time", "value":"8" },
+        { "name":"k_ESteamNetworkingConfig_FakePacketDup_Send", "value":"26" },
+        { "name":"k_ESteamNetworkingConfig_FakePacketDup_Recv", "value":"27" },
+        { "name":"k_ESteamNetworkingConfig_FakePacketDup_TimeMax", "value":"28" },
+        { "name":"k_ESteamNetworkingConfig_TimeoutInitial", "value":"24" },
+        { "name":"k_ESteamNetworkingConfig_TimeoutConnected", "value":"25" },
+        { "name":"k_ESteamNetworkingConfig_SendBufferSize", "value":"9" },
+        { "name":"k_ESteamNetworkingConfig_SendRateMin", "value":"10" },
+        { "name":"k_ESteamNetworkingConfig_SendRateMax", "value":"11" },
+        { "name":"k_ESteamNetworkingConfig_NagleTime", "value":"12" },
+        { "name":"k_ESteamNetworkingConfig_IP_AllowWithoutAuth", "value":"23" },
+        { "name":"k_ESteamNetworkingConfig_MTU_PacketSize", "value":"32" },
+        { "name":"k_ESteamNetworkingConfig_MTU_DataSize", "value":"33" },
+        { "name":"k_ESteamNetworkingConfig_Unencrypted", "value":"34" },
+        { "name":"k_ESteamNetworkingConfig_EnumerateDevVars", "value":"35" },
+        { "name":"k_ESteamNetworkingConfig_SDRClient_ConsecutitivePingTimeoutsFailInitial", "value":"19" },
+        { "name":"k_ESteamNetworkingConfig_SDRClient_ConsecutitivePingTimeoutsFail", "value":"20" },
+        { "name":"k_ESteamNetworkingConfig_SDRClient_MinPingsBeforePingAccurate", "value":"21" },
+        { "name":"k_ESteamNetworkingConfig_SDRClient_SingleSocket", "value":"22" },
+        { "name":"k_ESteamNetworkingConfig_SDRClient_ForceRelayCluster", "value":"29" },
+        { "name":"k_ESteamNetworkingConfig_SDRClient_DebugTicketAddress", "value":"30" },
+        { "name":"k_ESteamNetworkingConfig_SDRClient_ForceProxyAddr", "value":"31" },
+        { "name":"k_ESteamNetworkingConfig_SDRClient_FakeClusterPing", "value":"36" },
+        { "name":"k_ESteamNetworkingConfig_LogLevel_AckRTT", "value":"13" },
+        { "name":"k_ESteamNetworkingConfig_LogLevel_PacketDecode", "value":"14" },
+        { "name":"k_ESteamNetworkingConfig_LogLevel_Message", "value":"15" },
+        { "name":"k_ESteamNetworkingConfig_LogLevel_PacketGaps", "value":"16" },
+        { "name":"k_ESteamNetworkingConfig_LogLevel_P2PRendezvous", "value":"17" },
+        { "name":"k_ESteamNetworkingConfig_LogLevel_SDRRelayPings", "value":"18" },
+        { "name":"k_ESteamNetworkingConfigValue__Force32Bit", "value":"2147483647" }
+      ]
+    },
+    {
+      "enumname": "ESteamNetworkingGetConfigValueResult",
+      "values": [
+        { "name":"k_ESteamNetworkingGetConfigValue_BadValue", "value":"-1" },
+        { "name":"k_ESteamNetworkingGetConfigValue_BadScopeObj", "value":"-2" },
+        { "name":"k_ESteamNetworkingGetConfigValue_BufferTooSmall", "value":"-3" },
+        { "name":"k_ESteamNetworkingGetConfigValue_OK", "value":"1" },
+        { "name":"k_ESteamNetworkingGetConfigValue_OKInherited", "value":"2" },
+        { "name":"k_ESteamNetworkingGetConfigValueResult__Force32Bit", "value":"2147483647" }
+      ]
+    },
+    {
+      "enumname": "ESteamNetworkingSocketsDebugOutputType",
+      "values": [
+        { "name":"k_ESteamNetworkingSocketsDebugOutputType_None", "value":"0" },
+        { "name":"k_ESteamNetworkingSocketsDebugOutputType_Bug", "value":"1" },
+        { "name":"k_ESteamNetworkingSocketsDebugOutputType_Error", "value":"2" },
+        { "name":"k_ESteamNetworkingSocketsDebugOutputType_Important", "value":"3" },
+        { "name":"k_ESteamNetworkingSocketsDebugOutputType_Warning", "value":"4" },
+        { "name":"k_ESteamNetworkingSocketsDebugOutputType_Msg", "value":"5" },
+        { "name":"k_ESteamNetworkingSocketsDebugOutputType_Verbose", "value":"6" },
+        { "name":"k_ESteamNetworkingSocketsDebugOutputType_Debug", "value":"7" },
+        { "name":"k_ESteamNetworkingSocketsDebugOutputType_Everything", "value":"8" },
+        { "name":"k_ESteamNetworkingSocketsDebugOutputType__Force32Bit", "value":"2147483647" }
+      ]
+    },
+    {
+      "enumname": "EServerMode",
+      "values": [
+        { "name":"eServerModeInvalid", "value":"0" },
+        { "name":"eServerModeNoAuthentication", "value":"1" },
+        { "name":"eServerModeAuthentication", "value":"2" },
+        { "name":"eServerModeAuthenticationAndSecure", "value":"3" }
+      ]
+    }
+  ],
+  "interfaces": [
+    {
+      "classname": "ISteamClient",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "CreateSteamPipe",
+          "methodname_flat": "SteamAPI_ISteamClient_CreateSteamPipe",
+          "params": [],
+          "returntype": "HSteamPipe"
+        },
+        {
+          "methodname": "BReleaseSteamPipe",
+          "methodname_flat": "SteamAPI_ISteamClient_BReleaseSteamPipe",
+          "params": [
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "ConnectToGlobalUser",
+          "methodname_flat": "SteamAPI_ISteamClient_ConnectToGlobalUser",
+          "params": [
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" }
+          ],
+          "returntype": "HSteamUser"
+        },
+        {
+          "methodname": "CreateLocalUser",
+          "methodname_flat": "SteamAPI_ISteamClient_CreateLocalUser",
+          "params": [
+            { "paramname":"phSteamPipe", "paramtype":"HSteamPipe *" },
+            { "paramname":"eAccountType", "paramtype":"EAccountType" }
+          ],
+          "returntype": "HSteamUser"
+        },
+        {
+          "methodname": "ReleaseUser",
+          "methodname_flat": "SteamAPI_ISteamClient_ReleaseUser",
+          "params": [
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"hUser", "paramtype":"HSteamUser" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetISteamUser",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamUser",
+          "params": [
+            { "paramname":"hSteamUser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamUser *"
+        },
+        {
+          "methodname": "GetISteamGameServer",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamGameServer",
+          "params": [
+            { "paramname":"hSteamUser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamGameServer *"
+        },
+        {
+          "methodname": "SetLocalIPBinding",
+          "methodname_flat": "SteamAPI_ISteamClient_SetLocalIPBinding",
+          "params": [
+            { "paramname":"unIP", "paramtype":"const SteamIPAddress_t &" },
+            { "paramname":"usPort", "paramtype":"uint16" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetISteamFriends",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamFriends",
+          "params": [
+            { "paramname":"hSteamUser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamFriends *"
+        },
+        {
+          "methodname": "GetISteamUtils",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamUtils",
+          "params": [
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamUtils *"
+        },
+        {
+          "methodname": "GetISteamMatchmaking",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamMatchmaking",
+          "params": [
+            { "paramname":"hSteamUser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamMatchmaking *"
+        },
+        {
+          "methodname": "GetISteamMatchmakingServers",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamMatchmakingServers",
+          "params": [
+            { "paramname":"hSteamUser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamMatchmakingServers *"
+        },
+        {
+          "methodname": "GetISteamGenericInterface",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamGenericInterface",
+          "params": [
+            { "paramname":"hSteamUser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "void *"
+        },
+        {
+          "methodname": "GetISteamUserStats",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamUserStats",
+          "params": [
+            { "paramname":"hSteamUser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamUserStats *"
+        },
+        {
+          "methodname": "GetISteamGameServerStats",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamGameServerStats",
+          "params": [
+            { "paramname":"hSteamuser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamGameServerStats *"
+        },
+        {
+          "methodname": "GetISteamApps",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamApps",
+          "params": [
+            { "paramname":"hSteamUser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamApps *"
+        },
+        {
+          "methodname": "GetISteamNetworking",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamNetworking",
+          "params": [
+            { "paramname":"hSteamUser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamNetworking *"
+        },
+        {
+          "methodname": "GetISteamRemoteStorage",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamRemoteStorage",
+          "params": [
+            { "paramname":"hSteamuser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamRemoteStorage *"
+        },
+        {
+          "methodname": "GetISteamScreenshots",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamScreenshots",
+          "params": [
+            { "paramname":"hSteamuser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamScreenshots *"
+        },
+        {
+          "methodname": "GetISteamGameSearch",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamGameSearch",
+          "params": [
+            { "paramname":"hSteamuser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamGameSearch *"
+        },
+        {
+          "methodname": "GetIPCCallCount",
+          "methodname_flat": "SteamAPI_ISteamClient_GetIPCCallCount",
+          "params": [],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "SetWarningMessageHook",
+          "methodname_flat": "SteamAPI_ISteamClient_SetWarningMessageHook",
+          "params": [
+            { "paramname":"pFunction", "paramtype":"SteamAPIWarningMessageHook_t" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "BShutdownIfAllPipesClosed",
+          "methodname_flat": "SteamAPI_ISteamClient_BShutdownIfAllPipesClosed",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetISteamHTTP",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamHTTP",
+          "params": [
+            { "paramname":"hSteamuser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamHTTP *"
+        },
+        {
+          "methodname": "GetISteamController",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamController",
+          "params": [
+            { "paramname":"hSteamUser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamController *"
+        },
+        {
+          "methodname": "GetISteamUGC",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamUGC",
+          "params": [
+            { "paramname":"hSteamUser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamUGC *"
+        },
+        {
+          "methodname": "GetISteamAppList",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamAppList",
+          "params": [
+            { "paramname":"hSteamUser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamAppList *"
+        },
+        {
+          "methodname": "GetISteamMusic",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamMusic",
+          "params": [
+            { "paramname":"hSteamuser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamMusic *"
+        },
+        {
+          "methodname": "GetISteamMusicRemote",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamMusicRemote",
+          "params": [
+            { "paramname":"hSteamuser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamMusicRemote *"
+        },
+        {
+          "methodname": "GetISteamHTMLSurface",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamHTMLSurface",
+          "params": [
+            { "paramname":"hSteamuser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamHTMLSurface *"
+        },
+        {
+          "methodname": "GetISteamInventory",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamInventory",
+          "params": [
+            { "paramname":"hSteamuser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamInventory *"
+        },
+        {
+          "methodname": "GetISteamVideo",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamVideo",
+          "params": [
+            { "paramname":"hSteamuser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamVideo *"
+        },
+        {
+          "methodname": "GetISteamParentalSettings",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamParentalSettings",
+          "params": [
+            { "paramname":"hSteamuser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamParentalSettings *"
+        },
+        {
+          "methodname": "GetISteamInput",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamInput",
+          "params": [
+            { "paramname":"hSteamUser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamInput *"
+        },
+        {
+          "methodname": "GetISteamParties",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamParties",
+          "params": [
+            { "paramname":"hSteamUser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamParties *"
+        },
+        {
+          "methodname": "GetISteamRemotePlay",
+          "methodname_flat": "SteamAPI_ISteamClient_GetISteamRemotePlay",
+          "params": [
+            { "paramname":"hSteamUser", "paramtype":"HSteamUser" },
+            { "paramname":"hSteamPipe", "paramtype":"HSteamPipe" },
+            { "paramname":"pchVersion", "paramtype":"const char *" }
+          ],
+          "returntype": "ISteamRemotePlay *"
+        }
+      ]
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamUser",
+          "name_flat": "SteamAPI_SteamUser_v020"
+        }
+      ],
+      "classname": "ISteamUser",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "GetHSteamUser",
+          "methodname_flat": "SteamAPI_ISteamUser_GetHSteamUser",
+          "params": [],
+          "returntype": "HSteamUser"
+        },
+        {
+          "methodname": "BLoggedOn",
+          "methodname_flat": "SteamAPI_ISteamUser_BLoggedOn",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetSteamID",
+          "methodname_flat": "SteamAPI_ISteamUser_GetSteamID",
+          "params": [],
+          "returntype": "CSteamID",
+          "returntype_flat": "uint64_steamid"
+        },
+        {
+          "methodname": "InitiateGameConnection",
+          "methodname_flat": "SteamAPI_ISteamUser_InitiateGameConnection",
+          "params": [
+            { "paramname":"pAuthBlob", "paramtype":"void *" },
+            { "paramname":"cbMaxAuthBlob", "paramtype":"int" },
+            { "paramname":"steamIDGameServer", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"unIPServer", "paramtype":"uint32" },
+            { "paramname":"usPortServer", "paramtype":"uint16" },
+            { "paramname":"bSecure", "paramtype":"bool" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "TerminateGameConnection",
+          "methodname_flat": "SteamAPI_ISteamUser_TerminateGameConnection",
+          "params": [
+            { "paramname":"unIPServer", "paramtype":"uint32" },
+            { "paramname":"usPortServer", "paramtype":"uint16" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "TrackAppUsageEvent",
+          "methodname_flat": "SteamAPI_ISteamUser_TrackAppUsageEvent",
+          "params": [
+            { "paramname":"gameID", "paramtype":"CGameID", "paramtype_flat":"uint64_gameid" },
+            { "paramname":"eAppUsageEvent", "paramtype":"int" },
+            { "paramname":"pchExtraInfo", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetUserDataFolder",
+          "methodname_flat": "SteamAPI_ISteamUser_GetUserDataFolder",
+          "params": [
+            { "paramname":"pchBuffer", "paramtype":"char *" },
+            { "paramname":"cubBuffer", "paramtype":"int" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "StartVoiceRecording",
+          "methodname_flat": "SteamAPI_ISteamUser_StartVoiceRecording",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "StopVoiceRecording",
+          "methodname_flat": "SteamAPI_ISteamUser_StopVoiceRecording",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetAvailableVoice",
+          "methodname_flat": "SteamAPI_ISteamUser_GetAvailableVoice",
+          "params": [
+            { "paramname":"pcbCompressed", "paramtype":"uint32 *" },
+            { "paramname":"pcbUncompressed_Deprecated", "paramtype":"uint32 *" },
+            { "paramname":"nUncompressedVoiceDesiredSampleRate_Deprecated", "paramtype":"uint32" }
+          ],
+          "returntype": "EVoiceResult"
+        },
+        {
+          "methodname": "GetVoice",
+          "methodname_flat": "SteamAPI_ISteamUser_GetVoice",
+          "params": [
+            { "paramname":"bWantCompressed", "paramtype":"bool" },
+            { "paramname":"pDestBuffer", "paramtype":"void *" },
+            { "paramname":"cbDestBufferSize", "paramtype":"uint32" },
+            { "paramname":"nBytesWritten", "paramtype":"uint32 *" },
+            { "paramname":"bWantUncompressed_Deprecated", "paramtype":"bool" },
+            { "paramname":"pUncompressedDestBuffer_Deprecated", "paramtype":"void *" },
+            { "paramname":"cbUncompressedDestBufferSize_Deprecated", "paramtype":"uint32" },
+            { "paramname":"nUncompressBytesWritten_Deprecated", "paramtype":"uint32 *" },
+            { "paramname":"nUncompressedVoiceDesiredSampleRate_Deprecated", "paramtype":"uint32" }
+          ],
+          "returntype": "EVoiceResult"
+        },
+        {
+          "methodname": "DecompressVoice",
+          "methodname_flat": "SteamAPI_ISteamUser_DecompressVoice",
+          "params": [
+            { "paramname":"pCompressed", "paramtype":"const void *" },
+            { "paramname":"cbCompressed", "paramtype":"uint32" },
+            { "paramname":"pDestBuffer", "paramtype":"void *" },
+            { "paramname":"cbDestBufferSize", "paramtype":"uint32" },
+            { "paramname":"nBytesWritten", "paramtype":"uint32 *" },
+            { "paramname":"nDesiredSampleRate", "paramtype":"uint32" }
+          ],
+          "returntype": "EVoiceResult"
+        },
+        {
+          "methodname": "GetVoiceOptimalSampleRate",
+          "methodname_flat": "SteamAPI_ISteamUser_GetVoiceOptimalSampleRate",
+          "params": [],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "GetAuthSessionTicket",
+          "methodname_flat": "SteamAPI_ISteamUser_GetAuthSessionTicket",
+          "params": [
+            { "paramname":"pTicket", "paramtype":"void *" },
+            { "paramname":"cbMaxTicket", "paramtype":"int" },
+            { "paramname":"pcbTicket", "paramtype":"uint32 *" }
+          ],
+          "returntype": "HAuthTicket"
+        },
+        {
+          "methodname": "BeginAuthSession",
+          "methodname_flat": "SteamAPI_ISteamUser_BeginAuthSession",
+          "params": [
+            { "paramname":"pAuthTicket", "paramtype":"const void *" },
+            { "paramname":"cbAuthTicket", "paramtype":"int" },
+            { "paramname":"steamID", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "EBeginAuthSessionResult"
+        },
+        {
+          "methodname": "EndAuthSession",
+          "methodname_flat": "SteamAPI_ISteamUser_EndAuthSession",
+          "params": [
+            { "paramname":"steamID", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "CancelAuthTicket",
+          "methodname_flat": "SteamAPI_ISteamUser_CancelAuthTicket",
+          "params": [
+            { "paramname":"hAuthTicket", "paramtype":"HAuthTicket" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "UserHasLicenseForApp",
+          "methodname_flat": "SteamAPI_ISteamUser_UserHasLicenseForApp",
+          "params": [
+            { "paramname":"steamID", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"appID", "paramtype":"AppId_t" }
+          ],
+          "returntype": "EUserHasLicenseForAppResult"
+        },
+        {
+          "methodname": "BIsBehindNAT",
+          "methodname_flat": "SteamAPI_ISteamUser_BIsBehindNAT",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "AdvertiseGame",
+          "methodname_flat": "SteamAPI_ISteamUser_AdvertiseGame",
+          "params": [
+            { "paramname":"steamIDGameServer", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"unIPServer", "paramtype":"uint32" },
+            { "paramname":"usPortServer", "paramtype":"uint16" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "callresult": "EncryptedAppTicketResponse_t",
+          "methodname": "RequestEncryptedAppTicket",
+          "methodname_flat": "SteamAPI_ISteamUser_RequestEncryptedAppTicket",
+          "params": [
+            { "paramname":"pDataToInclude", "paramtype":"void *" },
+            { "paramname":"cbDataToInclude", "paramtype":"int" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "GetEncryptedAppTicket",
+          "methodname_flat": "SteamAPI_ISteamUser_GetEncryptedAppTicket",
+          "params": [
+            { "paramname":"pTicket", "paramtype":"void *" },
+            { "paramname":"cbMaxTicket", "paramtype":"int" },
+            { "paramname":"pcbTicket", "paramtype":"uint32 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetGameBadgeLevel",
+          "methodname_flat": "SteamAPI_ISteamUser_GetGameBadgeLevel",
+          "params": [
+            { "paramname":"nSeries", "paramtype":"int" },
+            { "paramname":"bFoil", "paramtype":"bool" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetPlayerSteamLevel",
+          "methodname_flat": "SteamAPI_ISteamUser_GetPlayerSteamLevel",
+          "params": [],
+          "returntype": "int"
+        },
+        {
+          "callresult": "StoreAuthURLResponse_t",
+          "methodname": "RequestStoreAuthURL",
+          "methodname_flat": "SteamAPI_ISteamUser_RequestStoreAuthURL",
+          "params": [
+            { "paramname":"pchRedirectURL", "paramtype":"const char *" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "BIsPhoneVerified",
+          "methodname_flat": "SteamAPI_ISteamUser_BIsPhoneVerified",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "BIsTwoFactorEnabled",
+          "methodname_flat": "SteamAPI_ISteamUser_BIsTwoFactorEnabled",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "BIsPhoneIdentifying",
+          "methodname_flat": "SteamAPI_ISteamUser_BIsPhoneIdentifying",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "BIsPhoneRequiringVerification",
+          "methodname_flat": "SteamAPI_ISteamUser_BIsPhoneRequiringVerification",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "callresult": "MarketEligibilityResponse_t",
+          "methodname": "GetMarketEligibility",
+          "methodname_flat": "SteamAPI_ISteamUser_GetMarketEligibility",
+          "params": [],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "DurationControl_t",
+          "methodname": "GetDurationControl",
+          "methodname_flat": "SteamAPI_ISteamUser_GetDurationControl",
+          "params": [],
+          "returntype": "SteamAPICall_t"
+        }
+      ],
+      "version_string": "SteamUser020"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamFriends",
+          "name_flat": "SteamAPI_SteamFriends_v017"
+        }
+      ],
+      "classname": "ISteamFriends",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "GetPersonaName",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetPersonaName",
+          "params": [],
+          "returntype": "const char *"
+        },
+        {
+          "callresult": "SetPersonaNameResponse_t",
+          "methodname": "SetPersonaName",
+          "methodname_flat": "SteamAPI_ISteamFriends_SetPersonaName",
+          "params": [
+            { "paramname":"pchPersonaName", "paramtype":"const char *" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "GetPersonaState",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetPersonaState",
+          "params": [],
+          "returntype": "EPersonaState"
+        },
+        {
+          "methodname": "GetFriendCount",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFriendCount",
+          "params": [
+            { "paramname":"iFriendFlags", "paramtype":"int" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetFriendByIndex",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFriendByIndex",
+          "params": [
+            { "paramname":"iFriend", "paramtype":"int" },
+            { "paramname":"iFriendFlags", "paramtype":"int" }
+          ],
+          "returntype": "CSteamID",
+          "returntype_flat": "uint64_steamid"
+        },
+        {
+          "methodname": "GetFriendRelationship",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFriendRelationship",
+          "params": [
+            { "paramname":"steamIDFriend", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "EFriendRelationship"
+        },
+        {
+          "methodname": "GetFriendPersonaState",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFriendPersonaState",
+          "params": [
+            { "paramname":"steamIDFriend", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "EPersonaState"
+        },
+        {
+          "methodname": "GetFriendPersonaName",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFriendPersonaName",
+          "params": [
+            { "paramname":"steamIDFriend", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "GetFriendGamePlayed",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFriendGamePlayed",
+          "params": [
+            { "paramname":"steamIDFriend", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            {
+              "out_struct": "",
+              "paramname": "pFriendGameInfo",
+              "paramtype": "FriendGameInfo_t *"
+            }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetFriendPersonaNameHistory",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFriendPersonaNameHistory",
+          "params": [
+            { "paramname":"steamIDFriend", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"iPersonaName", "paramtype":"int" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "GetFriendSteamLevel",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFriendSteamLevel",
+          "params": [
+            { "paramname":"steamIDFriend", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetPlayerNickname",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetPlayerNickname",
+          "params": [
+            { "paramname":"steamIDPlayer", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "GetFriendsGroupCount",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFriendsGroupCount",
+          "params": [],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetFriendsGroupIDByIndex",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFriendsGroupIDByIndex",
+          "params": [
+            { "paramname":"iFG", "paramtype":"int" }
+          ],
+          "returntype": "FriendsGroupID_t"
+        },
+        {
+          "methodname": "GetFriendsGroupName",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFriendsGroupName",
+          "params": [
+            { "paramname":"friendsGroupID", "paramtype":"FriendsGroupID_t" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "GetFriendsGroupMembersCount",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFriendsGroupMembersCount",
+          "params": [
+            { "paramname":"friendsGroupID", "paramtype":"FriendsGroupID_t" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetFriendsGroupMembersList",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFriendsGroupMembersList",
+          "params": [
+            { "paramname":"friendsGroupID", "paramtype":"FriendsGroupID_t" },
+            {
+              "out_array_call": "nMembersCount,GetFriendsGroupMembersCount,friendsGroupID",
+              "paramname": "pOutSteamIDMembers",
+              "paramtype": "CSteamID *"
+            },
+            { "paramname":"nMembersCount", "paramtype":"int" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "HasFriend",
+          "methodname_flat": "SteamAPI_ISteamFriends_HasFriend",
+          "params": [
+            { "paramname":"steamIDFriend", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"iFriendFlags", "paramtype":"int" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetClanCount",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetClanCount",
+          "params": [],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetClanByIndex",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetClanByIndex",
+          "params": [
+            { "paramname":"iClan", "paramtype":"int" }
+          ],
+          "returntype": "CSteamID",
+          "returntype_flat": "uint64_steamid"
+        },
+        {
+          "methodname": "GetClanName",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetClanName",
+          "params": [
+            { "paramname":"steamIDClan", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "GetClanTag",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetClanTag",
+          "params": [
+            { "paramname":"steamIDClan", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "GetClanActivityCounts",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetClanActivityCounts",
+          "params": [
+            { "paramname":"steamIDClan", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pnOnline", "paramtype":"int *" },
+            { "paramname":"pnInGame", "paramtype":"int *" },
+            { "paramname":"pnChatting", "paramtype":"int *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "callresult": "DownloadClanActivityCountsResult_t",
+          "methodname": "DownloadClanActivityCounts",
+          "methodname_flat": "SteamAPI_ISteamFriends_DownloadClanActivityCounts",
+          "params": [
+            {
+              "array_count": "cClansToRequest",
+              "paramname": "psteamIDClans",
+              "paramtype": "CSteamID *"
+            },
+            { "paramname":"cClansToRequest", "paramtype":"int" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "GetFriendCountFromSource",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFriendCountFromSource",
+          "params": [
+            { "paramname":"steamIDSource", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetFriendFromSourceByIndex",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFriendFromSourceByIndex",
+          "params": [
+            { "paramname":"steamIDSource", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"iFriend", "paramtype":"int" }
+          ],
+          "returntype": "CSteamID",
+          "returntype_flat": "uint64_steamid"
+        },
+        {
+          "methodname": "IsUserInSource",
+          "methodname_flat": "SteamAPI_ISteamFriends_IsUserInSource",
+          "params": [
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"steamIDSource", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetInGameVoiceSpeaking",
+          "methodname_flat": "SteamAPI_ISteamFriends_SetInGameVoiceSpeaking",
+          "params": [
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"bSpeaking", "paramtype":"bool" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "ActivateGameOverlay",
+          "methodname_flat": "SteamAPI_ISteamFriends_ActivateGameOverlay",
+          "params": [
+            { "paramname":"pchDialog", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "ActivateGameOverlayToUser",
+          "methodname_flat": "SteamAPI_ISteamFriends_ActivateGameOverlayToUser",
+          "params": [
+            { "paramname":"pchDialog", "paramtype":"const char *" },
+            { "paramname":"steamID", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "ActivateGameOverlayToWebPage",
+          "methodname_flat": "SteamAPI_ISteamFriends_ActivateGameOverlayToWebPage",
+          "params": [
+            { "paramname":"pchURL", "paramtype":"const char *" },
+            { "paramname":"eMode", "paramtype":"EActivateGameOverlayToWebPageMode" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "ActivateGameOverlayToStore",
+          "methodname_flat": "SteamAPI_ISteamFriends_ActivateGameOverlayToStore",
+          "params": [
+            { "paramname":"nAppID", "paramtype":"AppId_t" },
+            { "paramname":"eFlag", "paramtype":"EOverlayToStoreFlag" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetPlayedWith",
+          "methodname_flat": "SteamAPI_ISteamFriends_SetPlayedWith",
+          "params": [
+            { "paramname":"steamIDUserPlayedWith", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "ActivateGameOverlayInviteDialog",
+          "methodname_flat": "SteamAPI_ISteamFriends_ActivateGameOverlayInviteDialog",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetSmallFriendAvatar",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetSmallFriendAvatar",
+          "params": [
+            { "paramname":"steamIDFriend", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetMediumFriendAvatar",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetMediumFriendAvatar",
+          "params": [
+            { "paramname":"steamIDFriend", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetLargeFriendAvatar",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetLargeFriendAvatar",
+          "params": [
+            { "paramname":"steamIDFriend", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "RequestUserInformation",
+          "methodname_flat": "SteamAPI_ISteamFriends_RequestUserInformation",
+          "params": [
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"bRequireNameOnly", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "callresult": "ClanOfficerListResponse_t",
+          "methodname": "RequestClanOfficerList",
+          "methodname_flat": "SteamAPI_ISteamFriends_RequestClanOfficerList",
+          "params": [
+            { "paramname":"steamIDClan", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "GetClanOwner",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetClanOwner",
+          "params": [
+            { "paramname":"steamIDClan", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "CSteamID",
+          "returntype_flat": "uint64_steamid"
+        },
+        {
+          "methodname": "GetClanOfficerCount",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetClanOfficerCount",
+          "params": [
+            { "paramname":"steamIDClan", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetClanOfficerByIndex",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetClanOfficerByIndex",
+          "params": [
+            { "paramname":"steamIDClan", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"iOfficer", "paramtype":"int" }
+          ],
+          "returntype": "CSteamID",
+          "returntype_flat": "uint64_steamid"
+        },
+        {
+          "methodname": "GetUserRestrictions",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetUserRestrictions",
+          "params": [],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "SetRichPresence",
+          "methodname_flat": "SteamAPI_ISteamFriends_SetRichPresence",
+          "params": [
+            { "paramname":"pchKey", "paramtype":"const char *" },
+            { "paramname":"pchValue", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "ClearRichPresence",
+          "methodname_flat": "SteamAPI_ISteamFriends_ClearRichPresence",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetFriendRichPresence",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFriendRichPresence",
+          "params": [
+            { "paramname":"steamIDFriend", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchKey", "paramtype":"const char *" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "GetFriendRichPresenceKeyCount",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFriendRichPresenceKeyCount",
+          "params": [
+            { "paramname":"steamIDFriend", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetFriendRichPresenceKeyByIndex",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFriendRichPresenceKeyByIndex",
+          "params": [
+            { "paramname":"steamIDFriend", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"iKey", "paramtype":"int" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "RequestFriendRichPresence",
+          "methodname_flat": "SteamAPI_ISteamFriends_RequestFriendRichPresence",
+          "params": [
+            { "paramname":"steamIDFriend", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "InviteUserToGame",
+          "methodname_flat": "SteamAPI_ISteamFriends_InviteUserToGame",
+          "params": [
+            { "paramname":"steamIDFriend", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchConnectString", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetCoplayFriendCount",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetCoplayFriendCount",
+          "params": [],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetCoplayFriend",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetCoplayFriend",
+          "params": [
+            { "paramname":"iCoplayFriend", "paramtype":"int" }
+          ],
+          "returntype": "CSteamID",
+          "returntype_flat": "uint64_steamid"
+        },
+        {
+          "methodname": "GetFriendCoplayTime",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFriendCoplayTime",
+          "params": [
+            { "paramname":"steamIDFriend", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetFriendCoplayGame",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFriendCoplayGame",
+          "params": [
+            { "paramname":"steamIDFriend", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "AppId_t"
+        },
+        {
+          "callresult": "JoinClanChatRoomCompletionResult_t",
+          "methodname": "JoinClanChatRoom",
+          "methodname_flat": "SteamAPI_ISteamFriends_JoinClanChatRoom",
+          "params": [
+            { "paramname":"steamIDClan", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "LeaveClanChatRoom",
+          "methodname_flat": "SteamAPI_ISteamFriends_LeaveClanChatRoom",
+          "params": [
+            { "paramname":"steamIDClan", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetClanChatMemberCount",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetClanChatMemberCount",
+          "params": [
+            { "paramname":"steamIDClan", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetChatMemberByIndex",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetChatMemberByIndex",
+          "params": [
+            { "paramname":"steamIDClan", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"iUser", "paramtype":"int" }
+          ],
+          "returntype": "CSteamID",
+          "returntype_flat": "uint64_steamid"
+        },
+        {
+          "methodname": "SendClanChatMessage",
+          "methodname_flat": "SteamAPI_ISteamFriends_SendClanChatMessage",
+          "params": [
+            { "paramname":"steamIDClanChat", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchText", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetClanChatMessage",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetClanChatMessage",
+          "params": [
+            { "paramname":"steamIDClanChat", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"iMessage", "paramtype":"int" },
+            { "paramname":"prgchText", "paramtype":"void *" },
+            { "paramname":"cchTextMax", "paramtype":"int" },
+            { "paramname":"peChatEntryType", "paramtype":"EChatEntryType *" },
+            {
+              "out_struct": "",
+              "paramname": "psteamidChatter",
+              "paramtype": "CSteamID *"
+            }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "IsClanChatAdmin",
+          "methodname_flat": "SteamAPI_ISteamFriends_IsClanChatAdmin",
+          "params": [
+            { "paramname":"steamIDClanChat", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "IsClanChatWindowOpenInSteam",
+          "methodname_flat": "SteamAPI_ISteamFriends_IsClanChatWindowOpenInSteam",
+          "params": [
+            { "paramname":"steamIDClanChat", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "OpenClanChatWindowInSteam",
+          "methodname_flat": "SteamAPI_ISteamFriends_OpenClanChatWindowInSteam",
+          "params": [
+            { "paramname":"steamIDClanChat", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "CloseClanChatWindowInSteam",
+          "methodname_flat": "SteamAPI_ISteamFriends_CloseClanChatWindowInSteam",
+          "params": [
+            { "paramname":"steamIDClanChat", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetListenForFriendsMessages",
+          "methodname_flat": "SteamAPI_ISteamFriends_SetListenForFriendsMessages",
+          "params": [
+            { "paramname":"bInterceptEnabled", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "ReplyToFriendMessage",
+          "methodname_flat": "SteamAPI_ISteamFriends_ReplyToFriendMessage",
+          "params": [
+            { "paramname":"steamIDFriend", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchMsgToSend", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetFriendMessage",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFriendMessage",
+          "params": [
+            { "paramname":"steamIDFriend", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"iMessageID", "paramtype":"int" },
+            { "paramname":"pvData", "paramtype":"void *" },
+            { "paramname":"cubData", "paramtype":"int" },
+            { "paramname":"peChatEntryType", "paramtype":"EChatEntryType *" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "callresult": "FriendsGetFollowerCount_t",
+          "methodname": "GetFollowerCount",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetFollowerCount",
+          "params": [
+            { "paramname":"steamID", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "FriendsIsFollowing_t",
+          "methodname": "IsFollowing",
+          "methodname_flat": "SteamAPI_ISteamFriends_IsFollowing",
+          "params": [
+            { "paramname":"steamID", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "FriendsEnumerateFollowingList_t",
+          "methodname": "EnumerateFollowingList",
+          "methodname_flat": "SteamAPI_ISteamFriends_EnumerateFollowingList",
+          "params": [
+            { "paramname":"unStartIndex", "paramtype":"uint32" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "IsClanPublic",
+          "methodname_flat": "SteamAPI_ISteamFriends_IsClanPublic",
+          "params": [
+            { "paramname":"steamIDClan", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "IsClanOfficialGameGroup",
+          "methodname_flat": "SteamAPI_ISteamFriends_IsClanOfficialGameGroup",
+          "params": [
+            { "paramname":"steamIDClan", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetNumChatsWithUnreadPriorityMessages",
+          "methodname_flat": "SteamAPI_ISteamFriends_GetNumChatsWithUnreadPriorityMessages",
+          "params": [],
+          "returntype": "int"
+        },
+        {
+          "methodname": "ActivateGameOverlayRemotePlayTogetherInviteDialog",
+          "methodname_flat": "SteamAPI_ISteamFriends_ActivateGameOverlayRemotePlayTogetherInviteDialog",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "void"
+        }
+      ],
+      "version_string": "SteamFriends017"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamUtils",
+          "name_flat": "SteamAPI_SteamUtils_v009"
+        },
+        {
+          "kind": "gameserver",
+          "name": "SteamGameServerUtils",
+          "name_flat": "SteamAPI_SteamGameServerUtils_v009"
+        }
+      ],
+      "classname": "ISteamUtils",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "GetSecondsSinceAppActive",
+          "methodname_flat": "SteamAPI_ISteamUtils_GetSecondsSinceAppActive",
+          "params": [],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "GetSecondsSinceComputerActive",
+          "methodname_flat": "SteamAPI_ISteamUtils_GetSecondsSinceComputerActive",
+          "params": [],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "GetConnectedUniverse",
+          "methodname_flat": "SteamAPI_ISteamUtils_GetConnectedUniverse",
+          "params": [],
+          "returntype": "EUniverse"
+        },
+        {
+          "methodname": "GetServerRealTime",
+          "methodname_flat": "SteamAPI_ISteamUtils_GetServerRealTime",
+          "params": [],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "GetIPCountry",
+          "methodname_flat": "SteamAPI_ISteamUtils_GetIPCountry",
+          "params": [],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "GetImageSize",
+          "methodname_flat": "SteamAPI_ISteamUtils_GetImageSize",
+          "params": [
+            { "paramname":"iImage", "paramtype":"int" },
+            { "paramname":"pnWidth", "paramtype":"uint32 *" },
+            { "paramname":"pnHeight", "paramtype":"uint32 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetImageRGBA",
+          "methodname_flat": "SteamAPI_ISteamUtils_GetImageRGBA",
+          "params": [
+            { "paramname":"iImage", "paramtype":"int" },
+            { "paramname":"pubDest", "paramtype":"uint8 *" },
+            { "paramname":"nDestBufferSize", "paramtype":"int" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetCSERIPPort",
+          "methodname_flat": "SteamAPI_ISteamUtils_GetCSERIPPort",
+          "params": [
+            { "paramname":"unIP", "paramtype":"uint32 *" },
+            { "paramname":"usPort", "paramtype":"uint16 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetCurrentBatteryPower",
+          "methodname_flat": "SteamAPI_ISteamUtils_GetCurrentBatteryPower",
+          "params": [],
+          "returntype": "uint8"
+        },
+        {
+          "methodname": "GetAppID",
+          "methodname_flat": "SteamAPI_ISteamUtils_GetAppID",
+          "params": [],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "SetOverlayNotificationPosition",
+          "methodname_flat": "SteamAPI_ISteamUtils_SetOverlayNotificationPosition",
+          "params": [
+            { "paramname":"eNotificationPosition", "paramtype":"ENotificationPosition" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "IsAPICallCompleted",
+          "methodname_flat": "SteamAPI_ISteamUtils_IsAPICallCompleted",
+          "params": [
+            { "paramname":"hSteamAPICall", "paramtype":"SteamAPICall_t" },
+            { "paramname":"pbFailed", "paramtype":"bool *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetAPICallFailureReason",
+          "methodname_flat": "SteamAPI_ISteamUtils_GetAPICallFailureReason",
+          "params": [
+            { "paramname":"hSteamAPICall", "paramtype":"SteamAPICall_t" }
+          ],
+          "returntype": "ESteamAPICallFailure"
+        },
+        {
+          "methodname": "GetAPICallResult",
+          "methodname_flat": "SteamAPI_ISteamUtils_GetAPICallResult",
+          "params": [
+            { "paramname":"hSteamAPICall", "paramtype":"SteamAPICall_t" },
+            { "paramname":"pCallback", "paramtype":"void *" },
+            { "paramname":"cubCallback", "paramtype":"int" },
+            { "paramname":"iCallbackExpected", "paramtype":"int" },
+            { "paramname":"pbFailed", "paramtype":"bool *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetIPCCallCount",
+          "methodname_flat": "SteamAPI_ISteamUtils_GetIPCCallCount",
+          "params": [],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "SetWarningMessageHook",
+          "methodname_flat": "SteamAPI_ISteamUtils_SetWarningMessageHook",
+          "params": [
+            { "paramname":"pFunction", "paramtype":"SteamAPIWarningMessageHook_t" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "IsOverlayEnabled",
+          "methodname_flat": "SteamAPI_ISteamUtils_IsOverlayEnabled",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "BOverlayNeedsPresent",
+          "methodname_flat": "SteamAPI_ISteamUtils_BOverlayNeedsPresent",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "callresult": "CheckFileSignature_t",
+          "methodname": "CheckFileSignature",
+          "methodname_flat": "SteamAPI_ISteamUtils_CheckFileSignature",
+          "params": [
+            { "paramname":"szFileName", "paramtype":"const char *" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "ShowGamepadTextInput",
+          "methodname_flat": "SteamAPI_ISteamUtils_ShowGamepadTextInput",
+          "params": [
+            { "paramname":"eInputMode", "paramtype":"EGamepadTextInputMode" },
+            { "paramname":"eLineInputMode", "paramtype":"EGamepadTextInputLineMode" },
+            { "paramname":"pchDescription", "paramtype":"const char *" },
+            { "paramname":"unCharMax", "paramtype":"uint32" },
+            { "paramname":"pchExistingText", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetEnteredGamepadTextLength",
+          "methodname_flat": "SteamAPI_ISteamUtils_GetEnteredGamepadTextLength",
+          "params": [],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "GetEnteredGamepadTextInput",
+          "methodname_flat": "SteamAPI_ISteamUtils_GetEnteredGamepadTextInput",
+          "params": [
+            { "paramname":"pchText", "paramtype":"char *" },
+            { "paramname":"cchText", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetSteamUILanguage",
+          "methodname_flat": "SteamAPI_ISteamUtils_GetSteamUILanguage",
+          "params": [],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "IsSteamRunningInVR",
+          "methodname_flat": "SteamAPI_ISteamUtils_IsSteamRunningInVR",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetOverlayNotificationInset",
+          "methodname_flat": "SteamAPI_ISteamUtils_SetOverlayNotificationInset",
+          "params": [
+            { "paramname":"nHorizontalInset", "paramtype":"int" },
+            { "paramname":"nVerticalInset", "paramtype":"int" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "IsSteamInBigPictureMode",
+          "methodname_flat": "SteamAPI_ISteamUtils_IsSteamInBigPictureMode",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "StartVRDashboard",
+          "methodname_flat": "SteamAPI_ISteamUtils_StartVRDashboard",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "IsVRHeadsetStreamingEnabled",
+          "methodname_flat": "SteamAPI_ISteamUtils_IsVRHeadsetStreamingEnabled",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetVRHeadsetStreamingEnabled",
+          "methodname_flat": "SteamAPI_ISteamUtils_SetVRHeadsetStreamingEnabled",
+          "params": [
+            { "paramname":"bEnabled", "paramtype":"bool" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "IsSteamChinaLauncher",
+          "methodname_flat": "SteamAPI_ISteamUtils_IsSteamChinaLauncher",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "InitFilterText",
+          "methodname_flat": "SteamAPI_ISteamUtils_InitFilterText",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "FilterText",
+          "methodname_flat": "SteamAPI_ISteamUtils_FilterText",
+          "params": [
+            { "paramname":"pchOutFilteredText", "paramtype":"char *" },
+            { "paramname":"nByteSizeOutFilteredText", "paramtype":"uint32" },
+            { "paramname":"pchInputMessage", "paramtype":"const char *" },
+            { "paramname":"bLegalOnly", "paramtype":"bool" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetIPv6ConnectivityState",
+          "methodname_flat": "SteamAPI_ISteamUtils_GetIPv6ConnectivityState",
+          "params": [
+            { "paramname":"eProtocol", "paramtype":"ESteamIPv6ConnectivityProtocol" }
+          ],
+          "returntype": "ESteamIPv6ConnectivityState"
+        }
+      ],
+      "version_string": "SteamUtils009"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamMatchmaking",
+          "name_flat": "SteamAPI_SteamMatchmaking_v009"
+        }
+      ],
+      "classname": "ISteamMatchmaking",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "GetFavoriteGameCount",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_GetFavoriteGameCount",
+          "params": [],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetFavoriteGame",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_GetFavoriteGame",
+          "params": [
+            { "paramname":"iGame", "paramtype":"int" },
+            { "paramname":"pnAppID", "paramtype":"AppId_t *" },
+            { "paramname":"pnIP", "paramtype":"uint32 *" },
+            { "paramname":"pnConnPort", "paramtype":"uint16 *" },
+            { "paramname":"pnQueryPort", "paramtype":"uint16 *" },
+            { "paramname":"punFlags", "paramtype":"uint32 *" },
+            { "paramname":"pRTime32LastPlayedOnServer", "paramtype":"uint32 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "AddFavoriteGame",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_AddFavoriteGame",
+          "params": [
+            { "paramname":"nAppID", "paramtype":"AppId_t" },
+            { "paramname":"nIP", "paramtype":"uint32" },
+            { "paramname":"nConnPort", "paramtype":"uint16" },
+            { "paramname":"nQueryPort", "paramtype":"uint16" },
+            { "paramname":"unFlags", "paramtype":"uint32" },
+            { "paramname":"rTime32LastPlayedOnServer", "paramtype":"uint32" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "RemoveFavoriteGame",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_RemoveFavoriteGame",
+          "params": [
+            { "paramname":"nAppID", "paramtype":"AppId_t" },
+            { "paramname":"nIP", "paramtype":"uint32" },
+            { "paramname":"nConnPort", "paramtype":"uint16" },
+            { "paramname":"nQueryPort", "paramtype":"uint16" },
+            { "paramname":"unFlags", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "callresult": "LobbyMatchList_t",
+          "methodname": "RequestLobbyList",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_RequestLobbyList",
+          "params": [],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "AddRequestLobbyListStringFilter",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_AddRequestLobbyListStringFilter",
+          "params": [
+            { "paramname":"pchKeyToMatch", "paramtype":"const char *" },
+            { "paramname":"pchValueToMatch", "paramtype":"const char *" },
+            { "paramname":"eComparisonType", "paramtype":"ELobbyComparison" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "AddRequestLobbyListNumericalFilter",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_AddRequestLobbyListNumericalFilter",
+          "params": [
+            { "paramname":"pchKeyToMatch", "paramtype":"const char *" },
+            { "paramname":"nValueToMatch", "paramtype":"int" },
+            { "paramname":"eComparisonType", "paramtype":"ELobbyComparison" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "AddRequestLobbyListNearValueFilter",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_AddRequestLobbyListNearValueFilter",
+          "params": [
+            { "paramname":"pchKeyToMatch", "paramtype":"const char *" },
+            { "paramname":"nValueToBeCloseTo", "paramtype":"int" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "AddRequestLobbyListFilterSlotsAvailable",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_AddRequestLobbyListFilterSlotsAvailable",
+          "params": [
+            { "paramname":"nSlotsAvailable", "paramtype":"int" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "AddRequestLobbyListDistanceFilter",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_AddRequestLobbyListDistanceFilter",
+          "params": [
+            { "paramname":"eLobbyDistanceFilter", "paramtype":"ELobbyDistanceFilter" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "AddRequestLobbyListResultCountFilter",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_AddRequestLobbyListResultCountFilter",
+          "params": [
+            { "paramname":"cMaxResults", "paramtype":"int" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "AddRequestLobbyListCompatibleMembersFilter",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_AddRequestLobbyListCompatibleMembersFilter",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetLobbyByIndex",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_GetLobbyByIndex",
+          "params": [
+            { "paramname":"iLobby", "paramtype":"int" }
+          ],
+          "returntype": "CSteamID",
+          "returntype_flat": "uint64_steamid"
+        },
+        {
+          "callresult": "LobbyCreated_t",
+          "methodname": "CreateLobby",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_CreateLobby",
+          "params": [
+            { "paramname":"eLobbyType", "paramtype":"ELobbyType" },
+            { "paramname":"cMaxMembers", "paramtype":"int" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "LobbyEnter_t",
+          "methodname": "JoinLobby",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_JoinLobby",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "LeaveLobby",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_LeaveLobby",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "InviteUserToLobby",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_InviteUserToLobby",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"steamIDInvitee", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetNumLobbyMembers",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_GetNumLobbyMembers",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetLobbyMemberByIndex",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_GetLobbyMemberByIndex",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"iMember", "paramtype":"int" }
+          ],
+          "returntype": "CSteamID",
+          "returntype_flat": "uint64_steamid"
+        },
+        {
+          "methodname": "GetLobbyData",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_GetLobbyData",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchKey", "paramtype":"const char *" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "SetLobbyData",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_SetLobbyData",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchKey", "paramtype":"const char *" },
+            { "paramname":"pchValue", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetLobbyDataCount",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_GetLobbyDataCount",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetLobbyDataByIndex",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_GetLobbyDataByIndex",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"iLobbyData", "paramtype":"int" },
+            { "paramname":"pchKey", "paramtype":"char *" },
+            { "paramname":"cchKeyBufferSize", "paramtype":"int" },
+            { "paramname":"pchValue", "paramtype":"char *" },
+            { "paramname":"cchValueBufferSize", "paramtype":"int" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "DeleteLobbyData",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_DeleteLobbyData",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchKey", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetLobbyMemberData",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_GetLobbyMemberData",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchKey", "paramtype":"const char *" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "SetLobbyMemberData",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_SetLobbyMemberData",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchKey", "paramtype":"const char *" },
+            { "paramname":"pchValue", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SendLobbyChatMsg",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_SendLobbyChatMsg",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pvMsgBody", "paramtype":"const void *" },
+            { "paramname":"cubMsgBody", "paramtype":"int" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetLobbyChatEntry",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_GetLobbyChatEntry",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"iChatID", "paramtype":"int" },
+            {
+              "out_struct": "",
+              "paramname": "pSteamIDUser",
+              "paramtype": "CSteamID *"
+            },
+            { "paramname":"pvData", "paramtype":"void *" },
+            { "paramname":"cubData", "paramtype":"int" },
+            { "paramname":"peChatEntryType", "paramtype":"EChatEntryType *" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "RequestLobbyData",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_RequestLobbyData",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetLobbyGameServer",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_SetLobbyGameServer",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"unGameServerIP", "paramtype":"uint32" },
+            { "paramname":"unGameServerPort", "paramtype":"uint16" },
+            { "paramname":"steamIDGameServer", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetLobbyGameServer",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_GetLobbyGameServer",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"punGameServerIP", "paramtype":"uint32 *" },
+            { "paramname":"punGameServerPort", "paramtype":"uint16 *" },
+            {
+              "out_struct": "",
+              "paramname": "psteamIDGameServer",
+              "paramtype": "CSteamID *"
+            }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetLobbyMemberLimit",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_SetLobbyMemberLimit",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"cMaxMembers", "paramtype":"int" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetLobbyMemberLimit",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_GetLobbyMemberLimit",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "SetLobbyType",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_SetLobbyType",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"eLobbyType", "paramtype":"ELobbyType" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetLobbyJoinable",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_SetLobbyJoinable",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"bLobbyJoinable", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetLobbyOwner",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_GetLobbyOwner",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "CSteamID",
+          "returntype_flat": "uint64_steamid"
+        },
+        {
+          "methodname": "SetLobbyOwner",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_SetLobbyOwner",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"steamIDNewOwner", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetLinkedLobby",
+          "methodname_flat": "SteamAPI_ISteamMatchmaking_SetLinkedLobby",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"steamIDLobbyDependent", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "bool"
+        }
+      ],
+      "version_string": "SteamMatchMaking009"
+    },
+    {
+      "classname": "ISteamMatchmakingServerListResponse",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "ServerResponded",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingServerListResponse_ServerResponded",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HServerListRequest" },
+            { "paramname":"iServer", "paramtype":"int" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "ServerFailedToRespond",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingServerListResponse_ServerFailedToRespond",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HServerListRequest" },
+            { "paramname":"iServer", "paramtype":"int" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "RefreshComplete",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingServerListResponse_RefreshComplete",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HServerListRequest" },
+            { "paramname":"response", "paramtype":"EMatchMakingServerResponse" }
+          ],
+          "returntype": "void"
+        }
+      ]
+    },
+    {
+      "classname": "ISteamMatchmakingPingResponse",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "ServerResponded",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingPingResponse_ServerResponded",
+          "params": [
+            { "paramname":"server", "paramtype":"gameserveritem_t &" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "ServerFailedToRespond",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingPingResponse_ServerFailedToRespond",
+          "params": [],
+          "returntype": "void"
+        }
+      ]
+    },
+    {
+      "classname": "ISteamMatchmakingPlayersResponse",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "AddPlayerToList",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingPlayersResponse_AddPlayerToList",
+          "params": [
+            { "paramname":"pchName", "paramtype":"const char *" },
+            { "paramname":"nScore", "paramtype":"int" },
+            { "paramname":"flTimePlayed", "paramtype":"float" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "PlayersFailedToRespond",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingPlayersResponse_PlayersFailedToRespond",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "PlayersRefreshComplete",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingPlayersResponse_PlayersRefreshComplete",
+          "params": [],
+          "returntype": "void"
+        }
+      ]
+    },
+    {
+      "classname": "ISteamMatchmakingRulesResponse",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "RulesResponded",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingRulesResponse_RulesResponded",
+          "params": [
+            { "paramname":"pchRule", "paramtype":"const char *" },
+            { "paramname":"pchValue", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "RulesFailedToRespond",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingRulesResponse_RulesFailedToRespond",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "RulesRefreshComplete",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingRulesResponse_RulesRefreshComplete",
+          "params": [],
+          "returntype": "void"
+        }
+      ]
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamMatchmakingServers",
+          "name_flat": "SteamAPI_SteamMatchmakingServers_v002"
+        }
+      ],
+      "classname": "ISteamMatchmakingServers",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "RequestInternetServerList",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingServers_RequestInternetServerList",
+          "params": [
+            { "paramname":"iApp", "paramtype":"AppId_t" },
+            {
+              "array_count": "nFilters",
+              "paramname": "ppchFilters",
+              "paramtype": "MatchMakingKeyValuePair_t **"
+            },
+            { "paramname":"nFilters", "paramtype":"uint32" },
+            { "paramname":"pRequestServersResponse", "paramtype":"ISteamMatchmakingServerListResponse *" }
+          ],
+          "returntype": "HServerListRequest"
+        },
+        {
+          "methodname": "RequestLANServerList",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingServers_RequestLANServerList",
+          "params": [
+            { "paramname":"iApp", "paramtype":"AppId_t" },
+            { "paramname":"pRequestServersResponse", "paramtype":"ISteamMatchmakingServerListResponse *" }
+          ],
+          "returntype": "HServerListRequest"
+        },
+        {
+          "methodname": "RequestFriendsServerList",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingServers_RequestFriendsServerList",
+          "params": [
+            { "paramname":"iApp", "paramtype":"AppId_t" },
+            {
+              "array_count": "nFilters",
+              "paramname": "ppchFilters",
+              "paramtype": "MatchMakingKeyValuePair_t **"
+            },
+            { "paramname":"nFilters", "paramtype":"uint32" },
+            { "paramname":"pRequestServersResponse", "paramtype":"ISteamMatchmakingServerListResponse *" }
+          ],
+          "returntype": "HServerListRequest"
+        },
+        {
+          "methodname": "RequestFavoritesServerList",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingServers_RequestFavoritesServerList",
+          "params": [
+            { "paramname":"iApp", "paramtype":"AppId_t" },
+            {
+              "array_count": "nFilters",
+              "paramname": "ppchFilters",
+              "paramtype": "MatchMakingKeyValuePair_t **"
+            },
+            { "paramname":"nFilters", "paramtype":"uint32" },
+            { "paramname":"pRequestServersResponse", "paramtype":"ISteamMatchmakingServerListResponse *" }
+          ],
+          "returntype": "HServerListRequest"
+        },
+        {
+          "methodname": "RequestHistoryServerList",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingServers_RequestHistoryServerList",
+          "params": [
+            { "paramname":"iApp", "paramtype":"AppId_t" },
+            {
+              "array_count": "nFilters",
+              "paramname": "ppchFilters",
+              "paramtype": "MatchMakingKeyValuePair_t **"
+            },
+            { "paramname":"nFilters", "paramtype":"uint32" },
+            { "paramname":"pRequestServersResponse", "paramtype":"ISteamMatchmakingServerListResponse *" }
+          ],
+          "returntype": "HServerListRequest"
+        },
+        {
+          "methodname": "RequestSpectatorServerList",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingServers_RequestSpectatorServerList",
+          "params": [
+            { "paramname":"iApp", "paramtype":"AppId_t" },
+            {
+              "array_count": "nFilters",
+              "paramname": "ppchFilters",
+              "paramtype": "MatchMakingKeyValuePair_t **"
+            },
+            { "paramname":"nFilters", "paramtype":"uint32" },
+            { "paramname":"pRequestServersResponse", "paramtype":"ISteamMatchmakingServerListResponse *" }
+          ],
+          "returntype": "HServerListRequest"
+        },
+        {
+          "methodname": "ReleaseRequest",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingServers_ReleaseRequest",
+          "params": [
+            { "paramname":"hServerListRequest", "paramtype":"HServerListRequest" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetServerDetails",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingServers_GetServerDetails",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HServerListRequest" },
+            { "paramname":"iServer", "paramtype":"int" }
+          ],
+          "returntype": "gameserveritem_t *"
+        },
+        {
+          "methodname": "CancelQuery",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingServers_CancelQuery",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HServerListRequest" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "RefreshQuery",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingServers_RefreshQuery",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HServerListRequest" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "IsRefreshing",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingServers_IsRefreshing",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HServerListRequest" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetServerCount",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingServers_GetServerCount",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HServerListRequest" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "RefreshServer",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingServers_RefreshServer",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HServerListRequest" },
+            { "paramname":"iServer", "paramtype":"int" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "PingServer",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingServers_PingServer",
+          "params": [
+            { "paramname":"unIP", "paramtype":"uint32" },
+            { "paramname":"usPort", "paramtype":"uint16" },
+            { "paramname":"pRequestServersResponse", "paramtype":"ISteamMatchmakingPingResponse *" }
+          ],
+          "returntype": "HServerQuery"
+        },
+        {
+          "methodname": "PlayerDetails",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingServers_PlayerDetails",
+          "params": [
+            { "paramname":"unIP", "paramtype":"uint32" },
+            { "paramname":"usPort", "paramtype":"uint16" },
+            { "paramname":"pRequestServersResponse", "paramtype":"ISteamMatchmakingPlayersResponse *" }
+          ],
+          "returntype": "HServerQuery"
+        },
+        {
+          "methodname": "ServerRules",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingServers_ServerRules",
+          "params": [
+            { "paramname":"unIP", "paramtype":"uint32" },
+            { "paramname":"usPort", "paramtype":"uint16" },
+            { "paramname":"pRequestServersResponse", "paramtype":"ISteamMatchmakingRulesResponse *" }
+          ],
+          "returntype": "HServerQuery"
+        },
+        {
+          "methodname": "CancelServerQuery",
+          "methodname_flat": "SteamAPI_ISteamMatchmakingServers_CancelServerQuery",
+          "params": [
+            { "paramname":"hServerQuery", "paramtype":"HServerQuery" }
+          ],
+          "returntype": "void"
+        }
+      ],
+      "version_string": "SteamMatchMakingServers002"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamGameSearch",
+          "name_flat": "SteamAPI_SteamGameSearch_v001"
+        }
+      ],
+      "classname": "ISteamGameSearch",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "AddGameSearchParams",
+          "methodname_flat": "SteamAPI_ISteamGameSearch_AddGameSearchParams",
+          "params": [
+            { "paramname":"pchKeyToFind", "paramtype":"const char *" },
+            { "paramname":"pchValuesToFind", "paramtype":"const char *" }
+          ],
+          "returntype": "EGameSearchErrorCode_t"
+        },
+        {
+          "methodname": "SearchForGameWithLobby",
+          "methodname_flat": "SteamAPI_ISteamGameSearch_SearchForGameWithLobby",
+          "params": [
+            { "paramname":"steamIDLobby", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"nPlayerMin", "paramtype":"int" },
+            { "paramname":"nPlayerMax", "paramtype":"int" }
+          ],
+          "returntype": "EGameSearchErrorCode_t"
+        },
+        {
+          "methodname": "SearchForGameSolo",
+          "methodname_flat": "SteamAPI_ISteamGameSearch_SearchForGameSolo",
+          "params": [
+            { "paramname":"nPlayerMin", "paramtype":"int" },
+            { "paramname":"nPlayerMax", "paramtype":"int" }
+          ],
+          "returntype": "EGameSearchErrorCode_t"
+        },
+        {
+          "methodname": "AcceptGame",
+          "methodname_flat": "SteamAPI_ISteamGameSearch_AcceptGame",
+          "params": [],
+          "returntype": "EGameSearchErrorCode_t"
+        },
+        {
+          "methodname": "DeclineGame",
+          "methodname_flat": "SteamAPI_ISteamGameSearch_DeclineGame",
+          "params": [],
+          "returntype": "EGameSearchErrorCode_t"
+        },
+        {
+          "methodname": "RetrieveConnectionDetails",
+          "methodname_flat": "SteamAPI_ISteamGameSearch_RetrieveConnectionDetails",
+          "params": [
+            { "paramname":"steamIDHost", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchConnectionDetails", "paramtype":"char *" },
+            { "paramname":"cubConnectionDetails", "paramtype":"int" }
+          ],
+          "returntype": "EGameSearchErrorCode_t"
+        },
+        {
+          "methodname": "EndGameSearch",
+          "methodname_flat": "SteamAPI_ISteamGameSearch_EndGameSearch",
+          "params": [],
+          "returntype": "EGameSearchErrorCode_t"
+        },
+        {
+          "methodname": "SetGameHostParams",
+          "methodname_flat": "SteamAPI_ISteamGameSearch_SetGameHostParams",
+          "params": [
+            { "paramname":"pchKey", "paramtype":"const char *" },
+            { "paramname":"pchValue", "paramtype":"const char *" }
+          ],
+          "returntype": "EGameSearchErrorCode_t"
+        },
+        {
+          "methodname": "SetConnectionDetails",
+          "methodname_flat": "SteamAPI_ISteamGameSearch_SetConnectionDetails",
+          "params": [
+            { "paramname":"pchConnectionDetails", "paramtype":"const char *" },
+            { "paramname":"cubConnectionDetails", "paramtype":"int" }
+          ],
+          "returntype": "EGameSearchErrorCode_t"
+        },
+        {
+          "methodname": "RequestPlayersForGame",
+          "methodname_flat": "SteamAPI_ISteamGameSearch_RequestPlayersForGame",
+          "params": [
+            { "paramname":"nPlayerMin", "paramtype":"int" },
+            { "paramname":"nPlayerMax", "paramtype":"int" },
+            { "paramname":"nMaxTeamSize", "paramtype":"int" }
+          ],
+          "returntype": "EGameSearchErrorCode_t"
+        },
+        {
+          "methodname": "HostConfirmGameStart",
+          "methodname_flat": "SteamAPI_ISteamGameSearch_HostConfirmGameStart",
+          "params": [
+            { "paramname":"ullUniqueGameID", "paramtype":"uint64" }
+          ],
+          "returntype": "EGameSearchErrorCode_t"
+        },
+        {
+          "methodname": "CancelRequestPlayersForGame",
+          "methodname_flat": "SteamAPI_ISteamGameSearch_CancelRequestPlayersForGame",
+          "params": [],
+          "returntype": "EGameSearchErrorCode_t"
+        },
+        {
+          "methodname": "SubmitPlayerResult",
+          "methodname_flat": "SteamAPI_ISteamGameSearch_SubmitPlayerResult",
+          "params": [
+            { "paramname":"ullUniqueGameID", "paramtype":"uint64" },
+            { "paramname":"steamIDPlayer", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"EPlayerResult", "paramtype":"EPlayerResult_t" }
+          ],
+          "returntype": "EGameSearchErrorCode_t"
+        },
+        {
+          "methodname": "EndGame",
+          "methodname_flat": "SteamAPI_ISteamGameSearch_EndGame",
+          "params": [
+            { "paramname":"ullUniqueGameID", "paramtype":"uint64" }
+          ],
+          "returntype": "EGameSearchErrorCode_t"
+        }
+      ],
+      "version_string": "SteamMatchGameSearch001"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamParties",
+          "name_flat": "SteamAPI_SteamParties_v002"
+        }
+      ],
+      "classname": "ISteamParties",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "GetNumActiveBeacons",
+          "methodname_flat": "SteamAPI_ISteamParties_GetNumActiveBeacons",
+          "params": [],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "GetBeaconByIndex",
+          "methodname_flat": "SteamAPI_ISteamParties_GetBeaconByIndex",
+          "params": [
+            { "paramname":"unIndex", "paramtype":"uint32" }
+          ],
+          "returntype": "PartyBeaconID_t"
+        },
+        {
+          "methodname": "GetBeaconDetails",
+          "methodname_flat": "SteamAPI_ISteamParties_GetBeaconDetails",
+          "params": [
+            { "paramname":"ulBeaconID", "paramtype":"PartyBeaconID_t" },
+            { "paramname":"pSteamIDBeaconOwner", "paramtype":"CSteamID *" },
+            {
+              "out_struct": "",
+              "paramname": "pLocation",
+              "paramtype": "SteamPartyBeaconLocation_t *"
+            },
+            {
+              "out_string_count": "cchMetadata",
+              "paramname": "pchMetadata",
+              "paramtype": "char *"
+            },
+            { "paramname":"cchMetadata", "paramtype":"int" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "callresult": "JoinPartyCallback_t",
+          "methodname": "JoinParty",
+          "methodname_flat": "SteamAPI_ISteamParties_JoinParty",
+          "params": [
+            { "paramname":"ulBeaconID", "paramtype":"PartyBeaconID_t" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "GetNumAvailableBeaconLocations",
+          "methodname_flat": "SteamAPI_ISteamParties_GetNumAvailableBeaconLocations",
+          "params": [
+            { "paramname":"puNumLocations", "paramtype":"uint32 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetAvailableBeaconLocations",
+          "methodname_flat": "SteamAPI_ISteamParties_GetAvailableBeaconLocations",
+          "params": [
+            { "paramname":"pLocationList", "paramtype":"SteamPartyBeaconLocation_t *" },
+            { "paramname":"uMaxNumLocations", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "callresult": "CreateBeaconCallback_t",
+          "methodname": "CreateBeacon",
+          "methodname_flat": "SteamAPI_ISteamParties_CreateBeacon",
+          "params": [
+            { "paramname":"unOpenSlots", "paramtype":"uint32" },
+            { "paramname":"pBeaconLocation", "paramtype":"SteamPartyBeaconLocation_t *" },
+            { "paramname":"pchConnectString", "paramtype":"const char *" },
+            { "paramname":"pchMetadata", "paramtype":"const char *" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "OnReservationCompleted",
+          "methodname_flat": "SteamAPI_ISteamParties_OnReservationCompleted",
+          "params": [
+            { "paramname":"ulBeacon", "paramtype":"PartyBeaconID_t" },
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "CancelReservation",
+          "methodname_flat": "SteamAPI_ISteamParties_CancelReservation",
+          "params": [
+            { "paramname":"ulBeacon", "paramtype":"PartyBeaconID_t" },
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "callresult": "ChangeNumOpenSlotsCallback_t",
+          "methodname": "ChangeNumOpenSlots",
+          "methodname_flat": "SteamAPI_ISteamParties_ChangeNumOpenSlots",
+          "params": [
+            { "paramname":"ulBeacon", "paramtype":"PartyBeaconID_t" },
+            { "paramname":"unOpenSlots", "paramtype":"uint32" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "DestroyBeacon",
+          "methodname_flat": "SteamAPI_ISteamParties_DestroyBeacon",
+          "params": [
+            { "paramname":"ulBeacon", "paramtype":"PartyBeaconID_t" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetBeaconLocationData",
+          "methodname_flat": "SteamAPI_ISteamParties_GetBeaconLocationData",
+          "params": [
+            { "paramname":"BeaconLocation", "paramtype":"SteamPartyBeaconLocation_t" },
+            { "paramname":"eData", "paramtype":"ESteamPartyBeaconLocationData" },
+            {
+              "out_string_count": "cchDataStringOut",
+              "paramname": "pchDataStringOut",
+              "paramtype": "char *"
+            },
+            { "paramname":"cchDataStringOut", "paramtype":"int" }
+          ],
+          "returntype": "bool"
+        }
+      ],
+      "version_string": "SteamParties002"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamRemoteStorage",
+          "name_flat": "SteamAPI_SteamRemoteStorage_v014"
+        }
+      ],
+      "classname": "ISteamRemoteStorage",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "FileWrite",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_FileWrite",
+          "params": [
+            { "paramname":"pchFile", "paramtype":"const char *" },
+            { "paramname":"pvData", "paramtype":"const void *" },
+            { "paramname":"cubData", "paramtype":"int32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "FileRead",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_FileRead",
+          "params": [
+            { "paramname":"pchFile", "paramtype":"const char *" },
+            { "paramname":"pvData", "paramtype":"void *" },
+            { "paramname":"cubDataToRead", "paramtype":"int32" }
+          ],
+          "returntype": "int32"
+        },
+        {
+          "callresult": "RemoteStorageFileWriteAsyncComplete_t",
+          "methodname": "FileWriteAsync",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_FileWriteAsync",
+          "params": [
+            { "paramname":"pchFile", "paramtype":"const char *" },
+            { "paramname":"pvData", "paramtype":"const void *" },
+            { "paramname":"cubData", "paramtype":"uint32" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "RemoteStorageFileReadAsyncComplete_t",
+          "methodname": "FileReadAsync",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_FileReadAsync",
+          "params": [
+            { "paramname":"pchFile", "paramtype":"const char *" },
+            { "paramname":"nOffset", "paramtype":"uint32" },
+            { "paramname":"cubToRead", "paramtype":"uint32" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "FileReadAsyncComplete",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_FileReadAsyncComplete",
+          "params": [
+            { "paramname":"hReadCall", "paramtype":"SteamAPICall_t" },
+            { "paramname":"pvBuffer", "paramtype":"void *" },
+            { "paramname":"cubToRead", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "FileForget",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_FileForget",
+          "params": [
+            { "paramname":"pchFile", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "FileDelete",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_FileDelete",
+          "params": [
+            { "paramname":"pchFile", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "callresult": "RemoteStorageFileShareResult_t",
+          "methodname": "FileShare",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_FileShare",
+          "params": [
+            { "paramname":"pchFile", "paramtype":"const char *" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "SetSyncPlatforms",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_SetSyncPlatforms",
+          "params": [
+            { "paramname":"pchFile", "paramtype":"const char *" },
+            { "paramname":"eRemoteStoragePlatform", "paramtype":"ERemoteStoragePlatform" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "FileWriteStreamOpen",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_FileWriteStreamOpen",
+          "params": [
+            { "paramname":"pchFile", "paramtype":"const char *" }
+          ],
+          "returntype": "UGCFileWriteStreamHandle_t"
+        },
+        {
+          "methodname": "FileWriteStreamWriteChunk",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_FileWriteStreamWriteChunk",
+          "params": [
+            { "paramname":"writeHandle", "paramtype":"UGCFileWriteStreamHandle_t" },
+            { "paramname":"pvData", "paramtype":"const void *" },
+            { "paramname":"cubData", "paramtype":"int32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "FileWriteStreamClose",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_FileWriteStreamClose",
+          "params": [
+            { "paramname":"writeHandle", "paramtype":"UGCFileWriteStreamHandle_t" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "FileWriteStreamCancel",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_FileWriteStreamCancel",
+          "params": [
+            { "paramname":"writeHandle", "paramtype":"UGCFileWriteStreamHandle_t" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "FileExists",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_FileExists",
+          "params": [
+            { "paramname":"pchFile", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "FilePersisted",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_FilePersisted",
+          "params": [
+            { "paramname":"pchFile", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetFileSize",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_GetFileSize",
+          "params": [
+            { "paramname":"pchFile", "paramtype":"const char *" }
+          ],
+          "returntype": "int32"
+        },
+        {
+          "methodname": "GetFileTimestamp",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_GetFileTimestamp",
+          "params": [
+            { "paramname":"pchFile", "paramtype":"const char *" }
+          ],
+          "returntype": "int64"
+        },
+        {
+          "methodname": "GetSyncPlatforms",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_GetSyncPlatforms",
+          "params": [
+            { "paramname":"pchFile", "paramtype":"const char *" }
+          ],
+          "returntype": "ERemoteStoragePlatform"
+        },
+        {
+          "methodname": "GetFileCount",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_GetFileCount",
+          "params": [],
+          "returntype": "int32"
+        },
+        {
+          "methodname": "GetFileNameAndSize",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_GetFileNameAndSize",
+          "params": [
+            { "paramname":"iFile", "paramtype":"int" },
+            { "paramname":"pnFileSizeInBytes", "paramtype":"int32 *" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "GetQuota",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_GetQuota",
+          "params": [
+            { "paramname":"pnTotalBytes", "paramtype":"uint64 *" },
+            { "paramname":"puAvailableBytes", "paramtype":"uint64 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "IsCloudEnabledForAccount",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_IsCloudEnabledForAccount",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "IsCloudEnabledForApp",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_IsCloudEnabledForApp",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetCloudEnabledForApp",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_SetCloudEnabledForApp",
+          "params": [
+            { "paramname":"bEnabled", "paramtype":"bool" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "callresult": "RemoteStorageDownloadUGCResult_t",
+          "methodname": "UGCDownload",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_UGCDownload",
+          "params": [
+            { "paramname":"hContent", "paramtype":"UGCHandle_t" },
+            { "paramname":"unPriority", "paramtype":"uint32" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "GetUGCDownloadProgress",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_GetUGCDownloadProgress",
+          "params": [
+            { "paramname":"hContent", "paramtype":"UGCHandle_t" },
+            { "paramname":"pnBytesDownloaded", "paramtype":"int32 *" },
+            { "paramname":"pnBytesExpected", "paramtype":"int32 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetUGCDetails",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_GetUGCDetails",
+          "params": [
+            { "paramname":"hContent", "paramtype":"UGCHandle_t" },
+            { "paramname":"pnAppID", "paramtype":"AppId_t *" },
+            {
+              "out_string": "",
+              "paramname": "ppchName",
+              "paramtype": "char **"
+            },
+            { "paramname":"pnFileSizeInBytes", "paramtype":"int32 *" },
+            {
+              "out_struct": "",
+              "paramname": "pSteamIDOwner",
+              "paramtype": "CSteamID *"
+            }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "UGCRead",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_UGCRead",
+          "params": [
+            { "paramname":"hContent", "paramtype":"UGCHandle_t" },
+            { "paramname":"pvData", "paramtype":"void *" },
+            { "paramname":"cubDataToRead", "paramtype":"int32" },
+            { "paramname":"cOffset", "paramtype":"uint32" },
+            { "paramname":"eAction", "paramtype":"EUGCReadAction" }
+          ],
+          "returntype": "int32"
+        },
+        {
+          "methodname": "GetCachedUGCCount",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_GetCachedUGCCount",
+          "params": [],
+          "returntype": "int32"
+        },
+        {
+          "methodname": "GetCachedUGCHandle",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_GetCachedUGCHandle",
+          "params": [
+            { "paramname":"iCachedContent", "paramtype":"int32" }
+          ],
+          "returntype": "UGCHandle_t"
+        },
+        {
+          "callresult": "RemoteStoragePublishFileProgress_t",
+          "methodname": "PublishWorkshopFile",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_PublishWorkshopFile",
+          "params": [
+            { "paramname":"pchFile", "paramtype":"const char *" },
+            { "paramname":"pchPreviewFile", "paramtype":"const char *" },
+            { "paramname":"nConsumerAppId", "paramtype":"AppId_t" },
+            { "paramname":"pchTitle", "paramtype":"const char *" },
+            { "paramname":"pchDescription", "paramtype":"const char *" },
+            { "paramname":"eVisibility", "paramtype":"ERemoteStoragePublishedFileVisibility" },
+            { "paramname":"pTags", "paramtype":"SteamParamStringArray_t *" },
+            { "paramname":"eWorkshopFileType", "paramtype":"EWorkshopFileType" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "CreatePublishedFileUpdateRequest",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_CreatePublishedFileUpdateRequest",
+          "params": [
+            { "paramname":"unPublishedFileId", "paramtype":"PublishedFileId_t" }
+          ],
+          "returntype": "PublishedFileUpdateHandle_t"
+        },
+        {
+          "methodname": "UpdatePublishedFileFile",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_UpdatePublishedFileFile",
+          "params": [
+            { "paramname":"updateHandle", "paramtype":"PublishedFileUpdateHandle_t" },
+            { "paramname":"pchFile", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "UpdatePublishedFilePreviewFile",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_UpdatePublishedFilePreviewFile",
+          "params": [
+            { "paramname":"updateHandle", "paramtype":"PublishedFileUpdateHandle_t" },
+            { "paramname":"pchPreviewFile", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "UpdatePublishedFileTitle",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_UpdatePublishedFileTitle",
+          "params": [
+            { "paramname":"updateHandle", "paramtype":"PublishedFileUpdateHandle_t" },
+            { "paramname":"pchTitle", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "UpdatePublishedFileDescription",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_UpdatePublishedFileDescription",
+          "params": [
+            { "paramname":"updateHandle", "paramtype":"PublishedFileUpdateHandle_t" },
+            { "paramname":"pchDescription", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "UpdatePublishedFileVisibility",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_UpdatePublishedFileVisibility",
+          "params": [
+            { "paramname":"updateHandle", "paramtype":"PublishedFileUpdateHandle_t" },
+            { "paramname":"eVisibility", "paramtype":"ERemoteStoragePublishedFileVisibility" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "UpdatePublishedFileTags",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_UpdatePublishedFileTags",
+          "params": [
+            { "paramname":"updateHandle", "paramtype":"PublishedFileUpdateHandle_t" },
+            { "paramname":"pTags", "paramtype":"SteamParamStringArray_t *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "callresult": "RemoteStorageUpdatePublishedFileResult_t",
+          "methodname": "CommitPublishedFileUpdate",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_CommitPublishedFileUpdate",
+          "params": [
+            { "paramname":"updateHandle", "paramtype":"PublishedFileUpdateHandle_t" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "RemoteStorageGetPublishedFileDetailsResult_t",
+          "methodname": "GetPublishedFileDetails",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_GetPublishedFileDetails",
+          "params": [
+            { "paramname":"unPublishedFileId", "paramtype":"PublishedFileId_t" },
+            { "paramname":"unMaxSecondsOld", "paramtype":"uint32" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "RemoteStorageDeletePublishedFileResult_t",
+          "methodname": "DeletePublishedFile",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_DeletePublishedFile",
+          "params": [
+            { "paramname":"unPublishedFileId", "paramtype":"PublishedFileId_t" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "RemoteStorageEnumerateUserPublishedFilesResult_t",
+          "methodname": "EnumerateUserPublishedFiles",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_EnumerateUserPublishedFiles",
+          "params": [
+            { "paramname":"unStartIndex", "paramtype":"uint32" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "RemoteStorageSubscribePublishedFileResult_t",
+          "methodname": "SubscribePublishedFile",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_SubscribePublishedFile",
+          "params": [
+            { "paramname":"unPublishedFileId", "paramtype":"PublishedFileId_t" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "RemoteStorageEnumerateUserSubscribedFilesResult_t",
+          "methodname": "EnumerateUserSubscribedFiles",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_EnumerateUserSubscribedFiles",
+          "params": [
+            { "paramname":"unStartIndex", "paramtype":"uint32" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "RemoteStorageUnsubscribePublishedFileResult_t",
+          "methodname": "UnsubscribePublishedFile",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_UnsubscribePublishedFile",
+          "params": [
+            { "paramname":"unPublishedFileId", "paramtype":"PublishedFileId_t" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "UpdatePublishedFileSetChangeDescription",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_UpdatePublishedFileSetChangeDescription",
+          "params": [
+            { "paramname":"updateHandle", "paramtype":"PublishedFileUpdateHandle_t" },
+            { "paramname":"pchChangeDescription", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "callresult": "RemoteStorageGetPublishedItemVoteDetailsResult_t",
+          "methodname": "GetPublishedItemVoteDetails",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_GetPublishedItemVoteDetails",
+          "params": [
+            { "paramname":"unPublishedFileId", "paramtype":"PublishedFileId_t" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "RemoteStorageUpdateUserPublishedItemVoteResult_t",
+          "methodname": "UpdateUserPublishedItemVote",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_UpdateUserPublishedItemVote",
+          "params": [
+            { "paramname":"unPublishedFileId", "paramtype":"PublishedFileId_t" },
+            { "paramname":"bVoteUp", "paramtype":"bool" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "RemoteStorageGetPublishedItemVoteDetailsResult_t",
+          "methodname": "GetUserPublishedItemVoteDetails",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_GetUserPublishedItemVoteDetails",
+          "params": [
+            { "paramname":"unPublishedFileId", "paramtype":"PublishedFileId_t" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "RemoteStorageEnumerateUserPublishedFilesResult_t",
+          "methodname": "EnumerateUserSharedWorkshopFiles",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_EnumerateUserSharedWorkshopFiles",
+          "params": [
+            { "paramname":"steamId", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"unStartIndex", "paramtype":"uint32" },
+            { "paramname":"pRequiredTags", "paramtype":"SteamParamStringArray_t *" },
+            { "paramname":"pExcludedTags", "paramtype":"SteamParamStringArray_t *" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "RemoteStoragePublishFileProgress_t",
+          "methodname": "PublishVideo",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_PublishVideo",
+          "params": [
+            { "paramname":"eVideoProvider", "paramtype":"EWorkshopVideoProvider" },
+            { "paramname":"pchVideoAccount", "paramtype":"const char *" },
+            { "paramname":"pchVideoIdentifier", "paramtype":"const char *" },
+            { "paramname":"pchPreviewFile", "paramtype":"const char *" },
+            { "paramname":"nConsumerAppId", "paramtype":"AppId_t" },
+            { "paramname":"pchTitle", "paramtype":"const char *" },
+            { "paramname":"pchDescription", "paramtype":"const char *" },
+            { "paramname":"eVisibility", "paramtype":"ERemoteStoragePublishedFileVisibility" },
+            { "paramname":"pTags", "paramtype":"SteamParamStringArray_t *" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "RemoteStorageSetUserPublishedFileActionResult_t",
+          "methodname": "SetUserPublishedFileAction",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_SetUserPublishedFileAction",
+          "params": [
+            { "paramname":"unPublishedFileId", "paramtype":"PublishedFileId_t" },
+            { "paramname":"eAction", "paramtype":"EWorkshopFileAction" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "RemoteStorageEnumeratePublishedFilesByUserActionResult_t",
+          "methodname": "EnumeratePublishedFilesByUserAction",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_EnumeratePublishedFilesByUserAction",
+          "params": [
+            { "paramname":"eAction", "paramtype":"EWorkshopFileAction" },
+            { "paramname":"unStartIndex", "paramtype":"uint32" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "RemoteStorageEnumerateWorkshopFilesResult_t",
+          "methodname": "EnumeratePublishedWorkshopFiles",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_EnumeratePublishedWorkshopFiles",
+          "params": [
+            { "paramname":"eEnumerationType", "paramtype":"EWorkshopEnumerationType" },
+            { "paramname":"unStartIndex", "paramtype":"uint32" },
+            { "paramname":"unCount", "paramtype":"uint32" },
+            { "paramname":"unDays", "paramtype":"uint32" },
+            { "paramname":"pTags", "paramtype":"SteamParamStringArray_t *" },
+            { "paramname":"pUserTags", "paramtype":"SteamParamStringArray_t *" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "RemoteStorageDownloadUGCResult_t",
+          "methodname": "UGCDownloadToLocation",
+          "methodname_flat": "SteamAPI_ISteamRemoteStorage_UGCDownloadToLocation",
+          "params": [
+            { "paramname":"hContent", "paramtype":"UGCHandle_t" },
+            { "paramname":"pchLocation", "paramtype":"const char *" },
+            { "paramname":"unPriority", "paramtype":"uint32" }
+          ],
+          "returntype": "SteamAPICall_t"
+        }
+      ],
+      "version_string": "STEAMREMOTESTORAGE_INTERFACE_VERSION014"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamUserStats",
+          "name_flat": "SteamAPI_SteamUserStats_v011"
+        }
+      ],
+      "classname": "ISteamUserStats",
+      "fields": [],
+      "methods": [
+        {
+          "callback": "UserStatsReceived_t",
+          "methodname": "RequestCurrentStats",
+          "methodname_flat": "SteamAPI_ISteamUserStats_RequestCurrentStats",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetStat",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetStatInt32",
+          "params": [
+            { "paramname":"pchName", "paramtype":"const char *" },
+            { "paramname":"pData", "paramtype":"int32 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetStat",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetStatFloat",
+          "params": [
+            { "paramname":"pchName", "paramtype":"const char *" },
+            { "paramname":"pData", "paramtype":"float *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetStat",
+          "methodname_flat": "SteamAPI_ISteamUserStats_SetStatInt32",
+          "params": [
+            { "paramname":"pchName", "paramtype":"const char *" },
+            { "paramname":"nData", "paramtype":"int32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetStat",
+          "methodname_flat": "SteamAPI_ISteamUserStats_SetStatFloat",
+          "params": [
+            { "paramname":"pchName", "paramtype":"const char *" },
+            { "paramname":"fData", "paramtype":"float" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "UpdateAvgRateStat",
+          "methodname_flat": "SteamAPI_ISteamUserStats_UpdateAvgRateStat",
+          "params": [
+            { "paramname":"pchName", "paramtype":"const char *" },
+            { "paramname":"flCountThisSession", "paramtype":"float" },
+            { "paramname":"dSessionLength", "paramtype":"double" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetAchievement",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetAchievement",
+          "params": [
+            { "paramname":"pchName", "paramtype":"const char *" },
+            { "paramname":"pbAchieved", "paramtype":"bool *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetAchievement",
+          "methodname_flat": "SteamAPI_ISteamUserStats_SetAchievement",
+          "params": [
+            { "paramname":"pchName", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "ClearAchievement",
+          "methodname_flat": "SteamAPI_ISteamUserStats_ClearAchievement",
+          "params": [
+            { "paramname":"pchName", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetAchievementAndUnlockTime",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetAchievementAndUnlockTime",
+          "params": [
+            { "paramname":"pchName", "paramtype":"const char *" },
+            { "paramname":"pbAchieved", "paramtype":"bool *" },
+            { "paramname":"punUnlockTime", "paramtype":"uint32 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "StoreStats",
+          "methodname_flat": "SteamAPI_ISteamUserStats_StoreStats",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetAchievementIcon",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetAchievementIcon",
+          "params": [
+            { "paramname":"pchName", "paramtype":"const char *" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetAchievementDisplayAttribute",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetAchievementDisplayAttribute",
+          "params": [
+            { "paramname":"pchName", "paramtype":"const char *" },
+            { "paramname":"pchKey", "paramtype":"const char *" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "IndicateAchievementProgress",
+          "methodname_flat": "SteamAPI_ISteamUserStats_IndicateAchievementProgress",
+          "params": [
+            { "paramname":"pchName", "paramtype":"const char *" },
+            { "paramname":"nCurProgress", "paramtype":"uint32" },
+            { "paramname":"nMaxProgress", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetNumAchievements",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetNumAchievements",
+          "params": [],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "GetAchievementName",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetAchievementName",
+          "params": [
+            { "paramname":"iAchievement", "paramtype":"uint32" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "callresult": "UserStatsReceived_t",
+          "methodname": "RequestUserStats",
+          "methodname_flat": "SteamAPI_ISteamUserStats_RequestUserStats",
+          "params": [
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "GetUserStat",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetUserStatInt32",
+          "params": [
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchName", "paramtype":"const char *" },
+            { "paramname":"pData", "paramtype":"int32 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetUserStat",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetUserStatFloat",
+          "params": [
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchName", "paramtype":"const char *" },
+            { "paramname":"pData", "paramtype":"float *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetUserAchievement",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetUserAchievement",
+          "params": [
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchName", "paramtype":"const char *" },
+            { "paramname":"pbAchieved", "paramtype":"bool *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetUserAchievementAndUnlockTime",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetUserAchievementAndUnlockTime",
+          "params": [
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchName", "paramtype":"const char *" },
+            { "paramname":"pbAchieved", "paramtype":"bool *" },
+            { "paramname":"punUnlockTime", "paramtype":"uint32 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "ResetAllStats",
+          "methodname_flat": "SteamAPI_ISteamUserStats_ResetAllStats",
+          "params": [
+            { "paramname":"bAchievementsToo", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "callresult": "LeaderboardFindResult_t",
+          "methodname": "FindOrCreateLeaderboard",
+          "methodname_flat": "SteamAPI_ISteamUserStats_FindOrCreateLeaderboard",
+          "params": [
+            { "paramname":"pchLeaderboardName", "paramtype":"const char *" },
+            { "paramname":"eLeaderboardSortMethod", "paramtype":"ELeaderboardSortMethod" },
+            { "paramname":"eLeaderboardDisplayType", "paramtype":"ELeaderboardDisplayType" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "LeaderboardFindResult_t",
+          "methodname": "FindLeaderboard",
+          "methodname_flat": "SteamAPI_ISteamUserStats_FindLeaderboard",
+          "params": [
+            { "paramname":"pchLeaderboardName", "paramtype":"const char *" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "GetLeaderboardName",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetLeaderboardName",
+          "params": [
+            { "paramname":"hSteamLeaderboard", "paramtype":"SteamLeaderboard_t" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "GetLeaderboardEntryCount",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetLeaderboardEntryCount",
+          "params": [
+            { "paramname":"hSteamLeaderboard", "paramtype":"SteamLeaderboard_t" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetLeaderboardSortMethod",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetLeaderboardSortMethod",
+          "params": [
+            { "paramname":"hSteamLeaderboard", "paramtype":"SteamLeaderboard_t" }
+          ],
+          "returntype": "ELeaderboardSortMethod"
+        },
+        {
+          "methodname": "GetLeaderboardDisplayType",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetLeaderboardDisplayType",
+          "params": [
+            { "paramname":"hSteamLeaderboard", "paramtype":"SteamLeaderboard_t" }
+          ],
+          "returntype": "ELeaderboardDisplayType"
+        },
+        {
+          "callresult": "LeaderboardScoresDownloaded_t",
+          "methodname": "DownloadLeaderboardEntries",
+          "methodname_flat": "SteamAPI_ISteamUserStats_DownloadLeaderboardEntries",
+          "params": [
+            { "paramname":"hSteamLeaderboard", "paramtype":"SteamLeaderboard_t" },
+            { "paramname":"eLeaderboardDataRequest", "paramtype":"ELeaderboardDataRequest" },
+            { "paramname":"nRangeStart", "paramtype":"int" },
+            { "paramname":"nRangeEnd", "paramtype":"int" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "LeaderboardScoresDownloaded_t",
+          "desc": "Downloads leaderboard entries for an arbitrary set of users - ELeaderboardDataRequest is k_ELeaderboardDataRequestUsers",
+          "methodname": "DownloadLeaderboardEntriesForUsers",
+          "methodname_flat": "SteamAPI_ISteamUserStats_DownloadLeaderboardEntriesForUsers",
+          "params": [
+            { "paramname":"hSteamLeaderboard", "paramtype":"SteamLeaderboard_t" },
+            {
+              "array_count": "cUsers",
+              "desc": "Array of users to retrieve",
+              "paramname": "prgUsers",
+              "paramtype": "CSteamID *"
+            },
+            { "paramname":"cUsers", "paramtype":"int" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "GetDownloadedLeaderboardEntry",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetDownloadedLeaderboardEntry",
+          "params": [
+            { "paramname":"hSteamLeaderboardEntries", "paramtype":"SteamLeaderboardEntries_t" },
+            { "paramname":"index", "paramtype":"int" },
+            { "paramname":"pLeaderboardEntry", "paramtype":"LeaderboardEntry_t *" },
+            { "paramname":"pDetails", "paramtype":"int32 *" },
+            { "paramname":"cDetailsMax", "paramtype":"int" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "callresult": "LeaderboardScoreUploaded_t",
+          "methodname": "UploadLeaderboardScore",
+          "methodname_flat": "SteamAPI_ISteamUserStats_UploadLeaderboardScore",
+          "params": [
+            { "paramname":"hSteamLeaderboard", "paramtype":"SteamLeaderboard_t" },
+            { "paramname":"eLeaderboardUploadScoreMethod", "paramtype":"ELeaderboardUploadScoreMethod" },
+            { "paramname":"nScore", "paramtype":"int32" },
+            { "paramname":"pScoreDetails", "paramtype":"const int32 *" },
+            { "paramname":"cScoreDetailsCount", "paramtype":"int" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "LeaderboardUGCSet_t",
+          "methodname": "AttachLeaderboardUGC",
+          "methodname_flat": "SteamAPI_ISteamUserStats_AttachLeaderboardUGC",
+          "params": [
+            { "paramname":"hSteamLeaderboard", "paramtype":"SteamLeaderboard_t" },
+            { "paramname":"hUGC", "paramtype":"UGCHandle_t" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "NumberOfCurrentPlayers_t",
+          "methodname": "GetNumberOfCurrentPlayers",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetNumberOfCurrentPlayers",
+          "params": [],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "GlobalAchievementPercentagesReady_t",
+          "methodname": "RequestGlobalAchievementPercentages",
+          "methodname_flat": "SteamAPI_ISteamUserStats_RequestGlobalAchievementPercentages",
+          "params": [],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "GetMostAchievedAchievementInfo",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetMostAchievedAchievementInfo",
+          "params": [
+            { "paramname":"pchName", "paramtype":"char *" },
+            { "paramname":"unNameBufLen", "paramtype":"uint32" },
+            { "paramname":"pflPercent", "paramtype":"float *" },
+            { "paramname":"pbAchieved", "paramtype":"bool *" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetNextMostAchievedAchievementInfo",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetNextMostAchievedAchievementInfo",
+          "params": [
+            { "paramname":"iIteratorPrevious", "paramtype":"int" },
+            { "paramname":"pchName", "paramtype":"char *" },
+            { "paramname":"unNameBufLen", "paramtype":"uint32" },
+            { "paramname":"pflPercent", "paramtype":"float *" },
+            { "paramname":"pbAchieved", "paramtype":"bool *" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetAchievementAchievedPercent",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetAchievementAchievedPercent",
+          "params": [
+            { "paramname":"pchName", "paramtype":"const char *" },
+            { "paramname":"pflPercent", "paramtype":"float *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "callresult": "GlobalStatsReceived_t",
+          "methodname": "RequestGlobalStats",
+          "methodname_flat": "SteamAPI_ISteamUserStats_RequestGlobalStats",
+          "params": [
+            { "paramname":"nHistoryDays", "paramtype":"int" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "GetGlobalStat",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetGlobalStatInt64",
+          "params": [
+            { "paramname":"pchStatName", "paramtype":"const char *" },
+            { "paramname":"pData", "paramtype":"int64 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetGlobalStat",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetGlobalStatDouble",
+          "params": [
+            { "paramname":"pchStatName", "paramtype":"const char *" },
+            { "paramname":"pData", "paramtype":"double *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetGlobalStatHistory",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetGlobalStatHistoryInt64",
+          "params": [
+            { "paramname":"pchStatName", "paramtype":"const char *" },
+            {
+              "array_count": "cubData",
+              "paramname": "pData",
+              "paramtype": "int64 *"
+            },
+            { "paramname":"cubData", "paramtype":"uint32" }
+          ],
+          "returntype": "int32"
+        },
+        {
+          "methodname": "GetGlobalStatHistory",
+          "methodname_flat": "SteamAPI_ISteamUserStats_GetGlobalStatHistoryDouble",
+          "params": [
+            { "paramname":"pchStatName", "paramtype":"const char *" },
+            {
+              "array_count": "cubData",
+              "paramname": "pData",
+              "paramtype": "double *"
+            },
+            { "paramname":"cubData", "paramtype":"uint32" }
+          ],
+          "returntype": "int32"
+        }
+      ],
+      "version_string": "STEAMUSERSTATS_INTERFACE_VERSION011"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamApps",
+          "name_flat": "SteamAPI_SteamApps_v008"
+        },
+        {
+          "kind": "gameserver",
+          "name": "SteamGameServerApps",
+          "name_flat": "SteamAPI_SteamGameServerApps_v008"
+        }
+      ],
+      "classname": "ISteamApps",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "BIsSubscribed",
+          "methodname_flat": "SteamAPI_ISteamApps_BIsSubscribed",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "BIsLowViolence",
+          "methodname_flat": "SteamAPI_ISteamApps_BIsLowViolence",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "BIsCybercafe",
+          "methodname_flat": "SteamAPI_ISteamApps_BIsCybercafe",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "BIsVACBanned",
+          "methodname_flat": "SteamAPI_ISteamApps_BIsVACBanned",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetCurrentGameLanguage",
+          "methodname_flat": "SteamAPI_ISteamApps_GetCurrentGameLanguage",
+          "params": [],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "GetAvailableGameLanguages",
+          "methodname_flat": "SteamAPI_ISteamApps_GetAvailableGameLanguages",
+          "params": [],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "BIsSubscribedApp",
+          "methodname_flat": "SteamAPI_ISteamApps_BIsSubscribedApp",
+          "params": [
+            { "paramname":"appID", "paramtype":"AppId_t" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "BIsDlcInstalled",
+          "methodname_flat": "SteamAPI_ISteamApps_BIsDlcInstalled",
+          "params": [
+            { "paramname":"appID", "paramtype":"AppId_t" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetEarliestPurchaseUnixTime",
+          "methodname_flat": "SteamAPI_ISteamApps_GetEarliestPurchaseUnixTime",
+          "params": [
+            { "paramname":"nAppID", "paramtype":"AppId_t" }
+          ],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "BIsSubscribedFromFreeWeekend",
+          "methodname_flat": "SteamAPI_ISteamApps_BIsSubscribedFromFreeWeekend",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetDLCCount",
+          "methodname_flat": "SteamAPI_ISteamApps_GetDLCCount",
+          "params": [],
+          "returntype": "int"
+        },
+        {
+          "methodname": "BGetDLCDataByIndex",
+          "methodname_flat": "SteamAPI_ISteamApps_BGetDLCDataByIndex",
+          "params": [
+            { "paramname":"iDLC", "paramtype":"int" },
+            { "paramname":"pAppID", "paramtype":"AppId_t *" },
+            { "paramname":"pbAvailable", "paramtype":"bool *" },
+            { "paramname":"pchName", "paramtype":"char *" },
+            { "paramname":"cchNameBufferSize", "paramtype":"int" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "InstallDLC",
+          "methodname_flat": "SteamAPI_ISteamApps_InstallDLC",
+          "params": [
+            { "paramname":"nAppID", "paramtype":"AppId_t" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "UninstallDLC",
+          "methodname_flat": "SteamAPI_ISteamApps_UninstallDLC",
+          "params": [
+            { "paramname":"nAppID", "paramtype":"AppId_t" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "RequestAppProofOfPurchaseKey",
+          "methodname_flat": "SteamAPI_ISteamApps_RequestAppProofOfPurchaseKey",
+          "params": [
+            { "paramname":"nAppID", "paramtype":"AppId_t" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetCurrentBetaName",
+          "methodname_flat": "SteamAPI_ISteamApps_GetCurrentBetaName",
+          "params": [
+            { "paramname":"pchName", "paramtype":"char *" },
+            { "paramname":"cchNameBufferSize", "paramtype":"int" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "MarkContentCorrupt",
+          "methodname_flat": "SteamAPI_ISteamApps_MarkContentCorrupt",
+          "params": [
+            { "paramname":"bMissingFilesOnly", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetInstalledDepots",
+          "methodname_flat": "SteamAPI_ISteamApps_GetInstalledDepots",
+          "params": [
+            { "paramname":"appID", "paramtype":"AppId_t" },
+            { "paramname":"pvecDepots", "paramtype":"DepotId_t *" },
+            { "paramname":"cMaxDepots", "paramtype":"uint32" }
+          ],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "GetAppInstallDir",
+          "methodname_flat": "SteamAPI_ISteamApps_GetAppInstallDir",
+          "params": [
+            { "paramname":"appID", "paramtype":"AppId_t" },
+            { "paramname":"pchFolder", "paramtype":"char *" },
+            { "paramname":"cchFolderBufferSize", "paramtype":"uint32" }
+          ],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "BIsAppInstalled",
+          "methodname_flat": "SteamAPI_ISteamApps_BIsAppInstalled",
+          "params": [
+            { "paramname":"appID", "paramtype":"AppId_t" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetAppOwner",
+          "methodname_flat": "SteamAPI_ISteamApps_GetAppOwner",
+          "params": [],
+          "returntype": "CSteamID",
+          "returntype_flat": "uint64_steamid"
+        },
+        {
+          "methodname": "GetLaunchQueryParam",
+          "methodname_flat": "SteamAPI_ISteamApps_GetLaunchQueryParam",
+          "params": [
+            { "paramname":"pchKey", "paramtype":"const char *" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "GetDlcDownloadProgress",
+          "methodname_flat": "SteamAPI_ISteamApps_GetDlcDownloadProgress",
+          "params": [
+            { "paramname":"nAppID", "paramtype":"AppId_t" },
+            { "paramname":"punBytesDownloaded", "paramtype":"uint64 *" },
+            { "paramname":"punBytesTotal", "paramtype":"uint64 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetAppBuildId",
+          "methodname_flat": "SteamAPI_ISteamApps_GetAppBuildId",
+          "params": [],
+          "returntype": "int"
+        },
+        {
+          "methodname": "RequestAllProofOfPurchaseKeys",
+          "methodname_flat": "SteamAPI_ISteamApps_RequestAllProofOfPurchaseKeys",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "callresult": "FileDetailsResult_t",
+          "methodname": "GetFileDetails",
+          "methodname_flat": "SteamAPI_ISteamApps_GetFileDetails",
+          "params": [
+            { "paramname":"pszFileName", "paramtype":"const char *" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "GetLaunchCommandLine",
+          "methodname_flat": "SteamAPI_ISteamApps_GetLaunchCommandLine",
+          "params": [
+            { "paramname":"pszCommandLine", "paramtype":"char *" },
+            { "paramname":"cubCommandLine", "paramtype":"int" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "BIsSubscribedFromFamilySharing",
+          "methodname_flat": "SteamAPI_ISteamApps_BIsSubscribedFromFamilySharing",
+          "params": [],
+          "returntype": "bool"
+        }
+      ],
+      "version_string": "STEAMAPPS_INTERFACE_VERSION008"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamNetworking",
+          "name_flat": "SteamAPI_SteamNetworking_v006"
+        },
+        {
+          "kind": "gameserver",
+          "name": "SteamGameServerNetworking",
+          "name_flat": "SteamAPI_SteamGameServerNetworking_v006"
+        }
+      ],
+      "classname": "ISteamNetworking",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "SendP2PPacket",
+          "methodname_flat": "SteamAPI_ISteamNetworking_SendP2PPacket",
+          "params": [
+            { "paramname":"steamIDRemote", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pubData", "paramtype":"const void *" },
+            { "paramname":"cubData", "paramtype":"uint32" },
+            { "paramname":"eP2PSendType", "paramtype":"EP2PSend" },
+            { "paramname":"nChannel", "paramtype":"int" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "IsP2PPacketAvailable",
+          "methodname_flat": "SteamAPI_ISteamNetworking_IsP2PPacketAvailable",
+          "params": [
+            { "paramname":"pcubMsgSize", "paramtype":"uint32 *" },
+            { "paramname":"nChannel", "paramtype":"int" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "ReadP2PPacket",
+          "methodname_flat": "SteamAPI_ISteamNetworking_ReadP2PPacket",
+          "params": [
+            { "paramname":"pubDest", "paramtype":"void *" },
+            { "paramname":"cubDest", "paramtype":"uint32" },
+            { "paramname":"pcubMsgSize", "paramtype":"uint32 *" },
+            { "paramname":"psteamIDRemote", "paramtype":"CSteamID *" },
+            { "paramname":"nChannel", "paramtype":"int" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "AcceptP2PSessionWithUser",
+          "methodname_flat": "SteamAPI_ISteamNetworking_AcceptP2PSessionWithUser",
+          "params": [
+            { "paramname":"steamIDRemote", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "CloseP2PSessionWithUser",
+          "methodname_flat": "SteamAPI_ISteamNetworking_CloseP2PSessionWithUser",
+          "params": [
+            { "paramname":"steamIDRemote", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "CloseP2PChannelWithUser",
+          "methodname_flat": "SteamAPI_ISteamNetworking_CloseP2PChannelWithUser",
+          "params": [
+            { "paramname":"steamIDRemote", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"nChannel", "paramtype":"int" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetP2PSessionState",
+          "methodname_flat": "SteamAPI_ISteamNetworking_GetP2PSessionState",
+          "params": [
+            { "paramname":"steamIDRemote", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pConnectionState", "paramtype":"P2PSessionState_t *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "AllowP2PPacketRelay",
+          "methodname_flat": "SteamAPI_ISteamNetworking_AllowP2PPacketRelay",
+          "params": [
+            { "paramname":"bAllow", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "CreateListenSocket",
+          "methodname_flat": "SteamAPI_ISteamNetworking_CreateListenSocket",
+          "params": [
+            { "paramname":"nVirtualP2PPort", "paramtype":"int" },
+            { "paramname":"nIP", "paramtype":"SteamIPAddress_t" },
+            { "paramname":"nPort", "paramtype":"uint16" },
+            { "paramname":"bAllowUseOfPacketRelay", "paramtype":"bool" }
+          ],
+          "returntype": "SNetListenSocket_t"
+        },
+        {
+          "methodname": "CreateP2PConnectionSocket",
+          "methodname_flat": "SteamAPI_ISteamNetworking_CreateP2PConnectionSocket",
+          "params": [
+            { "paramname":"steamIDTarget", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"nVirtualPort", "paramtype":"int" },
+            { "paramname":"nTimeoutSec", "paramtype":"int" },
+            { "paramname":"bAllowUseOfPacketRelay", "paramtype":"bool" }
+          ],
+          "returntype": "SNetSocket_t"
+        },
+        {
+          "methodname": "CreateConnectionSocket",
+          "methodname_flat": "SteamAPI_ISteamNetworking_CreateConnectionSocket",
+          "params": [
+            { "paramname":"nIP", "paramtype":"SteamIPAddress_t" },
+            { "paramname":"nPort", "paramtype":"uint16" },
+            { "paramname":"nTimeoutSec", "paramtype":"int" }
+          ],
+          "returntype": "SNetSocket_t"
+        },
+        {
+          "methodname": "DestroySocket",
+          "methodname_flat": "SteamAPI_ISteamNetworking_DestroySocket",
+          "params": [
+            { "paramname":"hSocket", "paramtype":"SNetSocket_t" },
+            { "paramname":"bNotifyRemoteEnd", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "DestroyListenSocket",
+          "methodname_flat": "SteamAPI_ISteamNetworking_DestroyListenSocket",
+          "params": [
+            { "paramname":"hSocket", "paramtype":"SNetListenSocket_t" },
+            { "paramname":"bNotifyRemoteEnd", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SendDataOnSocket",
+          "methodname_flat": "SteamAPI_ISteamNetworking_SendDataOnSocket",
+          "params": [
+            { "paramname":"hSocket", "paramtype":"SNetSocket_t" },
+            { "paramname":"pubData", "paramtype":"void *" },
+            { "paramname":"cubData", "paramtype":"uint32" },
+            { "paramname":"bReliable", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "IsDataAvailableOnSocket",
+          "methodname_flat": "SteamAPI_ISteamNetworking_IsDataAvailableOnSocket",
+          "params": [
+            { "paramname":"hSocket", "paramtype":"SNetSocket_t" },
+            { "paramname":"pcubMsgSize", "paramtype":"uint32 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "RetrieveDataFromSocket",
+          "methodname_flat": "SteamAPI_ISteamNetworking_RetrieveDataFromSocket",
+          "params": [
+            { "paramname":"hSocket", "paramtype":"SNetSocket_t" },
+            { "paramname":"pubDest", "paramtype":"void *" },
+            { "paramname":"cubDest", "paramtype":"uint32" },
+            { "paramname":"pcubMsgSize", "paramtype":"uint32 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "IsDataAvailable",
+          "methodname_flat": "SteamAPI_ISteamNetworking_IsDataAvailable",
+          "params": [
+            { "paramname":"hListenSocket", "paramtype":"SNetListenSocket_t" },
+            { "paramname":"pcubMsgSize", "paramtype":"uint32 *" },
+            { "paramname":"phSocket", "paramtype":"SNetSocket_t *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "RetrieveData",
+          "methodname_flat": "SteamAPI_ISteamNetworking_RetrieveData",
+          "params": [
+            { "paramname":"hListenSocket", "paramtype":"SNetListenSocket_t" },
+            { "paramname":"pubDest", "paramtype":"void *" },
+            { "paramname":"cubDest", "paramtype":"uint32" },
+            { "paramname":"pcubMsgSize", "paramtype":"uint32 *" },
+            { "paramname":"phSocket", "paramtype":"SNetSocket_t *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetSocketInfo",
+          "methodname_flat": "SteamAPI_ISteamNetworking_GetSocketInfo",
+          "params": [
+            { "paramname":"hSocket", "paramtype":"SNetSocket_t" },
+            { "paramname":"pSteamIDRemote", "paramtype":"CSteamID *" },
+            { "paramname":"peSocketStatus", "paramtype":"int *" },
+            { "paramname":"punIPRemote", "paramtype":"SteamIPAddress_t *" },
+            { "paramname":"punPortRemote", "paramtype":"uint16 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetListenSocketInfo",
+          "methodname_flat": "SteamAPI_ISteamNetworking_GetListenSocketInfo",
+          "params": [
+            { "paramname":"hListenSocket", "paramtype":"SNetListenSocket_t" },
+            { "paramname":"pnIP", "paramtype":"SteamIPAddress_t *" },
+            { "paramname":"pnPort", "paramtype":"uint16 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetSocketConnectionType",
+          "methodname_flat": "SteamAPI_ISteamNetworking_GetSocketConnectionType",
+          "params": [
+            { "paramname":"hSocket", "paramtype":"SNetSocket_t" }
+          ],
+          "returntype": "ESNetSocketConnectionType"
+        },
+        {
+          "methodname": "GetMaxPacketSize",
+          "methodname_flat": "SteamAPI_ISteamNetworking_GetMaxPacketSize",
+          "params": [
+            { "paramname":"hSocket", "paramtype":"SNetSocket_t" }
+          ],
+          "returntype": "int"
+        }
+      ],
+      "version_string": "SteamNetworking006"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamScreenshots",
+          "name_flat": "SteamAPI_SteamScreenshots_v003"
+        }
+      ],
+      "classname": "ISteamScreenshots",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "WriteScreenshot",
+          "methodname_flat": "SteamAPI_ISteamScreenshots_WriteScreenshot",
+          "params": [
+            { "paramname":"pubRGB", "paramtype":"void *" },
+            { "paramname":"cubRGB", "paramtype":"uint32" },
+            { "paramname":"nWidth", "paramtype":"int" },
+            { "paramname":"nHeight", "paramtype":"int" }
+          ],
+          "returntype": "ScreenshotHandle"
+        },
+        {
+          "methodname": "AddScreenshotToLibrary",
+          "methodname_flat": "SteamAPI_ISteamScreenshots_AddScreenshotToLibrary",
+          "params": [
+            { "paramname":"pchFilename", "paramtype":"const char *" },
+            { "paramname":"pchThumbnailFilename", "paramtype":"const char *" },
+            { "paramname":"nWidth", "paramtype":"int" },
+            { "paramname":"nHeight", "paramtype":"int" }
+          ],
+          "returntype": "ScreenshotHandle"
+        },
+        {
+          "methodname": "TriggerScreenshot",
+          "methodname_flat": "SteamAPI_ISteamScreenshots_TriggerScreenshot",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "HookScreenshots",
+          "methodname_flat": "SteamAPI_ISteamScreenshots_HookScreenshots",
+          "params": [
+            { "paramname":"bHook", "paramtype":"bool" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetLocation",
+          "methodname_flat": "SteamAPI_ISteamScreenshots_SetLocation",
+          "params": [
+            { "paramname":"hScreenshot", "paramtype":"ScreenshotHandle" },
+            { "paramname":"pchLocation", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "TagUser",
+          "methodname_flat": "SteamAPI_ISteamScreenshots_TagUser",
+          "params": [
+            { "paramname":"hScreenshot", "paramtype":"ScreenshotHandle" },
+            { "paramname":"steamID", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "TagPublishedFile",
+          "methodname_flat": "SteamAPI_ISteamScreenshots_TagPublishedFile",
+          "params": [
+            { "paramname":"hScreenshot", "paramtype":"ScreenshotHandle" },
+            { "paramname":"unPublishedFileID", "paramtype":"PublishedFileId_t" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "IsScreenshotsHooked",
+          "methodname_flat": "SteamAPI_ISteamScreenshots_IsScreenshotsHooked",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "AddVRScreenshotToLibrary",
+          "methodname_flat": "SteamAPI_ISteamScreenshots_AddVRScreenshotToLibrary",
+          "params": [
+            { "paramname":"eType", "paramtype":"EVRScreenshotType" },
+            { "paramname":"pchFilename", "paramtype":"const char *" },
+            { "paramname":"pchVRFilename", "paramtype":"const char *" }
+          ],
+          "returntype": "ScreenshotHandle"
+        }
+      ],
+      "version_string": "STEAMSCREENSHOTS_INTERFACE_VERSION003"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamMusic",
+          "name_flat": "SteamAPI_SteamMusic_v001"
+        }
+      ],
+      "classname": "ISteamMusic",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "BIsEnabled",
+          "methodname_flat": "SteamAPI_ISteamMusic_BIsEnabled",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "BIsPlaying",
+          "methodname_flat": "SteamAPI_ISteamMusic_BIsPlaying",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetPlaybackStatus",
+          "methodname_flat": "SteamAPI_ISteamMusic_GetPlaybackStatus",
+          "params": [],
+          "returntype": "AudioPlayback_Status"
+        },
+        {
+          "methodname": "Play",
+          "methodname_flat": "SteamAPI_ISteamMusic_Play",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "Pause",
+          "methodname_flat": "SteamAPI_ISteamMusic_Pause",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "PlayPrevious",
+          "methodname_flat": "SteamAPI_ISteamMusic_PlayPrevious",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "PlayNext",
+          "methodname_flat": "SteamAPI_ISteamMusic_PlayNext",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetVolume",
+          "methodname_flat": "SteamAPI_ISteamMusic_SetVolume",
+          "params": [
+            { "paramname":"flVolume", "paramtype":"float" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetVolume",
+          "methodname_flat": "SteamAPI_ISteamMusic_GetVolume",
+          "params": [],
+          "returntype": "float"
+        }
+      ],
+      "version_string": "STEAMMUSIC_INTERFACE_VERSION001"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamMusicRemote",
+          "name_flat": "SteamAPI_SteamMusicRemote_v001"
+        }
+      ],
+      "classname": "ISteamMusicRemote",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "RegisterSteamMusicRemote",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_RegisterSteamMusicRemote",
+          "params": [
+            { "paramname":"pchName", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "DeregisterSteamMusicRemote",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_DeregisterSteamMusicRemote",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "BIsCurrentMusicRemote",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_BIsCurrentMusicRemote",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "BActivationSuccess",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_BActivationSuccess",
+          "params": [
+            { "paramname":"bValue", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetDisplayName",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_SetDisplayName",
+          "params": [
+            { "paramname":"pchDisplayName", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetPNGIcon_64x64",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_SetPNGIcon_64x64",
+          "params": [
+            { "paramname":"pvBuffer", "paramtype":"void *" },
+            { "paramname":"cbBufferLength", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "EnablePlayPrevious",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_EnablePlayPrevious",
+          "params": [
+            { "paramname":"bValue", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "EnablePlayNext",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_EnablePlayNext",
+          "params": [
+            { "paramname":"bValue", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "EnableShuffled",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_EnableShuffled",
+          "params": [
+            { "paramname":"bValue", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "EnableLooped",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_EnableLooped",
+          "params": [
+            { "paramname":"bValue", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "EnableQueue",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_EnableQueue",
+          "params": [
+            { "paramname":"bValue", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "EnablePlaylists",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_EnablePlaylists",
+          "params": [
+            { "paramname":"bValue", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "UpdatePlaybackStatus",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_UpdatePlaybackStatus",
+          "params": [
+            { "paramname":"nStatus", "paramtype":"AudioPlayback_Status" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "UpdateShuffled",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_UpdateShuffled",
+          "params": [
+            { "paramname":"bValue", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "UpdateLooped",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_UpdateLooped",
+          "params": [
+            { "paramname":"bValue", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "UpdateVolume",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_UpdateVolume",
+          "params": [
+            { "paramname":"flValue", "paramtype":"float" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "CurrentEntryWillChange",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_CurrentEntryWillChange",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "CurrentEntryIsAvailable",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_CurrentEntryIsAvailable",
+          "params": [
+            { "paramname":"bAvailable", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "UpdateCurrentEntryText",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_UpdateCurrentEntryText",
+          "params": [
+            { "paramname":"pchText", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "UpdateCurrentEntryElapsedSeconds",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_UpdateCurrentEntryElapsedSeconds",
+          "params": [
+            { "paramname":"nValue", "paramtype":"int" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "UpdateCurrentEntryCoverArt",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_UpdateCurrentEntryCoverArt",
+          "params": [
+            { "paramname":"pvBuffer", "paramtype":"void *" },
+            { "paramname":"cbBufferLength", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "CurrentEntryDidChange",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_CurrentEntryDidChange",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "QueueWillChange",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_QueueWillChange",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "ResetQueueEntries",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_ResetQueueEntries",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetQueueEntry",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_SetQueueEntry",
+          "params": [
+            { "paramname":"nID", "paramtype":"int" },
+            { "paramname":"nPosition", "paramtype":"int" },
+            { "paramname":"pchEntryText", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetCurrentQueueEntry",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_SetCurrentQueueEntry",
+          "params": [
+            { "paramname":"nID", "paramtype":"int" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "QueueDidChange",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_QueueDidChange",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "PlaylistWillChange",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_PlaylistWillChange",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "ResetPlaylistEntries",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_ResetPlaylistEntries",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetPlaylistEntry",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_SetPlaylistEntry",
+          "params": [
+            { "paramname":"nID", "paramtype":"int" },
+            { "paramname":"nPosition", "paramtype":"int" },
+            { "paramname":"pchEntryText", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetCurrentPlaylistEntry",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_SetCurrentPlaylistEntry",
+          "params": [
+            { "paramname":"nID", "paramtype":"int" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "PlaylistDidChange",
+          "methodname_flat": "SteamAPI_ISteamMusicRemote_PlaylistDidChange",
+          "params": [],
+          "returntype": "bool"
+        }
+      ],
+      "version_string": "STEAMMUSICREMOTE_INTERFACE_VERSION001"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamHTTP",
+          "name_flat": "SteamAPI_SteamHTTP_v003"
+        },
+        {
+          "kind": "gameserver",
+          "name": "SteamGameServerHTTP",
+          "name_flat": "SteamAPI_SteamGameServerHTTP_v003"
+        }
+      ],
+      "classname": "ISteamHTTP",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "CreateHTTPRequest",
+          "methodname_flat": "SteamAPI_ISteamHTTP_CreateHTTPRequest",
+          "params": [
+            { "paramname":"eHTTPRequestMethod", "paramtype":"EHTTPMethod" },
+            { "paramname":"pchAbsoluteURL", "paramtype":"const char *" }
+          ],
+          "returntype": "HTTPRequestHandle"
+        },
+        {
+          "methodname": "SetHTTPRequestContextValue",
+          "methodname_flat": "SteamAPI_ISteamHTTP_SetHTTPRequestContextValue",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HTTPRequestHandle" },
+            { "paramname":"ulContextValue", "paramtype":"uint64" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetHTTPRequestNetworkActivityTimeout",
+          "methodname_flat": "SteamAPI_ISteamHTTP_SetHTTPRequestNetworkActivityTimeout",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HTTPRequestHandle" },
+            { "paramname":"unTimeoutSeconds", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetHTTPRequestHeaderValue",
+          "methodname_flat": "SteamAPI_ISteamHTTP_SetHTTPRequestHeaderValue",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HTTPRequestHandle" },
+            { "paramname":"pchHeaderName", "paramtype":"const char *" },
+            { "paramname":"pchHeaderValue", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetHTTPRequestGetOrPostParameter",
+          "methodname_flat": "SteamAPI_ISteamHTTP_SetHTTPRequestGetOrPostParameter",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HTTPRequestHandle" },
+            { "paramname":"pchParamName", "paramtype":"const char *" },
+            { "paramname":"pchParamValue", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SendHTTPRequest",
+          "methodname_flat": "SteamAPI_ISteamHTTP_SendHTTPRequest",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HTTPRequestHandle" },
+            { "paramname":"pCallHandle", "paramtype":"SteamAPICall_t *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SendHTTPRequestAndStreamResponse",
+          "methodname_flat": "SteamAPI_ISteamHTTP_SendHTTPRequestAndStreamResponse",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HTTPRequestHandle" },
+            { "paramname":"pCallHandle", "paramtype":"SteamAPICall_t *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "DeferHTTPRequest",
+          "methodname_flat": "SteamAPI_ISteamHTTP_DeferHTTPRequest",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HTTPRequestHandle" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "PrioritizeHTTPRequest",
+          "methodname_flat": "SteamAPI_ISteamHTTP_PrioritizeHTTPRequest",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HTTPRequestHandle" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetHTTPResponseHeaderSize",
+          "methodname_flat": "SteamAPI_ISteamHTTP_GetHTTPResponseHeaderSize",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HTTPRequestHandle" },
+            { "paramname":"pchHeaderName", "paramtype":"const char *" },
+            { "paramname":"unResponseHeaderSize", "paramtype":"uint32 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetHTTPResponseHeaderValue",
+          "methodname_flat": "SteamAPI_ISteamHTTP_GetHTTPResponseHeaderValue",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HTTPRequestHandle" },
+            { "paramname":"pchHeaderName", "paramtype":"const char *" },
+            { "paramname":"pHeaderValueBuffer", "paramtype":"uint8 *" },
+            { "paramname":"unBufferSize", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetHTTPResponseBodySize",
+          "methodname_flat": "SteamAPI_ISteamHTTP_GetHTTPResponseBodySize",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HTTPRequestHandle" },
+            { "paramname":"unBodySize", "paramtype":"uint32 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetHTTPResponseBodyData",
+          "methodname_flat": "SteamAPI_ISteamHTTP_GetHTTPResponseBodyData",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HTTPRequestHandle" },
+            { "paramname":"pBodyDataBuffer", "paramtype":"uint8 *" },
+            { "paramname":"unBufferSize", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetHTTPStreamingResponseBodyData",
+          "methodname_flat": "SteamAPI_ISteamHTTP_GetHTTPStreamingResponseBodyData",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HTTPRequestHandle" },
+            { "paramname":"cOffset", "paramtype":"uint32" },
+            { "paramname":"pBodyDataBuffer", "paramtype":"uint8 *" },
+            { "paramname":"unBufferSize", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "ReleaseHTTPRequest",
+          "methodname_flat": "SteamAPI_ISteamHTTP_ReleaseHTTPRequest",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HTTPRequestHandle" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetHTTPDownloadProgressPct",
+          "methodname_flat": "SteamAPI_ISteamHTTP_GetHTTPDownloadProgressPct",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HTTPRequestHandle" },
+            { "paramname":"pflPercentOut", "paramtype":"float *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetHTTPRequestRawPostBody",
+          "methodname_flat": "SteamAPI_ISteamHTTP_SetHTTPRequestRawPostBody",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HTTPRequestHandle" },
+            { "paramname":"pchContentType", "paramtype":"const char *" },
+            { "paramname":"pubBody", "paramtype":"uint8 *" },
+            { "paramname":"unBodyLen", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "CreateCookieContainer",
+          "methodname_flat": "SteamAPI_ISteamHTTP_CreateCookieContainer",
+          "params": [
+            { "paramname":"bAllowResponsesToModify", "paramtype":"bool" }
+          ],
+          "returntype": "HTTPCookieContainerHandle"
+        },
+        {
+          "methodname": "ReleaseCookieContainer",
+          "methodname_flat": "SteamAPI_ISteamHTTP_ReleaseCookieContainer",
+          "params": [
+            { "paramname":"hCookieContainer", "paramtype":"HTTPCookieContainerHandle" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetCookie",
+          "methodname_flat": "SteamAPI_ISteamHTTP_SetCookie",
+          "params": [
+            { "paramname":"hCookieContainer", "paramtype":"HTTPCookieContainerHandle" },
+            { "paramname":"pchHost", "paramtype":"const char *" },
+            { "paramname":"pchUrl", "paramtype":"const char *" },
+            { "paramname":"pchCookie", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetHTTPRequestCookieContainer",
+          "methodname_flat": "SteamAPI_ISteamHTTP_SetHTTPRequestCookieContainer",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HTTPRequestHandle" },
+            { "paramname":"hCookieContainer", "paramtype":"HTTPCookieContainerHandle" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetHTTPRequestUserAgentInfo",
+          "methodname_flat": "SteamAPI_ISteamHTTP_SetHTTPRequestUserAgentInfo",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HTTPRequestHandle" },
+            { "paramname":"pchUserAgentInfo", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetHTTPRequestRequiresVerifiedCertificate",
+          "methodname_flat": "SteamAPI_ISteamHTTP_SetHTTPRequestRequiresVerifiedCertificate",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HTTPRequestHandle" },
+            { "paramname":"bRequireVerifiedCertificate", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetHTTPRequestAbsoluteTimeoutMS",
+          "methodname_flat": "SteamAPI_ISteamHTTP_SetHTTPRequestAbsoluteTimeoutMS",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HTTPRequestHandle" },
+            { "paramname":"unMilliseconds", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetHTTPRequestWasTimedOut",
+          "methodname_flat": "SteamAPI_ISteamHTTP_GetHTTPRequestWasTimedOut",
+          "params": [
+            { "paramname":"hRequest", "paramtype":"HTTPRequestHandle" },
+            { "paramname":"pbWasTimedOut", "paramtype":"bool *" }
+          ],
+          "returntype": "bool"
+        }
+      ],
+      "version_string": "STEAMHTTP_INTERFACE_VERSION003"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamInput",
+          "name_flat": "SteamAPI_SteamInput_v001"
+        }
+      ],
+      "classname": "ISteamInput",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "Init",
+          "methodname_flat": "SteamAPI_ISteamInput_Init",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "Shutdown",
+          "methodname_flat": "SteamAPI_ISteamInput_Shutdown",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "RunFrame",
+          "methodname_flat": "SteamAPI_ISteamInput_RunFrame",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetConnectedControllers",
+          "methodname_flat": "SteamAPI_ISteamInput_GetConnectedControllers",
+          "params": [
+            {
+              "desc": "Receives list of connected controllers",
+              "out_array_count": "STEAM_INPUT_MAX_COUNT",
+              "paramname": "handlesOut",
+              "paramtype": "InputHandle_t *"
+            }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetActionSetHandle",
+          "methodname_flat": "SteamAPI_ISteamInput_GetActionSetHandle",
+          "params": [
+            { "paramname":"pszActionSetName", "paramtype":"const char *" }
+          ],
+          "returntype": "InputActionSetHandle_t"
+        },
+        {
+          "methodname": "ActivateActionSet",
+          "methodname_flat": "SteamAPI_ISteamInput_ActivateActionSet",
+          "params": [
+            { "paramname":"inputHandle", "paramtype":"InputHandle_t" },
+            { "paramname":"actionSetHandle", "paramtype":"InputActionSetHandle_t" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetCurrentActionSet",
+          "methodname_flat": "SteamAPI_ISteamInput_GetCurrentActionSet",
+          "params": [
+            { "paramname":"inputHandle", "paramtype":"InputHandle_t" }
+          ],
+          "returntype": "InputActionSetHandle_t"
+        },
+        {
+          "methodname": "ActivateActionSetLayer",
+          "methodname_flat": "SteamAPI_ISteamInput_ActivateActionSetLayer",
+          "params": [
+            { "paramname":"inputHandle", "paramtype":"InputHandle_t" },
+            { "paramname":"actionSetLayerHandle", "paramtype":"InputActionSetHandle_t" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "DeactivateActionSetLayer",
+          "methodname_flat": "SteamAPI_ISteamInput_DeactivateActionSetLayer",
+          "params": [
+            { "paramname":"inputHandle", "paramtype":"InputHandle_t" },
+            { "paramname":"actionSetLayerHandle", "paramtype":"InputActionSetHandle_t" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "DeactivateAllActionSetLayers",
+          "methodname_flat": "SteamAPI_ISteamInput_DeactivateAllActionSetLayers",
+          "params": [
+            { "paramname":"inputHandle", "paramtype":"InputHandle_t" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetActiveActionSetLayers",
+          "methodname_flat": "SteamAPI_ISteamInput_GetActiveActionSetLayers",
+          "params": [
+            { "paramname":"inputHandle", "paramtype":"InputHandle_t" },
+            {
+              "desc": "Receives list of active layers",
+              "out_array_count": "STEAM_INPUT_MAX_ACTIVE_LAYERS",
+              "paramname": "handlesOut",
+              "paramtype": "InputActionSetHandle_t *"
+            }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetDigitalActionHandle",
+          "methodname_flat": "SteamAPI_ISteamInput_GetDigitalActionHandle",
+          "params": [
+            { "paramname":"pszActionName", "paramtype":"const char *" }
+          ],
+          "returntype": "InputDigitalActionHandle_t"
+        },
+        {
+          "methodname": "GetDigitalActionData",
+          "methodname_flat": "SteamAPI_ISteamInput_GetDigitalActionData",
+          "params": [
+            { "paramname":"inputHandle", "paramtype":"InputHandle_t" },
+            { "paramname":"digitalActionHandle", "paramtype":"InputDigitalActionHandle_t" }
+          ],
+          "returntype": "InputDigitalActionData_t"
+        },
+        {
+          "methodname": "GetDigitalActionOrigins",
+          "methodname_flat": "SteamAPI_ISteamInput_GetDigitalActionOrigins",
+          "params": [
+            { "paramname":"inputHandle", "paramtype":"InputHandle_t" },
+            { "paramname":"actionSetHandle", "paramtype":"InputActionSetHandle_t" },
+            { "paramname":"digitalActionHandle", "paramtype":"InputDigitalActionHandle_t" },
+            {
+              "desc": "Receives list of action origins",
+              "out_array_count": "STEAM_INPUT_MAX_ORIGINS",
+              "paramname": "originsOut",
+              "paramtype": "EInputActionOrigin *"
+            }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetAnalogActionHandle",
+          "methodname_flat": "SteamAPI_ISteamInput_GetAnalogActionHandle",
+          "params": [
+            { "paramname":"pszActionName", "paramtype":"const char *" }
+          ],
+          "returntype": "InputAnalogActionHandle_t"
+        },
+        {
+          "methodname": "GetAnalogActionData",
+          "methodname_flat": "SteamAPI_ISteamInput_GetAnalogActionData",
+          "params": [
+            { "paramname":"inputHandle", "paramtype":"InputHandle_t" },
+            { "paramname":"analogActionHandle", "paramtype":"InputAnalogActionHandle_t" }
+          ],
+          "returntype": "InputAnalogActionData_t"
+        },
+        {
+          "methodname": "GetAnalogActionOrigins",
+          "methodname_flat": "SteamAPI_ISteamInput_GetAnalogActionOrigins",
+          "params": [
+            { "paramname":"inputHandle", "paramtype":"InputHandle_t" },
+            { "paramname":"actionSetHandle", "paramtype":"InputActionSetHandle_t" },
+            { "paramname":"analogActionHandle", "paramtype":"InputAnalogActionHandle_t" },
+            {
+              "desc": "Receives list of action origins",
+              "out_array_count": "STEAM_INPUT_MAX_ORIGINS",
+              "paramname": "originsOut",
+              "paramtype": "EInputActionOrigin *"
+            }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetGlyphForActionOrigin",
+          "methodname_flat": "SteamAPI_ISteamInput_GetGlyphForActionOrigin",
+          "params": [
+            { "paramname":"eOrigin", "paramtype":"EInputActionOrigin" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "GetStringForActionOrigin",
+          "methodname_flat": "SteamAPI_ISteamInput_GetStringForActionOrigin",
+          "params": [
+            { "paramname":"eOrigin", "paramtype":"EInputActionOrigin" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "StopAnalogActionMomentum",
+          "methodname_flat": "SteamAPI_ISteamInput_StopAnalogActionMomentum",
+          "params": [
+            { "paramname":"inputHandle", "paramtype":"InputHandle_t" },
+            { "paramname":"eAction", "paramtype":"InputAnalogActionHandle_t" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetMotionData",
+          "methodname_flat": "SteamAPI_ISteamInput_GetMotionData",
+          "params": [
+            { "paramname":"inputHandle", "paramtype":"InputHandle_t" }
+          ],
+          "returntype": "InputMotionData_t"
+        },
+        {
+          "methodname": "TriggerVibration",
+          "methodname_flat": "SteamAPI_ISteamInput_TriggerVibration",
+          "params": [
+            { "paramname":"inputHandle", "paramtype":"InputHandle_t" },
+            { "paramname":"usLeftSpeed", "paramtype":"unsigned short" },
+            { "paramname":"usRightSpeed", "paramtype":"unsigned short" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetLEDColor",
+          "methodname_flat": "SteamAPI_ISteamInput_SetLEDColor",
+          "params": [
+            { "paramname":"inputHandle", "paramtype":"InputHandle_t" },
+            { "paramname":"nColorR", "paramtype":"uint8" },
+            { "paramname":"nColorG", "paramtype":"uint8" },
+            { "paramname":"nColorB", "paramtype":"uint8" },
+            { "paramname":"nFlags", "paramtype":"unsigned int" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "TriggerHapticPulse",
+          "methodname_flat": "SteamAPI_ISteamInput_TriggerHapticPulse",
+          "params": [
+            { "paramname":"inputHandle", "paramtype":"InputHandle_t" },
+            { "paramname":"eTargetPad", "paramtype":"ESteamControllerPad" },
+            { "paramname":"usDurationMicroSec", "paramtype":"unsigned short" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "TriggerRepeatedHapticPulse",
+          "methodname_flat": "SteamAPI_ISteamInput_TriggerRepeatedHapticPulse",
+          "params": [
+            { "paramname":"inputHandle", "paramtype":"InputHandle_t" },
+            { "paramname":"eTargetPad", "paramtype":"ESteamControllerPad" },
+            { "paramname":"usDurationMicroSec", "paramtype":"unsigned short" },
+            { "paramname":"usOffMicroSec", "paramtype":"unsigned short" },
+            { "paramname":"unRepeat", "paramtype":"unsigned short" },
+            { "paramname":"nFlags", "paramtype":"unsigned int" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "ShowBindingPanel",
+          "methodname_flat": "SteamAPI_ISteamInput_ShowBindingPanel",
+          "params": [
+            { "paramname":"inputHandle", "paramtype":"InputHandle_t" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetInputTypeForHandle",
+          "methodname_flat": "SteamAPI_ISteamInput_GetInputTypeForHandle",
+          "params": [
+            { "paramname":"inputHandle", "paramtype":"InputHandle_t" }
+          ],
+          "returntype": "ESteamInputType"
+        },
+        {
+          "methodname": "GetControllerForGamepadIndex",
+          "methodname_flat": "SteamAPI_ISteamInput_GetControllerForGamepadIndex",
+          "params": [
+            { "paramname":"nIndex", "paramtype":"int" }
+          ],
+          "returntype": "InputHandle_t"
+        },
+        {
+          "methodname": "GetGamepadIndexForController",
+          "methodname_flat": "SteamAPI_ISteamInput_GetGamepadIndexForController",
+          "params": [
+            { "paramname":"ulinputHandle", "paramtype":"InputHandle_t" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetStringForXboxOrigin",
+          "methodname_flat": "SteamAPI_ISteamInput_GetStringForXboxOrigin",
+          "params": [
+            { "paramname":"eOrigin", "paramtype":"EXboxOrigin" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "GetGlyphForXboxOrigin",
+          "methodname_flat": "SteamAPI_ISteamInput_GetGlyphForXboxOrigin",
+          "params": [
+            { "paramname":"eOrigin", "paramtype":"EXboxOrigin" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "GetActionOriginFromXboxOrigin",
+          "methodname_flat": "SteamAPI_ISteamInput_GetActionOriginFromXboxOrigin",
+          "params": [
+            { "paramname":"inputHandle", "paramtype":"InputHandle_t" },
+            { "paramname":"eOrigin", "paramtype":"EXboxOrigin" }
+          ],
+          "returntype": "EInputActionOrigin"
+        },
+        {
+          "methodname": "TranslateActionOrigin",
+          "methodname_flat": "SteamAPI_ISteamInput_TranslateActionOrigin",
+          "params": [
+            { "paramname":"eDestinationInputType", "paramtype":"ESteamInputType" },
+            { "paramname":"eSourceOrigin", "paramtype":"EInputActionOrigin" }
+          ],
+          "returntype": "EInputActionOrigin"
+        },
+        {
+          "methodname": "GetDeviceBindingRevision",
+          "methodname_flat": "SteamAPI_ISteamInput_GetDeviceBindingRevision",
+          "params": [
+            { "paramname":"inputHandle", "paramtype":"InputHandle_t" },
+            { "paramname":"pMajor", "paramtype":"int *" },
+            { "paramname":"pMinor", "paramtype":"int *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetRemotePlaySessionID",
+          "methodname_flat": "SteamAPI_ISteamInput_GetRemotePlaySessionID",
+          "params": [
+            { "paramname":"inputHandle", "paramtype":"InputHandle_t" }
+          ],
+          "returntype": "uint32"
+        }
+      ],
+      "version_string": "SteamInput001"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamController",
+          "name_flat": "SteamAPI_SteamController_v007"
+        }
+      ],
+      "classname": "ISteamController",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "Init",
+          "methodname_flat": "SteamAPI_ISteamController_Init",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "Shutdown",
+          "methodname_flat": "SteamAPI_ISteamController_Shutdown",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "RunFrame",
+          "methodname_flat": "SteamAPI_ISteamController_RunFrame",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetConnectedControllers",
+          "methodname_flat": "SteamAPI_ISteamController_GetConnectedControllers",
+          "params": [
+            {
+              "desc": "Receives list of connected controllers",
+              "out_array_count": "STEAM_CONTROLLER_MAX_COUNT",
+              "paramname": "handlesOut",
+              "paramtype": "ControllerHandle_t *"
+            }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetActionSetHandle",
+          "methodname_flat": "SteamAPI_ISteamController_GetActionSetHandle",
+          "params": [
+            { "paramname":"pszActionSetName", "paramtype":"const char *" }
+          ],
+          "returntype": "ControllerActionSetHandle_t"
+        },
+        {
+          "methodname": "ActivateActionSet",
+          "methodname_flat": "SteamAPI_ISteamController_ActivateActionSet",
+          "params": [
+            { "paramname":"controllerHandle", "paramtype":"ControllerHandle_t" },
+            { "paramname":"actionSetHandle", "paramtype":"ControllerActionSetHandle_t" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetCurrentActionSet",
+          "methodname_flat": "SteamAPI_ISteamController_GetCurrentActionSet",
+          "params": [
+            { "paramname":"controllerHandle", "paramtype":"ControllerHandle_t" }
+          ],
+          "returntype": "ControllerActionSetHandle_t"
+        },
+        {
+          "methodname": "ActivateActionSetLayer",
+          "methodname_flat": "SteamAPI_ISteamController_ActivateActionSetLayer",
+          "params": [
+            { "paramname":"controllerHandle", "paramtype":"ControllerHandle_t" },
+            { "paramname":"actionSetLayerHandle", "paramtype":"ControllerActionSetHandle_t" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "DeactivateActionSetLayer",
+          "methodname_flat": "SteamAPI_ISteamController_DeactivateActionSetLayer",
+          "params": [
+            { "paramname":"controllerHandle", "paramtype":"ControllerHandle_t" },
+            { "paramname":"actionSetLayerHandle", "paramtype":"ControllerActionSetHandle_t" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "DeactivateAllActionSetLayers",
+          "methodname_flat": "SteamAPI_ISteamController_DeactivateAllActionSetLayers",
+          "params": [
+            { "paramname":"controllerHandle", "paramtype":"ControllerHandle_t" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetActiveActionSetLayers",
+          "methodname_flat": "SteamAPI_ISteamController_GetActiveActionSetLayers",
+          "params": [
+            { "paramname":"controllerHandle", "paramtype":"ControllerHandle_t" },
+            {
+              "desc": "Receives list of active layers",
+              "out_array_count": "STEAM_CONTROLLER_MAX_ACTIVE_LAYERS",
+              "paramname": "handlesOut",
+              "paramtype": "ControllerActionSetHandle_t *"
+            }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetDigitalActionHandle",
+          "methodname_flat": "SteamAPI_ISteamController_GetDigitalActionHandle",
+          "params": [
+            { "paramname":"pszActionName", "paramtype":"const char *" }
+          ],
+          "returntype": "ControllerDigitalActionHandle_t"
+        },
+        {
+          "methodname": "GetDigitalActionData",
+          "methodname_flat": "SteamAPI_ISteamController_GetDigitalActionData",
+          "params": [
+            { "paramname":"controllerHandle", "paramtype":"ControllerHandle_t" },
+            { "paramname":"digitalActionHandle", "paramtype":"ControllerDigitalActionHandle_t" }
+          ],
+          "returntype": "InputDigitalActionData_t"
+        },
+        {
+          "methodname": "GetDigitalActionOrigins",
+          "methodname_flat": "SteamAPI_ISteamController_GetDigitalActionOrigins",
+          "params": [
+            { "paramname":"controllerHandle", "paramtype":"ControllerHandle_t" },
+            { "paramname":"actionSetHandle", "paramtype":"ControllerActionSetHandle_t" },
+            { "paramname":"digitalActionHandle", "paramtype":"ControllerDigitalActionHandle_t" },
+            {
+              "desc": "Receives list of aciton origins",
+              "out_array_count": "STEAM_CONTROLLER_MAX_ORIGINS",
+              "paramname": "originsOut",
+              "paramtype": "EControllerActionOrigin *"
+            }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetAnalogActionHandle",
+          "methodname_flat": "SteamAPI_ISteamController_GetAnalogActionHandle",
+          "params": [
+            { "paramname":"pszActionName", "paramtype":"const char *" }
+          ],
+          "returntype": "ControllerAnalogActionHandle_t"
+        },
+        {
+          "methodname": "GetAnalogActionData",
+          "methodname_flat": "SteamAPI_ISteamController_GetAnalogActionData",
+          "params": [
+            { "paramname":"controllerHandle", "paramtype":"ControllerHandle_t" },
+            { "paramname":"analogActionHandle", "paramtype":"ControllerAnalogActionHandle_t" }
+          ],
+          "returntype": "InputAnalogActionData_t"
+        },
+        {
+          "methodname": "GetAnalogActionOrigins",
+          "methodname_flat": "SteamAPI_ISteamController_GetAnalogActionOrigins",
+          "params": [
+            { "paramname":"controllerHandle", "paramtype":"ControllerHandle_t" },
+            { "paramname":"actionSetHandle", "paramtype":"ControllerActionSetHandle_t" },
+            { "paramname":"analogActionHandle", "paramtype":"ControllerAnalogActionHandle_t" },
+            {
+              "desc": "Receives list of action origins",
+              "out_array_count": "STEAM_CONTROLLER_MAX_ORIGINS",
+              "paramname": "originsOut",
+              "paramtype": "EControllerActionOrigin *"
+            }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetGlyphForActionOrigin",
+          "methodname_flat": "SteamAPI_ISteamController_GetGlyphForActionOrigin",
+          "params": [
+            { "paramname":"eOrigin", "paramtype":"EControllerActionOrigin" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "GetStringForActionOrigin",
+          "methodname_flat": "SteamAPI_ISteamController_GetStringForActionOrigin",
+          "params": [
+            { "paramname":"eOrigin", "paramtype":"EControllerActionOrigin" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "StopAnalogActionMomentum",
+          "methodname_flat": "SteamAPI_ISteamController_StopAnalogActionMomentum",
+          "params": [
+            { "paramname":"controllerHandle", "paramtype":"ControllerHandle_t" },
+            { "paramname":"eAction", "paramtype":"ControllerAnalogActionHandle_t" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetMotionData",
+          "methodname_flat": "SteamAPI_ISteamController_GetMotionData",
+          "params": [
+            { "paramname":"controllerHandle", "paramtype":"ControllerHandle_t" }
+          ],
+          "returntype": "InputMotionData_t"
+        },
+        {
+          "methodname": "TriggerHapticPulse",
+          "methodname_flat": "SteamAPI_ISteamController_TriggerHapticPulse",
+          "params": [
+            { "paramname":"controllerHandle", "paramtype":"ControllerHandle_t" },
+            { "paramname":"eTargetPad", "paramtype":"ESteamControllerPad" },
+            { "paramname":"usDurationMicroSec", "paramtype":"unsigned short" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "TriggerRepeatedHapticPulse",
+          "methodname_flat": "SteamAPI_ISteamController_TriggerRepeatedHapticPulse",
+          "params": [
+            { "paramname":"controllerHandle", "paramtype":"ControllerHandle_t" },
+            { "paramname":"eTargetPad", "paramtype":"ESteamControllerPad" },
+            { "paramname":"usDurationMicroSec", "paramtype":"unsigned short" },
+            { "paramname":"usOffMicroSec", "paramtype":"unsigned short" },
+            { "paramname":"unRepeat", "paramtype":"unsigned short" },
+            { "paramname":"nFlags", "paramtype":"unsigned int" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "TriggerVibration",
+          "methodname_flat": "SteamAPI_ISteamController_TriggerVibration",
+          "params": [
+            { "paramname":"controllerHandle", "paramtype":"ControllerHandle_t" },
+            { "paramname":"usLeftSpeed", "paramtype":"unsigned short" },
+            { "paramname":"usRightSpeed", "paramtype":"unsigned short" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetLEDColor",
+          "methodname_flat": "SteamAPI_ISteamController_SetLEDColor",
+          "params": [
+            { "paramname":"controllerHandle", "paramtype":"ControllerHandle_t" },
+            { "paramname":"nColorR", "paramtype":"uint8" },
+            { "paramname":"nColorG", "paramtype":"uint8" },
+            { "paramname":"nColorB", "paramtype":"uint8" },
+            { "paramname":"nFlags", "paramtype":"unsigned int" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "ShowBindingPanel",
+          "methodname_flat": "SteamAPI_ISteamController_ShowBindingPanel",
+          "params": [
+            { "paramname":"controllerHandle", "paramtype":"ControllerHandle_t" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetInputTypeForHandle",
+          "methodname_flat": "SteamAPI_ISteamController_GetInputTypeForHandle",
+          "params": [
+            { "paramname":"controllerHandle", "paramtype":"ControllerHandle_t" }
+          ],
+          "returntype": "ESteamInputType"
+        },
+        {
+          "methodname": "GetControllerForGamepadIndex",
+          "methodname_flat": "SteamAPI_ISteamController_GetControllerForGamepadIndex",
+          "params": [
+            { "paramname":"nIndex", "paramtype":"int" }
+          ],
+          "returntype": "ControllerHandle_t"
+        },
+        {
+          "methodname": "GetGamepadIndexForController",
+          "methodname_flat": "SteamAPI_ISteamController_GetGamepadIndexForController",
+          "params": [
+            { "paramname":"ulControllerHandle", "paramtype":"ControllerHandle_t" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetStringForXboxOrigin",
+          "methodname_flat": "SteamAPI_ISteamController_GetStringForXboxOrigin",
+          "params": [
+            { "paramname":"eOrigin", "paramtype":"EXboxOrigin" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "GetGlyphForXboxOrigin",
+          "methodname_flat": "SteamAPI_ISteamController_GetGlyphForXboxOrigin",
+          "params": [
+            { "paramname":"eOrigin", "paramtype":"EXboxOrigin" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "GetActionOriginFromXboxOrigin",
+          "methodname_flat": "SteamAPI_ISteamController_GetActionOriginFromXboxOrigin",
+          "params": [
+            { "paramname":"controllerHandle", "paramtype":"ControllerHandle_t" },
+            { "paramname":"eOrigin", "paramtype":"EXboxOrigin" }
+          ],
+          "returntype": "EControllerActionOrigin"
+        },
+        {
+          "methodname": "TranslateActionOrigin",
+          "methodname_flat": "SteamAPI_ISteamController_TranslateActionOrigin",
+          "params": [
+            { "paramname":"eDestinationInputType", "paramtype":"ESteamInputType" },
+            { "paramname":"eSourceOrigin", "paramtype":"EControllerActionOrigin" }
+          ],
+          "returntype": "EControllerActionOrigin"
+        },
+        {
+          "methodname": "GetControllerBindingRevision",
+          "methodname_flat": "SteamAPI_ISteamController_GetControllerBindingRevision",
+          "params": [
+            { "paramname":"controllerHandle", "paramtype":"ControllerHandle_t" },
+            { "paramname":"pMajor", "paramtype":"int *" },
+            { "paramname":"pMinor", "paramtype":"int *" }
+          ],
+          "returntype": "bool"
+        }
+      ],
+      "version_string": "SteamController007"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamUGC",
+          "name_flat": "SteamAPI_SteamUGC_v014"
+        },
+        {
+          "kind": "gameserver",
+          "name": "SteamGameServerUGC",
+          "name_flat": "SteamAPI_SteamGameServerUGC_v014"
+        }
+      ],
+      "classname": "ISteamUGC",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "CreateQueryUserUGCRequest",
+          "methodname_flat": "SteamAPI_ISteamUGC_CreateQueryUserUGCRequest",
+          "params": [
+            { "paramname":"unAccountID", "paramtype":"AccountID_t" },
+            { "paramname":"eListType", "paramtype":"EUserUGCList" },
+            { "paramname":"eMatchingUGCType", "paramtype":"EUGCMatchingUGCType" },
+            { "paramname":"eSortOrder", "paramtype":"EUserUGCListSortOrder" },
+            { "paramname":"nCreatorAppID", "paramtype":"AppId_t" },
+            { "paramname":"nConsumerAppID", "paramtype":"AppId_t" },
+            { "paramname":"unPage", "paramtype":"uint32" }
+          ],
+          "returntype": "UGCQueryHandle_t"
+        },
+        {
+          "methodname": "CreateQueryAllUGCRequest",
+          "methodname_flat": "SteamAPI_ISteamUGC_CreateQueryAllUGCRequestPage",
+          "params": [
+            { "paramname":"eQueryType", "paramtype":"EUGCQuery" },
+            { "paramname":"eMatchingeMatchingUGCTypeFileType", "paramtype":"EUGCMatchingUGCType" },
+            { "paramname":"nCreatorAppID", "paramtype":"AppId_t" },
+            { "paramname":"nConsumerAppID", "paramtype":"AppId_t" },
+            { "paramname":"unPage", "paramtype":"uint32" }
+          ],
+          "returntype": "UGCQueryHandle_t"
+        },
+        {
+          "methodname": "CreateQueryAllUGCRequest",
+          "methodname_flat": "SteamAPI_ISteamUGC_CreateQueryAllUGCRequestCursor",
+          "params": [
+            { "paramname":"eQueryType", "paramtype":"EUGCQuery" },
+            { "paramname":"eMatchingeMatchingUGCTypeFileType", "paramtype":"EUGCMatchingUGCType" },
+            { "paramname":"nCreatorAppID", "paramtype":"AppId_t" },
+            { "paramname":"nConsumerAppID", "paramtype":"AppId_t" },
+            { "paramname":"pchCursor", "paramtype":"const char *" }
+          ],
+          "returntype": "UGCQueryHandle_t"
+        },
+        {
+          "methodname": "CreateQueryUGCDetailsRequest",
+          "methodname_flat": "SteamAPI_ISteamUGC_CreateQueryUGCDetailsRequest",
+          "params": [
+            { "paramname":"pvecPublishedFileID", "paramtype":"PublishedFileId_t *" },
+            { "paramname":"unNumPublishedFileIDs", "paramtype":"uint32" }
+          ],
+          "returntype": "UGCQueryHandle_t"
+        },
+        {
+          "callresult": "SteamUGCQueryCompleted_t",
+          "methodname": "SendQueryUGCRequest",
+          "methodname_flat": "SteamAPI_ISteamUGC_SendQueryUGCRequest",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "GetQueryUGCResult",
+          "methodname_flat": "SteamAPI_ISteamUGC_GetQueryUGCResult",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"index", "paramtype":"uint32" },
+            { "paramname":"pDetails", "paramtype":"SteamUGCDetails_t *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetQueryUGCPreviewURL",
+          "methodname_flat": "SteamAPI_ISteamUGC_GetQueryUGCPreviewURL",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"index", "paramtype":"uint32" },
+            {
+              "out_string_count": "cchURLSize",
+              "paramname": "pchURL",
+              "paramtype": "char *"
+            },
+            { "paramname":"cchURLSize", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetQueryUGCMetadata",
+          "methodname_flat": "SteamAPI_ISteamUGC_GetQueryUGCMetadata",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"index", "paramtype":"uint32" },
+            {
+              "out_string_count": "cchMetadatasize",
+              "paramname": "pchMetadata",
+              "paramtype": "char *"
+            },
+            { "paramname":"cchMetadatasize", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetQueryUGCChildren",
+          "methodname_flat": "SteamAPI_ISteamUGC_GetQueryUGCChildren",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"index", "paramtype":"uint32" },
+            { "paramname":"pvecPublishedFileID", "paramtype":"PublishedFileId_t *" },
+            { "paramname":"cMaxEntries", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetQueryUGCStatistic",
+          "methodname_flat": "SteamAPI_ISteamUGC_GetQueryUGCStatistic",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"index", "paramtype":"uint32" },
+            { "paramname":"eStatType", "paramtype":"EItemStatistic" },
+            { "paramname":"pStatValue", "paramtype":"uint64 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetQueryUGCNumAdditionalPreviews",
+          "methodname_flat": "SteamAPI_ISteamUGC_GetQueryUGCNumAdditionalPreviews",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"index", "paramtype":"uint32" }
+          ],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "GetQueryUGCAdditionalPreview",
+          "methodname_flat": "SteamAPI_ISteamUGC_GetQueryUGCAdditionalPreview",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"index", "paramtype":"uint32" },
+            { "paramname":"previewIndex", "paramtype":"uint32" },
+            {
+              "out_string_count": "cchURLSize",
+              "paramname": "pchURLOrVideoID",
+              "paramtype": "char *"
+            },
+            { "paramname":"cchURLSize", "paramtype":"uint32" },
+            {
+              "out_string_count": "cchURLSize",
+              "paramname": "pchOriginalFileName",
+              "paramtype": "char *"
+            },
+            { "paramname":"cchOriginalFileNameSize", "paramtype":"uint32" },
+            { "paramname":"pPreviewType", "paramtype":"EItemPreviewType *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetQueryUGCNumKeyValueTags",
+          "methodname_flat": "SteamAPI_ISteamUGC_GetQueryUGCNumKeyValueTags",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"index", "paramtype":"uint32" }
+          ],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "GetQueryUGCKeyValueTag",
+          "methodname_flat": "SteamAPI_ISteamUGC_GetQueryUGCKeyValueTag",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"index", "paramtype":"uint32" },
+            { "paramname":"keyValueTagIndex", "paramtype":"uint32" },
+            {
+              "out_string_count": "cchKeySize",
+              "paramname": "pchKey",
+              "paramtype": "char *"
+            },
+            { "paramname":"cchKeySize", "paramtype":"uint32" },
+            {
+              "out_string_count": "cchValueSize",
+              "paramname": "pchValue",
+              "paramtype": "char *"
+            },
+            { "paramname":"cchValueSize", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetQueryUGCKeyValueTag",
+          "methodname_flat": "SteamAPI_ISteamUGC_GetQueryFirstUGCKeyValueTag",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"index", "paramtype":"uint32" },
+            { "paramname":"pchKey", "paramtype":"const char *" },
+            {
+              "out_string_count": "cchValueSize",
+              "paramname": "pchValue",
+              "paramtype": "char *"
+            },
+            { "paramname":"cchValueSize", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "ReleaseQueryUGCRequest",
+          "methodname_flat": "SteamAPI_ISteamUGC_ReleaseQueryUGCRequest",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "AddRequiredTag",
+          "methodname_flat": "SteamAPI_ISteamUGC_AddRequiredTag",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"pTagName", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "AddRequiredTagGroup",
+          "methodname_flat": "SteamAPI_ISteamUGC_AddRequiredTagGroup",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"pTagGroups", "paramtype":"const SteamParamStringArray_t *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "AddExcludedTag",
+          "methodname_flat": "SteamAPI_ISteamUGC_AddExcludedTag",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"pTagName", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetReturnOnlyIDs",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetReturnOnlyIDs",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"bReturnOnlyIDs", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetReturnKeyValueTags",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetReturnKeyValueTags",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"bReturnKeyValueTags", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetReturnLongDescription",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetReturnLongDescription",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"bReturnLongDescription", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetReturnMetadata",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetReturnMetadata",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"bReturnMetadata", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetReturnChildren",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetReturnChildren",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"bReturnChildren", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetReturnAdditionalPreviews",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetReturnAdditionalPreviews",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"bReturnAdditionalPreviews", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetReturnTotalOnly",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetReturnTotalOnly",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"bReturnTotalOnly", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetReturnPlaytimeStats",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetReturnPlaytimeStats",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"unDays", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetLanguage",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetLanguage",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"pchLanguage", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetAllowCachedResponse",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetAllowCachedResponse",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"unMaxAgeSeconds", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetCloudFileNameFilter",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetCloudFileNameFilter",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"pMatchCloudFileName", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetMatchAnyTag",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetMatchAnyTag",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"bMatchAnyTag", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetSearchText",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetSearchText",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"pSearchText", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetRankedByTrendDays",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetRankedByTrendDays",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"unDays", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "AddRequiredKeyValueTag",
+          "methodname_flat": "SteamAPI_ISteamUGC_AddRequiredKeyValueTag",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCQueryHandle_t" },
+            { "paramname":"pKey", "paramtype":"const char *" },
+            { "paramname":"pValue", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "callresult": "SteamUGCRequestUGCDetailsResult_t",
+          "methodname": "RequestUGCDetails",
+          "methodname_flat": "SteamAPI_ISteamUGC_RequestUGCDetails",
+          "params": [
+            { "paramname":"nPublishedFileID", "paramtype":"PublishedFileId_t" },
+            { "paramname":"unMaxAgeSeconds", "paramtype":"uint32" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "CreateItemResult_t",
+          "methodname": "CreateItem",
+          "methodname_flat": "SteamAPI_ISteamUGC_CreateItem",
+          "params": [
+            { "paramname":"nConsumerAppId", "paramtype":"AppId_t" },
+            { "paramname":"eFileType", "paramtype":"EWorkshopFileType" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "StartItemUpdate",
+          "methodname_flat": "SteamAPI_ISteamUGC_StartItemUpdate",
+          "params": [
+            { "paramname":"nConsumerAppId", "paramtype":"AppId_t" },
+            { "paramname":"nPublishedFileID", "paramtype":"PublishedFileId_t" }
+          ],
+          "returntype": "UGCUpdateHandle_t"
+        },
+        {
+          "methodname": "SetItemTitle",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetItemTitle",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCUpdateHandle_t" },
+            { "paramname":"pchTitle", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetItemDescription",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetItemDescription",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCUpdateHandle_t" },
+            { "paramname":"pchDescription", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetItemUpdateLanguage",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetItemUpdateLanguage",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCUpdateHandle_t" },
+            { "paramname":"pchLanguage", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetItemMetadata",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetItemMetadata",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCUpdateHandle_t" },
+            { "paramname":"pchMetaData", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetItemVisibility",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetItemVisibility",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCUpdateHandle_t" },
+            { "paramname":"eVisibility", "paramtype":"ERemoteStoragePublishedFileVisibility" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetItemTags",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetItemTags",
+          "params": [
+            { "paramname":"updateHandle", "paramtype":"UGCUpdateHandle_t" },
+            { "paramname":"pTags", "paramtype":"const SteamParamStringArray_t *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetItemContent",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetItemContent",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCUpdateHandle_t" },
+            { "paramname":"pszContentFolder", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetItemPreview",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetItemPreview",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCUpdateHandle_t" },
+            { "paramname":"pszPreviewFile", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetAllowLegacyUpload",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetAllowLegacyUpload",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCUpdateHandle_t" },
+            { "paramname":"bAllowLegacyUpload", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "RemoveAllItemKeyValueTags",
+          "methodname_flat": "SteamAPI_ISteamUGC_RemoveAllItemKeyValueTags",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCUpdateHandle_t" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "RemoveItemKeyValueTags",
+          "methodname_flat": "SteamAPI_ISteamUGC_RemoveItemKeyValueTags",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCUpdateHandle_t" },
+            { "paramname":"pchKey", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "AddItemKeyValueTag",
+          "methodname_flat": "SteamAPI_ISteamUGC_AddItemKeyValueTag",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCUpdateHandle_t" },
+            { "paramname":"pchKey", "paramtype":"const char *" },
+            { "paramname":"pchValue", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "AddItemPreviewFile",
+          "methodname_flat": "SteamAPI_ISteamUGC_AddItemPreviewFile",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCUpdateHandle_t" },
+            { "paramname":"pszPreviewFile", "paramtype":"const char *" },
+            { "paramname":"type", "paramtype":"EItemPreviewType" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "AddItemPreviewVideo",
+          "methodname_flat": "SteamAPI_ISteamUGC_AddItemPreviewVideo",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCUpdateHandle_t" },
+            { "paramname":"pszVideoID", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "UpdateItemPreviewFile",
+          "methodname_flat": "SteamAPI_ISteamUGC_UpdateItemPreviewFile",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCUpdateHandle_t" },
+            { "paramname":"index", "paramtype":"uint32" },
+            { "paramname":"pszPreviewFile", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "UpdateItemPreviewVideo",
+          "methodname_flat": "SteamAPI_ISteamUGC_UpdateItemPreviewVideo",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCUpdateHandle_t" },
+            { "paramname":"index", "paramtype":"uint32" },
+            { "paramname":"pszVideoID", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "RemoveItemPreview",
+          "methodname_flat": "SteamAPI_ISteamUGC_RemoveItemPreview",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCUpdateHandle_t" },
+            { "paramname":"index", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "callresult": "SubmitItemUpdateResult_t",
+          "methodname": "SubmitItemUpdate",
+          "methodname_flat": "SteamAPI_ISteamUGC_SubmitItemUpdate",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCUpdateHandle_t" },
+            { "paramname":"pchChangeNote", "paramtype":"const char *" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "GetItemUpdateProgress",
+          "methodname_flat": "SteamAPI_ISteamUGC_GetItemUpdateProgress",
+          "params": [
+            { "paramname":"handle", "paramtype":"UGCUpdateHandle_t" },
+            { "paramname":"punBytesProcessed", "paramtype":"uint64 *" },
+            { "paramname":"punBytesTotal", "paramtype":"uint64 *" }
+          ],
+          "returntype": "EItemUpdateStatus"
+        },
+        {
+          "callresult": "SetUserItemVoteResult_t",
+          "methodname": "SetUserItemVote",
+          "methodname_flat": "SteamAPI_ISteamUGC_SetUserItemVote",
+          "params": [
+            { "paramname":"nPublishedFileID", "paramtype":"PublishedFileId_t" },
+            { "paramname":"bVoteUp", "paramtype":"bool" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "GetUserItemVoteResult_t",
+          "methodname": "GetUserItemVote",
+          "methodname_flat": "SteamAPI_ISteamUGC_GetUserItemVote",
+          "params": [
+            { "paramname":"nPublishedFileID", "paramtype":"PublishedFileId_t" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "UserFavoriteItemsListChanged_t",
+          "methodname": "AddItemToFavorites",
+          "methodname_flat": "SteamAPI_ISteamUGC_AddItemToFavorites",
+          "params": [
+            { "paramname":"nAppId", "paramtype":"AppId_t" },
+            { "paramname":"nPublishedFileID", "paramtype":"PublishedFileId_t" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "UserFavoriteItemsListChanged_t",
+          "methodname": "RemoveItemFromFavorites",
+          "methodname_flat": "SteamAPI_ISteamUGC_RemoveItemFromFavorites",
+          "params": [
+            { "paramname":"nAppId", "paramtype":"AppId_t" },
+            { "paramname":"nPublishedFileID", "paramtype":"PublishedFileId_t" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "RemoteStorageSubscribePublishedFileResult_t",
+          "methodname": "SubscribeItem",
+          "methodname_flat": "SteamAPI_ISteamUGC_SubscribeItem",
+          "params": [
+            { "paramname":"nPublishedFileID", "paramtype":"PublishedFileId_t" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "RemoteStorageUnsubscribePublishedFileResult_t",
+          "methodname": "UnsubscribeItem",
+          "methodname_flat": "SteamAPI_ISteamUGC_UnsubscribeItem",
+          "params": [
+            { "paramname":"nPublishedFileID", "paramtype":"PublishedFileId_t" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "GetNumSubscribedItems",
+          "methodname_flat": "SteamAPI_ISteamUGC_GetNumSubscribedItems",
+          "params": [],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "GetSubscribedItems",
+          "methodname_flat": "SteamAPI_ISteamUGC_GetSubscribedItems",
+          "params": [
+            { "paramname":"pvecPublishedFileID", "paramtype":"PublishedFileId_t *" },
+            { "paramname":"cMaxEntries", "paramtype":"uint32" }
+          ],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "GetItemState",
+          "methodname_flat": "SteamAPI_ISteamUGC_GetItemState",
+          "params": [
+            { "paramname":"nPublishedFileID", "paramtype":"PublishedFileId_t" }
+          ],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "GetItemInstallInfo",
+          "methodname_flat": "SteamAPI_ISteamUGC_GetItemInstallInfo",
+          "params": [
+            { "paramname":"nPublishedFileID", "paramtype":"PublishedFileId_t" },
+            { "paramname":"punSizeOnDisk", "paramtype":"uint64 *" },
+            {
+              "out_string_count": "cchFolderSize",
+              "paramname": "pchFolder",
+              "paramtype": "char *"
+            },
+            { "paramname":"cchFolderSize", "paramtype":"uint32" },
+            { "paramname":"punTimeStamp", "paramtype":"uint32 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetItemDownloadInfo",
+          "methodname_flat": "SteamAPI_ISteamUGC_GetItemDownloadInfo",
+          "params": [
+            { "paramname":"nPublishedFileID", "paramtype":"PublishedFileId_t" },
+            { "paramname":"punBytesDownloaded", "paramtype":"uint64 *" },
+            { "paramname":"punBytesTotal", "paramtype":"uint64 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "DownloadItem",
+          "methodname_flat": "SteamAPI_ISteamUGC_DownloadItem",
+          "params": [
+            { "paramname":"nPublishedFileID", "paramtype":"PublishedFileId_t" },
+            { "paramname":"bHighPriority", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "BInitWorkshopForGameServer",
+          "methodname_flat": "SteamAPI_ISteamUGC_BInitWorkshopForGameServer",
+          "params": [
+            { "paramname":"unWorkshopDepotID", "paramtype":"DepotId_t" },
+            { "paramname":"pszFolder", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SuspendDownloads",
+          "methodname_flat": "SteamAPI_ISteamUGC_SuspendDownloads",
+          "params": [
+            { "paramname":"bSuspend", "paramtype":"bool" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "callresult": "StartPlaytimeTrackingResult_t",
+          "methodname": "StartPlaytimeTracking",
+          "methodname_flat": "SteamAPI_ISteamUGC_StartPlaytimeTracking",
+          "params": [
+            { "paramname":"pvecPublishedFileID", "paramtype":"PublishedFileId_t *" },
+            { "paramname":"unNumPublishedFileIDs", "paramtype":"uint32" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "StopPlaytimeTrackingResult_t",
+          "methodname": "StopPlaytimeTracking",
+          "methodname_flat": "SteamAPI_ISteamUGC_StopPlaytimeTracking",
+          "params": [
+            { "paramname":"pvecPublishedFileID", "paramtype":"PublishedFileId_t *" },
+            { "paramname":"unNumPublishedFileIDs", "paramtype":"uint32" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "StopPlaytimeTrackingResult_t",
+          "methodname": "StopPlaytimeTrackingForAllItems",
+          "methodname_flat": "SteamAPI_ISteamUGC_StopPlaytimeTrackingForAllItems",
+          "params": [],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "AddUGCDependencyResult_t",
+          "methodname": "AddDependency",
+          "methodname_flat": "SteamAPI_ISteamUGC_AddDependency",
+          "params": [
+            { "paramname":"nParentPublishedFileID", "paramtype":"PublishedFileId_t" },
+            { "paramname":"nChildPublishedFileID", "paramtype":"PublishedFileId_t" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "RemoveUGCDependencyResult_t",
+          "methodname": "RemoveDependency",
+          "methodname_flat": "SteamAPI_ISteamUGC_RemoveDependency",
+          "params": [
+            { "paramname":"nParentPublishedFileID", "paramtype":"PublishedFileId_t" },
+            { "paramname":"nChildPublishedFileID", "paramtype":"PublishedFileId_t" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "AddAppDependencyResult_t",
+          "methodname": "AddAppDependency",
+          "methodname_flat": "SteamAPI_ISteamUGC_AddAppDependency",
+          "params": [
+            { "paramname":"nPublishedFileID", "paramtype":"PublishedFileId_t" },
+            { "paramname":"nAppID", "paramtype":"AppId_t" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "RemoveAppDependencyResult_t",
+          "methodname": "RemoveAppDependency",
+          "methodname_flat": "SteamAPI_ISteamUGC_RemoveAppDependency",
+          "params": [
+            { "paramname":"nPublishedFileID", "paramtype":"PublishedFileId_t" },
+            { "paramname":"nAppID", "paramtype":"AppId_t" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "GetAppDependenciesResult_t",
+          "methodname": "GetAppDependencies",
+          "methodname_flat": "SteamAPI_ISteamUGC_GetAppDependencies",
+          "params": [
+            { "paramname":"nPublishedFileID", "paramtype":"PublishedFileId_t" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "DeleteItemResult_t",
+          "methodname": "DeleteItem",
+          "methodname_flat": "SteamAPI_ISteamUGC_DeleteItem",
+          "params": [
+            { "paramname":"nPublishedFileID", "paramtype":"PublishedFileId_t" }
+          ],
+          "returntype": "SteamAPICall_t"
+        }
+      ],
+      "version_string": "STEAMUGC_INTERFACE_VERSION014"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamAppList",
+          "name_flat": "SteamAPI_SteamAppList_v001"
+        }
+      ],
+      "classname": "ISteamAppList",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "GetNumInstalledApps",
+          "methodname_flat": "SteamAPI_ISteamAppList_GetNumInstalledApps",
+          "params": [],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "GetInstalledApps",
+          "methodname_flat": "SteamAPI_ISteamAppList_GetInstalledApps",
+          "params": [
+            { "paramname":"pvecAppID", "paramtype":"AppId_t *" },
+            { "paramname":"unMaxAppIDs", "paramtype":"uint32" }
+          ],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "GetAppName",
+          "methodname_flat": "SteamAPI_ISteamAppList_GetAppName",
+          "params": [
+            { "paramname":"nAppID", "paramtype":"AppId_t" },
+            {
+              "out_string": "",
+              "paramname": "pchName",
+              "paramtype": "char *"
+            },
+            { "paramname":"cchNameMax", "paramtype":"int" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetAppInstallDir",
+          "methodname_flat": "SteamAPI_ISteamAppList_GetAppInstallDir",
+          "params": [
+            { "paramname":"nAppID", "paramtype":"AppId_t" },
+            { "paramname":"pchDirectory", "paramtype":"char *" },
+            { "paramname":"cchNameMax", "paramtype":"int" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetAppBuildId",
+          "methodname_flat": "SteamAPI_ISteamAppList_GetAppBuildId",
+          "params": [
+            { "paramname":"nAppID", "paramtype":"AppId_t" }
+          ],
+          "returntype": "int"
+        }
+      ],
+      "version_string": "STEAMAPPLIST_INTERFACE_VERSION001"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamHTMLSurface",
+          "name_flat": "SteamAPI_SteamHTMLSurface_v005"
+        }
+      ],
+      "classname": "ISteamHTMLSurface",
+      "enums": [
+        {
+          "enumname": "EHTMLMouseButton",
+          "fqname": "ISteamHTMLSurface::EHTMLMouseButton",
+          "values": [
+            { "name":"eHTMLMouseButton_Left", "value":"0" },
+            { "name":"eHTMLMouseButton_Right", "value":"1" },
+            { "name":"eHTMLMouseButton_Middle", "value":"2" }
+          ]
+        },
+        {
+          "enumname": "EMouseCursor",
+          "fqname": "ISteamHTMLSurface::EMouseCursor",
+          "values": [
+            { "name":"dc_user", "value":"0" },
+            { "name":"dc_none", "value":"1" },
+            { "name":"dc_arrow", "value":"2" },
+            { "name":"dc_ibeam", "value":"3" },
+            { "name":"dc_hourglass", "value":"4" },
+            { "name":"dc_waitarrow", "value":"5" },
+            { "name":"dc_crosshair", "value":"6" },
+            { "name":"dc_up", "value":"7" },
+            { "name":"dc_sizenw", "value":"8" },
+            { "name":"dc_sizese", "value":"9" },
+            { "name":"dc_sizene", "value":"10" },
+            { "name":"dc_sizesw", "value":"11" },
+            { "name":"dc_sizew", "value":"12" },
+            { "name":"dc_sizee", "value":"13" },
+            { "name":"dc_sizen", "value":"14" },
+            { "name":"dc_sizes", "value":"15" },
+            { "name":"dc_sizewe", "value":"16" },
+            { "name":"dc_sizens", "value":"17" },
+            { "name":"dc_sizeall", "value":"18" },
+            { "name":"dc_no", "value":"19" },
+            { "name":"dc_hand", "value":"20" },
+            { "name":"dc_blank", "value":"21" },
+            { "name":"dc_middle_pan", "value":"22" },
+            { "name":"dc_north_pan", "value":"23" },
+            { "name":"dc_north_east_pan", "value":"24" },
+            { "name":"dc_east_pan", "value":"25" },
+            { "name":"dc_south_east_pan", "value":"26" },
+            { "name":"dc_south_pan", "value":"27" },
+            { "name":"dc_south_west_pan", "value":"28" },
+            { "name":"dc_west_pan", "value":"29" },
+            { "name":"dc_north_west_pan", "value":"30" },
+            { "name":"dc_alias", "value":"31" },
+            { "name":"dc_cell", "value":"32" },
+            { "name":"dc_colresize", "value":"33" },
+            { "name":"dc_copycur", "value":"34" },
+            { "name":"dc_verticaltext", "value":"35" },
+            { "name":"dc_rowresize", "value":"36" },
+            { "name":"dc_zoomin", "value":"37" },
+            { "name":"dc_zoomout", "value":"38" },
+            { "name":"dc_help", "value":"39" },
+            { "name":"dc_custom", "value":"40" },
+            { "name":"dc_last", "value":"41" }
+          ]
+        },
+        {
+          "enumname": "EHTMLKeyModifiers",
+          "fqname": "ISteamHTMLSurface::EHTMLKeyModifiers",
+          "values": [
+            { "name":"k_eHTMLKeyModifier_None", "value":"0" },
+            { "name":"k_eHTMLKeyModifier_AltDown", "value":"1" },
+            { "name":"k_eHTMLKeyModifier_CtrlDown", "value":"2" },
+            { "name":"k_eHTMLKeyModifier_ShiftDown", "value":"4" }
+          ]
+        }
+      ],
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "Init",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_Init",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "Shutdown",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_Shutdown",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "callresult": "HTML_BrowserReady_t",
+          "methodname": "CreateBrowser",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_CreateBrowser",
+          "params": [
+            { "paramname":"pchUserAgent", "paramtype":"const char *" },
+            { "paramname":"pchUserCSS", "paramtype":"const char *" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "RemoveBrowser",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_RemoveBrowser",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "LoadURL",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_LoadURL",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"pchURL", "paramtype":"const char *" },
+            { "paramname":"pchPostData", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetSize",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_SetSize",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"unWidth", "paramtype":"uint32" },
+            { "paramname":"unHeight", "paramtype":"uint32" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "StopLoad",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_StopLoad",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "Reload",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_Reload",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GoBack",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_GoBack",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GoForward",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_GoForward",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "AddHeader",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_AddHeader",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"pchKey", "paramtype":"const char *" },
+            { "paramname":"pchValue", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "ExecuteJavascript",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_ExecuteJavascript",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"pchScript", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "MouseUp",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_MouseUp",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"eMouseButton", "paramtype":"ISteamHTMLSurface::EHTMLMouseButton" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "MouseDown",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_MouseDown",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"eMouseButton", "paramtype":"ISteamHTMLSurface::EHTMLMouseButton" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "MouseDoubleClick",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_MouseDoubleClick",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"eMouseButton", "paramtype":"ISteamHTMLSurface::EHTMLMouseButton" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "MouseMove",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_MouseMove",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"x", "paramtype":"int" },
+            { "paramname":"y", "paramtype":"int" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "MouseWheel",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_MouseWheel",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"nDelta", "paramtype":"int32" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "KeyDown",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_KeyDown",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"nNativeKeyCode", "paramtype":"uint32" },
+            { "paramname":"eHTMLKeyModifiers", "paramtype":"ISteamHTMLSurface::EHTMLKeyModifiers" },
+            { "paramname":"bIsSystemKey", "paramtype":"bool" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "KeyUp",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_KeyUp",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"nNativeKeyCode", "paramtype":"uint32" },
+            { "paramname":"eHTMLKeyModifiers", "paramtype":"ISteamHTMLSurface::EHTMLKeyModifiers" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "KeyChar",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_KeyChar",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"cUnicodeChar", "paramtype":"uint32" },
+            { "paramname":"eHTMLKeyModifiers", "paramtype":"ISteamHTMLSurface::EHTMLKeyModifiers" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetHorizontalScroll",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_SetHorizontalScroll",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"nAbsolutePixelScroll", "paramtype":"uint32" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetVerticalScroll",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_SetVerticalScroll",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"nAbsolutePixelScroll", "paramtype":"uint32" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetKeyFocus",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_SetKeyFocus",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"bHasKeyFocus", "paramtype":"bool" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "ViewSource",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_ViewSource",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "CopyToClipboard",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_CopyToClipboard",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "PasteFromClipboard",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_PasteFromClipboard",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "Find",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_Find",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"pchSearchStr", "paramtype":"const char *" },
+            { "paramname":"bCurrentlyInFind", "paramtype":"bool" },
+            { "paramname":"bReverse", "paramtype":"bool" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "StopFind",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_StopFind",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetLinkAtPosition",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_GetLinkAtPosition",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"x", "paramtype":"int" },
+            { "paramname":"y", "paramtype":"int" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetCookie",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_SetCookie",
+          "params": [
+            { "paramname":"pchHostname", "paramtype":"const char *" },
+            { "paramname":"pchKey", "paramtype":"const char *" },
+            { "paramname":"pchValue", "paramtype":"const char *" },
+            { "paramname":"pchPath", "paramtype":"const char *" },
+            { "paramname":"nExpires", "paramtype":"RTime32" },
+            { "paramname":"bSecure", "paramtype":"bool" },
+            { "paramname":"bHTTPOnly", "paramtype":"bool" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetPageScaleFactor",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_SetPageScaleFactor",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"flZoom", "paramtype":"float" },
+            { "paramname":"nPointX", "paramtype":"int" },
+            { "paramname":"nPointY", "paramtype":"int" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetBackgroundMode",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_SetBackgroundMode",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"bBackgroundMode", "paramtype":"bool" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetDPIScalingFactor",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_SetDPIScalingFactor",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"flDPIScaling", "paramtype":"float" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "OpenDeveloperTools",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_OpenDeveloperTools",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "AllowStartRequest",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_AllowStartRequest",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"bAllowed", "paramtype":"bool" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "JSDialogResponse",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_JSDialogResponse",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"bResult", "paramtype":"bool" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "ignore": null,
+          "methodname": "FileLoadDialogResponse",
+          "methodname_flat": "SteamAPI_ISteamHTMLSurface_FileLoadDialogResponse",
+          "params": [
+            { "paramname":"unBrowserHandle", "paramtype":"HHTMLBrowser" },
+            { "paramname":"pchSelectedFiles", "paramtype":"const char **" }
+          ],
+          "returntype": "void"
+        }
+      ],
+      "version_string": "STEAMHTMLSURFACE_INTERFACE_VERSION_005"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamInventory",
+          "name_flat": "SteamAPI_SteamInventory_v003"
+        },
+        {
+          "kind": "gameserver",
+          "name": "SteamGameServerInventory",
+          "name_flat": "SteamAPI_SteamGameServerInventory_v003"
+        }
+      ],
+      "classname": "ISteamInventory",
+      "fields": [],
+      "methods": [
+        {
+          "desc": "Find out the status of an asynchronous inventory result handle.",
+          "methodname": "GetResultStatus",
+          "methodname_flat": "SteamAPI_ISteamInventory_GetResultStatus",
+          "params": [
+            { "paramname":"resultHandle", "paramtype":"SteamInventoryResult_t" }
+          ],
+          "returntype": "EResult"
+        },
+        {
+          "desc": "Copies the contents of a result set into a flat array. The specific contents of the result set depend on which query which was used.",
+          "methodname": "GetResultItems",
+          "methodname_flat": "SteamAPI_ISteamInventory_GetResultItems",
+          "params": [
+            { "paramname":"resultHandle", "paramtype":"SteamInventoryResult_t" },
+            {
+              "desc": "Output array",
+              "out_array_count": "punOutItemsArraySize",
+              "paramname": "pOutItemsArray",
+              "paramtype": "SteamItemDetails_t *"
+            },
+            { "paramname":"punOutItemsArraySize", "paramtype":"uint32 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetResultItemProperty",
+          "methodname_flat": "SteamAPI_ISteamInventory_GetResultItemProperty",
+          "params": [
+            { "paramname":"resultHandle", "paramtype":"SteamInventoryResult_t" },
+            { "paramname":"unItemIndex", "paramtype":"uint32" },
+            { "paramname":"pchPropertyName", "paramtype":"const char *" },
+            {
+              "out_string_count": "punValueBufferSizeOut",
+              "paramname": "pchValueBuffer",
+              "paramtype": "char *"
+            },
+            { "paramname":"punValueBufferSizeOut", "paramtype":"uint32 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "desc": "Returns the server time at which the result was generated. Compare against the value of IClientUtils::GetServerRealTime() to determine age.",
+          "methodname": "GetResultTimestamp",
+          "methodname_flat": "SteamAPI_ISteamInventory_GetResultTimestamp",
+          "params": [
+            { "paramname":"resultHandle", "paramtype":"SteamInventoryResult_t" }
+          ],
+          "returntype": "uint32"
+        },
+        {
+          "desc": "Returns true if the result belongs to the target steam ID or false if the result does not. This is important when using DeserializeResult to verify that a remote player is not pretending to have a different users inventory.",
+          "methodname": "CheckResultSteamID",
+          "methodname_flat": "SteamAPI_ISteamInventory_CheckResultSteamID",
+          "params": [
+            { "paramname":"resultHandle", "paramtype":"SteamInventoryResult_t" },
+            { "paramname":"steamIDExpected", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "desc": "Destroys a result handle and frees all associated memory.",
+          "methodname": "DestroyResult",
+          "methodname_flat": "SteamAPI_ISteamInventory_DestroyResult",
+          "params": [
+            { "paramname":"resultHandle", "paramtype":"SteamInventoryResult_t" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "desc": "Captures the entire state of the current users Steam inventory.",
+          "methodname": "GetAllItems",
+          "methodname_flat": "SteamAPI_ISteamInventory_GetAllItems",
+          "params": [
+            { "paramname":"pResultHandle", "paramtype":"SteamInventoryResult_t *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "desc": "Captures the state of a subset of the current users Steam inventory identified by an array of item instance IDs.",
+          "methodname": "GetItemsByID",
+          "methodname_flat": "SteamAPI_ISteamInventory_GetItemsByID",
+          "params": [
+            { "paramname":"pResultHandle", "paramtype":"SteamInventoryResult_t *" },
+            {
+              "array_count": "unCountInstanceIDs",
+              "paramname": "pInstanceIDs",
+              "paramtype": "const SteamItemInstanceID_t *"
+            },
+            { "paramname":"unCountInstanceIDs", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SerializeResult",
+          "methodname_flat": "SteamAPI_ISteamInventory_SerializeResult",
+          "params": [
+            { "paramname":"resultHandle", "paramtype":"SteamInventoryResult_t" },
+            {
+              "out_buffer_count": "punOutBufferSize",
+              "paramname": "pOutBuffer",
+              "paramtype": "void *"
+            },
+            { "paramname":"punOutBufferSize", "paramtype":"uint32 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "DeserializeResult",
+          "methodname_flat": "SteamAPI_ISteamInventory_DeserializeResult",
+          "params": [
+            { "paramname":"pOutResultHandle", "paramtype":"SteamInventoryResult_t *" },
+            {
+              "buffer_count": "punOutBufferSize",
+              "paramname": "pBuffer",
+              "paramtype": "const void *"
+            },
+            { "paramname":"unBufferSize", "paramtype":"uint32" },
+            { "paramname":"bRESERVED_MUST_BE_FALSE", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GenerateItems",
+          "methodname_flat": "SteamAPI_ISteamInventory_GenerateItems",
+          "params": [
+            { "paramname":"pResultHandle", "paramtype":"SteamInventoryResult_t *" },
+            {
+              "array_count": "unArrayLength",
+              "paramname": "pArrayItemDefs",
+              "paramtype": "const SteamItemDef_t *"
+            },
+            {
+              "array_count": "unArrayLength",
+              "paramname": "punArrayQuantity",
+              "paramtype": "const uint32 *"
+            },
+            { "paramname":"unArrayLength", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "desc": "GrantPromoItems() checks the list of promotional items for which the user may be eligible and grants the items (one time only).",
+          "methodname": "GrantPromoItems",
+          "methodname_flat": "SteamAPI_ISteamInventory_GrantPromoItems",
+          "params": [
+            { "paramname":"pResultHandle", "paramtype":"SteamInventoryResult_t *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "AddPromoItem",
+          "methodname_flat": "SteamAPI_ISteamInventory_AddPromoItem",
+          "params": [
+            { "paramname":"pResultHandle", "paramtype":"SteamInventoryResult_t *" },
+            { "paramname":"itemDef", "paramtype":"SteamItemDef_t" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "AddPromoItems",
+          "methodname_flat": "SteamAPI_ISteamInventory_AddPromoItems",
+          "params": [
+            { "paramname":"pResultHandle", "paramtype":"SteamInventoryResult_t *" },
+            {
+              "array_count": "unArrayLength",
+              "paramname": "pArrayItemDefs",
+              "paramtype": "const SteamItemDef_t *"
+            },
+            { "paramname":"unArrayLength", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "desc": "ConsumeItem() removes items from the inventory permanently.",
+          "methodname": "ConsumeItem",
+          "methodname_flat": "SteamAPI_ISteamInventory_ConsumeItem",
+          "params": [
+            { "paramname":"pResultHandle", "paramtype":"SteamInventoryResult_t *" },
+            { "paramname":"itemConsume", "paramtype":"SteamItemInstanceID_t" },
+            { "paramname":"unQuantity", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "ExchangeItems",
+          "methodname_flat": "SteamAPI_ISteamInventory_ExchangeItems",
+          "params": [
+            { "paramname":"pResultHandle", "paramtype":"SteamInventoryResult_t *" },
+            {
+              "array_count": "unArrayGenerateLength",
+              "paramname": "pArrayGenerate",
+              "paramtype": "const SteamItemDef_t *"
+            },
+            {
+              "array_count": "unArrayGenerateLength",
+              "paramname": "punArrayGenerateQuantity",
+              "paramtype": "const uint32 *"
+            },
+            { "paramname":"unArrayGenerateLength", "paramtype":"uint32" },
+            {
+              "array_count": "unArrayDestroyLength",
+              "paramname": "pArrayDestroy",
+              "paramtype": "const SteamItemInstanceID_t *"
+            },
+            {
+              "array_count": "unArrayDestroyLength",
+              "paramname": "punArrayDestroyQuantity",
+              "paramtype": "const uint32 *"
+            },
+            { "paramname":"unArrayDestroyLength", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "TransferItemQuantity",
+          "methodname_flat": "SteamAPI_ISteamInventory_TransferItemQuantity",
+          "params": [
+            { "paramname":"pResultHandle", "paramtype":"SteamInventoryResult_t *" },
+            { "paramname":"itemIdSource", "paramtype":"SteamItemInstanceID_t" },
+            { "paramname":"unQuantity", "paramtype":"uint32" },
+            { "paramname":"itemIdDest", "paramtype":"SteamItemInstanceID_t" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "desc": "Deprecated method. Playtime accounting is performed on the Steam servers.",
+          "methodname": "SendItemDropHeartbeat",
+          "methodname_flat": "SteamAPI_ISteamInventory_SendItemDropHeartbeat",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "desc": "Playtime credit must be consumed and turned into item drops by your game.",
+          "methodname": "TriggerItemDrop",
+          "methodname_flat": "SteamAPI_ISteamInventory_TriggerItemDrop",
+          "params": [
+            { "paramname":"pResultHandle", "paramtype":"SteamInventoryResult_t *" },
+            { "paramname":"dropListDefinition", "paramtype":"SteamItemDef_t" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "TradeItems",
+          "methodname_flat": "SteamAPI_ISteamInventory_TradeItems",
+          "params": [
+            { "paramname":"pResultHandle", "paramtype":"SteamInventoryResult_t *" },
+            { "paramname":"steamIDTradePartner", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            {
+              "array_count": "nArrayGiveLength",
+              "paramname": "pArrayGive",
+              "paramtype": "const SteamItemInstanceID_t *"
+            },
+            {
+              "array_count": "nArrayGiveLength",
+              "paramname": "pArrayGiveQuantity",
+              "paramtype": "const uint32 *"
+            },
+            { "paramname":"nArrayGiveLength", "paramtype":"uint32" },
+            {
+              "array_count": "nArrayGetLength",
+              "paramname": "pArrayGet",
+              "paramtype": "const SteamItemInstanceID_t *"
+            },
+            {
+              "array_count": "nArrayGetLength",
+              "paramname": "pArrayGetQuantity",
+              "paramtype": "const uint32 *"
+            },
+            { "paramname":"nArrayGetLength", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "desc": "LoadItemDefinitions triggers the automatic load and refresh of item definitions.",
+          "methodname": "LoadItemDefinitions",
+          "methodname_flat": "SteamAPI_ISteamInventory_LoadItemDefinitions",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetItemDefinitionIDs",
+          "methodname_flat": "SteamAPI_ISteamInventory_GetItemDefinitionIDs",
+          "params": [
+            {
+              "desc": "List of item definition IDs",
+              "out_array_count": "punItemDefIDsArraySize",
+              "paramname": "pItemDefIDs",
+              "paramtype": "SteamItemDef_t *"
+            },
+            {
+              "desc": "Size of array is passed in and actual size used is returned in this param",
+              "paramname": "punItemDefIDsArraySize",
+              "paramtype": "uint32 *"
+            }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetItemDefinitionProperty",
+          "methodname_flat": "SteamAPI_ISteamInventory_GetItemDefinitionProperty",
+          "params": [
+            { "paramname":"iDefinition", "paramtype":"SteamItemDef_t" },
+            { "paramname":"pchPropertyName", "paramtype":"const char *" },
+            {
+              "out_string_count": "punValueBufferSizeOut",
+              "paramname": "pchValueBuffer",
+              "paramtype": "char *"
+            },
+            { "paramname":"punValueBufferSizeOut", "paramtype":"uint32 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "callresult": "SteamInventoryEligiblePromoItemDefIDs_t",
+          "methodname": "RequestEligiblePromoItemDefinitionsIDs",
+          "methodname_flat": "SteamAPI_ISteamInventory_RequestEligiblePromoItemDefinitionsIDs",
+          "params": [
+            { "paramname":"steamID", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "GetEligiblePromoItemDefinitionIDs",
+          "methodname_flat": "SteamAPI_ISteamInventory_GetEligiblePromoItemDefinitionIDs",
+          "params": [
+            { "paramname":"steamID", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            {
+              "desc": "List of item definition IDs",
+              "out_array_count": "punItemDefIDsArraySize",
+              "paramname": "pItemDefIDs",
+              "paramtype": "SteamItemDef_t *"
+            },
+            {
+              "desc": "Size of array is passed in and actual size used is returned in this param",
+              "paramname": "punItemDefIDsArraySize",
+              "paramtype": "uint32 *"
+            }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "callresult": "SteamInventoryStartPurchaseResult_t",
+          "methodname": "StartPurchase",
+          "methodname_flat": "SteamAPI_ISteamInventory_StartPurchase",
+          "params": [
+            {
+              "array_count": "unArrayLength",
+              "paramname": "pArrayItemDefs",
+              "paramtype": "const SteamItemDef_t *"
+            },
+            {
+              "array_count": "unArrayLength",
+              "paramname": "punArrayQuantity",
+              "paramtype": "const uint32 *"
+            },
+            { "paramname":"unArrayLength", "paramtype":"uint32" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "SteamInventoryRequestPricesResult_t",
+          "methodname": "RequestPrices",
+          "methodname_flat": "SteamAPI_ISteamInventory_RequestPrices",
+          "params": [],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "GetNumItemsWithPrices",
+          "methodname_flat": "SteamAPI_ISteamInventory_GetNumItemsWithPrices",
+          "params": [],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "GetItemsWithPrices",
+          "methodname_flat": "SteamAPI_ISteamInventory_GetItemsWithPrices",
+          "params": [
+            {
+              "array_count": "unArrayLength",
+              "desc": "Items with prices",
+              "out_array_count": "pArrayItemDefs",
+              "paramname": "pArrayItemDefs",
+              "paramtype": "SteamItemDef_t *"
+            },
+            {
+              "array_count": "unArrayLength",
+              "desc": "List of prices for the given item defs",
+              "out_array_count": "pPrices",
+              "paramname": "pCurrentPrices",
+              "paramtype": "uint64 *"
+            },
+            {
+              "array_count": "unArrayLength",
+              "desc": "List of prices for the given item defs",
+              "out_array_count": "pPrices",
+              "paramname": "pBasePrices",
+              "paramtype": "uint64 *"
+            },
+            { "paramname":"unArrayLength", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetItemPrice",
+          "methodname_flat": "SteamAPI_ISteamInventory_GetItemPrice",
+          "params": [
+            { "paramname":"iDefinition", "paramtype":"SteamItemDef_t" },
+            { "paramname":"pCurrentPrice", "paramtype":"uint64 *" },
+            { "paramname":"pBasePrice", "paramtype":"uint64 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "StartUpdateProperties",
+          "methodname_flat": "SteamAPI_ISteamInventory_StartUpdateProperties",
+          "params": [],
+          "returntype": "SteamInventoryUpdateHandle_t"
+        },
+        {
+          "methodname": "RemoveProperty",
+          "methodname_flat": "SteamAPI_ISteamInventory_RemoveProperty",
+          "params": [
+            { "paramname":"handle", "paramtype":"SteamInventoryUpdateHandle_t" },
+            { "paramname":"nItemID", "paramtype":"SteamItemInstanceID_t" },
+            { "paramname":"pchPropertyName", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetProperty",
+          "methodname_flat": "SteamAPI_ISteamInventory_SetPropertyString",
+          "params": [
+            { "paramname":"handle", "paramtype":"SteamInventoryUpdateHandle_t" },
+            { "paramname":"nItemID", "paramtype":"SteamItemInstanceID_t" },
+            { "paramname":"pchPropertyName", "paramtype":"const char *" },
+            { "paramname":"pchPropertyValue", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetProperty",
+          "methodname_flat": "SteamAPI_ISteamInventory_SetPropertyBool",
+          "params": [
+            { "paramname":"handle", "paramtype":"SteamInventoryUpdateHandle_t" },
+            { "paramname":"nItemID", "paramtype":"SteamItemInstanceID_t" },
+            { "paramname":"pchPropertyName", "paramtype":"const char *" },
+            { "paramname":"bValue", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetProperty",
+          "methodname_flat": "SteamAPI_ISteamInventory_SetPropertyInt64",
+          "params": [
+            { "paramname":"handle", "paramtype":"SteamInventoryUpdateHandle_t" },
+            { "paramname":"nItemID", "paramtype":"SteamItemInstanceID_t" },
+            { "paramname":"pchPropertyName", "paramtype":"const char *" },
+            { "paramname":"nValue", "paramtype":"int64" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetProperty",
+          "methodname_flat": "SteamAPI_ISteamInventory_SetPropertyFloat",
+          "params": [
+            { "paramname":"handle", "paramtype":"SteamInventoryUpdateHandle_t" },
+            { "paramname":"nItemID", "paramtype":"SteamItemInstanceID_t" },
+            { "paramname":"pchPropertyName", "paramtype":"const char *" },
+            { "paramname":"flValue", "paramtype":"float" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SubmitUpdateProperties",
+          "methodname_flat": "SteamAPI_ISteamInventory_SubmitUpdateProperties",
+          "params": [
+            { "paramname":"handle", "paramtype":"SteamInventoryUpdateHandle_t" },
+            { "paramname":"pResultHandle", "paramtype":"SteamInventoryResult_t *" }
+          ],
+          "returntype": "bool"
+        }
+      ],
+      "version_string": "STEAMINVENTORY_INTERFACE_V003"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamVideo",
+          "name_flat": "SteamAPI_SteamVideo_v002"
+        }
+      ],
+      "classname": "ISteamVideo",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "GetVideoURL",
+          "methodname_flat": "SteamAPI_ISteamVideo_GetVideoURL",
+          "params": [
+            { "paramname":"unVideoAppID", "paramtype":"AppId_t" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "IsBroadcasting",
+          "methodname_flat": "SteamAPI_ISteamVideo_IsBroadcasting",
+          "params": [
+            { "paramname":"pnNumViewers", "paramtype":"int *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "callback": "GetOPFSettingsResult_t",
+          "methodname": "GetOPFSettings",
+          "methodname_flat": "SteamAPI_ISteamVideo_GetOPFSettings",
+          "params": [
+            { "paramname":"unVideoAppID", "paramtype":"AppId_t" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetOPFStringForApp",
+          "methodname_flat": "SteamAPI_ISteamVideo_GetOPFStringForApp",
+          "params": [
+            { "paramname":"unVideoAppID", "paramtype":"AppId_t" },
+            { "paramname":"pchBuffer", "paramtype":"char *" },
+            { "paramname":"pnBufferSize", "paramtype":"int32 *" }
+          ],
+          "returntype": "bool"
+        }
+      ],
+      "version_string": "STEAMVIDEO_INTERFACE_V002"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamTV",
+          "name_flat": "SteamAPI_SteamTV_v001"
+        }
+      ],
+      "classname": "ISteamTV",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "IsBroadcasting",
+          "methodname_flat": "SteamAPI_ISteamTV_IsBroadcasting",
+          "params": [
+            { "paramname":"pnNumViewers", "paramtype":"int *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "AddBroadcastGameData",
+          "methodname_flat": "SteamAPI_ISteamTV_AddBroadcastGameData",
+          "params": [
+            { "paramname":"pchKey", "paramtype":"const char *" },
+            { "paramname":"pchValue", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "RemoveBroadcastGameData",
+          "methodname_flat": "SteamAPI_ISteamTV_RemoveBroadcastGameData",
+          "params": [
+            { "paramname":"pchKey", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "AddTimelineMarker",
+          "methodname_flat": "SteamAPI_ISteamTV_AddTimelineMarker",
+          "params": [
+            { "paramname":"pchTemplateName", "paramtype":"const char *" },
+            { "paramname":"bPersistent", "paramtype":"bool" },
+            { "paramname":"nColorR", "paramtype":"uint8" },
+            { "paramname":"nColorG", "paramtype":"uint8" },
+            { "paramname":"nColorB", "paramtype":"uint8" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "RemoveTimelineMarker",
+          "methodname_flat": "SteamAPI_ISteamTV_RemoveTimelineMarker",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "AddRegion",
+          "methodname_flat": "SteamAPI_ISteamTV_AddRegion",
+          "params": [
+            { "paramname":"pchElementName", "paramtype":"const char *" },
+            { "paramname":"pchTimelineDataSection", "paramtype":"const char *" },
+            { "paramname":"pSteamTVRegion", "paramtype":"const SteamTVRegion_t *" },
+            { "paramname":"eSteamTVRegionBehavior", "paramtype":"ESteamTVRegionBehavior" }
+          ],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "RemoveRegion",
+          "methodname_flat": "SteamAPI_ISteamTV_RemoveRegion",
+          "params": [
+            { "paramname":"unRegionHandle", "paramtype":"uint32" }
+          ],
+          "returntype": "void"
+        }
+      ],
+      "version_string": "STEAMTV_INTERFACE_V001"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamParentalSettings",
+          "name_flat": "SteamAPI_SteamParentalSettings_v001"
+        }
+      ],
+      "classname": "ISteamParentalSettings",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "BIsParentalLockEnabled",
+          "methodname_flat": "SteamAPI_ISteamParentalSettings_BIsParentalLockEnabled",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "BIsParentalLockLocked",
+          "methodname_flat": "SteamAPI_ISteamParentalSettings_BIsParentalLockLocked",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "BIsAppBlocked",
+          "methodname_flat": "SteamAPI_ISteamParentalSettings_BIsAppBlocked",
+          "params": [
+            { "paramname":"nAppID", "paramtype":"AppId_t" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "BIsAppInBlockList",
+          "methodname_flat": "SteamAPI_ISteamParentalSettings_BIsAppInBlockList",
+          "params": [
+            { "paramname":"nAppID", "paramtype":"AppId_t" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "BIsFeatureBlocked",
+          "methodname_flat": "SteamAPI_ISteamParentalSettings_BIsFeatureBlocked",
+          "params": [
+            { "paramname":"eFeature", "paramtype":"EParentalFeature" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "BIsFeatureInBlockList",
+          "methodname_flat": "SteamAPI_ISteamParentalSettings_BIsFeatureInBlockList",
+          "params": [
+            { "paramname":"eFeature", "paramtype":"EParentalFeature" }
+          ],
+          "returntype": "bool"
+        }
+      ],
+      "version_string": "STEAMPARENTALSETTINGS_INTERFACE_VERSION001"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamRemotePlay",
+          "name_flat": "SteamAPI_SteamRemotePlay_v001"
+        }
+      ],
+      "classname": "ISteamRemotePlay",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "GetSessionCount",
+          "methodname_flat": "SteamAPI_ISteamRemotePlay_GetSessionCount",
+          "params": [],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "GetSessionID",
+          "methodname_flat": "SteamAPI_ISteamRemotePlay_GetSessionID",
+          "params": [
+            { "paramname":"iSessionIndex", "paramtype":"int" }
+          ],
+          "returntype": "RemotePlaySessionID_t"
+        },
+        {
+          "methodname": "GetSessionSteamID",
+          "methodname_flat": "SteamAPI_ISteamRemotePlay_GetSessionSteamID",
+          "params": [
+            { "paramname":"unSessionID", "paramtype":"RemotePlaySessionID_t" }
+          ],
+          "returntype": "CSteamID",
+          "returntype_flat": "uint64_steamid"
+        },
+        {
+          "methodname": "GetSessionClientName",
+          "methodname_flat": "SteamAPI_ISteamRemotePlay_GetSessionClientName",
+          "params": [
+            { "paramname":"unSessionID", "paramtype":"RemotePlaySessionID_t" }
+          ],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "GetSessionClientFormFactor",
+          "methodname_flat": "SteamAPI_ISteamRemotePlay_GetSessionClientFormFactor",
+          "params": [
+            { "paramname":"unSessionID", "paramtype":"RemotePlaySessionID_t" }
+          ],
+          "returntype": "ESteamDeviceFormFactor"
+        },
+        {
+          "methodname": "BGetSessionClientResolution",
+          "methodname_flat": "SteamAPI_ISteamRemotePlay_BGetSessionClientResolution",
+          "params": [
+            { "paramname":"unSessionID", "paramtype":"RemotePlaySessionID_t" },
+            { "paramname":"pnResolutionX", "paramtype":"int *" },
+            { "paramname":"pnResolutionY", "paramtype":"int *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "BSendRemotePlayTogetherInvite",
+          "methodname_flat": "SteamAPI_ISteamRemotePlay_BSendRemotePlayTogetherInvite",
+          "params": [
+            { "paramname":"steamIDFriend", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "bool"
+        }
+      ],
+      "version_string": "STEAMREMOTEPLAY_INTERFACE_VERSION001"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "user",
+          "name": "SteamNetworkingSockets",
+          "name_flat": "SteamAPI_SteamNetworkingSockets_v008"
+        },
+        {
+          "kind": "gameserver",
+          "name": "SteamGameServerNetworkingSockets",
+          "name_flat": "SteamAPI_SteamGameServerNetworkingSockets_v008"
+        }
+      ],
+      "classname": "ISteamNetworkingSockets",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "CreateListenSocketIP",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_CreateListenSocketIP",
+          "params": [
+            { "paramname":"localAddress", "paramtype":"const SteamNetworkingIPAddr &" },
+            { "paramname":"nOptions", "paramtype":"int" },
+            { "paramname":"pOptions", "paramtype":"const SteamNetworkingConfigValue_t *" }
+          ],
+          "returntype": "HSteamListenSocket"
+        },
+        {
+          "methodname": "ConnectByIPAddress",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_ConnectByIPAddress",
+          "params": [
+            { "paramname":"address", "paramtype":"const SteamNetworkingIPAddr &" },
+            { "paramname":"nOptions", "paramtype":"int" },
+            { "paramname":"pOptions", "paramtype":"const SteamNetworkingConfigValue_t *" }
+          ],
+          "returntype": "HSteamNetConnection"
+        },
+        {
+          "methodname": "CreateListenSocketP2P",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_CreateListenSocketP2P",
+          "params": [
+            { "paramname":"nVirtualPort", "paramtype":"int" },
+            { "paramname":"nOptions", "paramtype":"int" },
+            { "paramname":"pOptions", "paramtype":"const SteamNetworkingConfigValue_t *" }
+          ],
+          "returntype": "HSteamListenSocket"
+        },
+        {
+          "methodname": "ConnectP2P",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_ConnectP2P",
+          "params": [
+            { "paramname":"identityRemote", "paramtype":"const SteamNetworkingIdentity &" },
+            { "paramname":"nVirtualPort", "paramtype":"int" },
+            { "paramname":"nOptions", "paramtype":"int" },
+            { "paramname":"pOptions", "paramtype":"const SteamNetworkingConfigValue_t *" }
+          ],
+          "returntype": "HSteamNetConnection"
+        },
+        {
+          "methodname": "AcceptConnection",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_AcceptConnection",
+          "params": [
+            { "paramname":"hConn", "paramtype":"HSteamNetConnection" }
+          ],
+          "returntype": "EResult"
+        },
+        {
+          "methodname": "CloseConnection",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_CloseConnection",
+          "params": [
+            { "paramname":"hPeer", "paramtype":"HSteamNetConnection" },
+            { "paramname":"nReason", "paramtype":"int" },
+            { "paramname":"pszDebug", "paramtype":"const char *" },
+            { "paramname":"bEnableLinger", "paramtype":"bool" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "CloseListenSocket",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_CloseListenSocket",
+          "params": [
+            { "paramname":"hSocket", "paramtype":"HSteamListenSocket" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetConnectionUserData",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_SetConnectionUserData",
+          "params": [
+            { "paramname":"hPeer", "paramtype":"HSteamNetConnection" },
+            { "paramname":"nUserData", "paramtype":"int64" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetConnectionUserData",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_GetConnectionUserData",
+          "params": [
+            { "paramname":"hPeer", "paramtype":"HSteamNetConnection" }
+          ],
+          "returntype": "int64"
+        },
+        {
+          "methodname": "SetConnectionName",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_SetConnectionName",
+          "params": [
+            { "paramname":"hPeer", "paramtype":"HSteamNetConnection" },
+            { "paramname":"pszName", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetConnectionName",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_GetConnectionName",
+          "params": [
+            { "paramname":"hPeer", "paramtype":"HSteamNetConnection" },
+            { "paramname":"pszName", "paramtype":"char *" },
+            { "paramname":"nMaxLen", "paramtype":"int" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SendMessageToConnection",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_SendMessageToConnection",
+          "params": [
+            { "paramname":"hConn", "paramtype":"HSteamNetConnection" },
+            { "paramname":"pData", "paramtype":"const void *" },
+            { "paramname":"cbData", "paramtype":"uint32" },
+            { "paramname":"nSendFlags", "paramtype":"int" },
+            { "paramname":"pOutMessageNumber", "paramtype":"int64 *" }
+          ],
+          "returntype": "EResult"
+        },
+        {
+          "methodname": "SendMessages",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_SendMessages",
+          "params": [
+            { "paramname":"nMessages", "paramtype":"int" },
+            { "paramname":"pMessages", "paramtype":"SteamNetworkingMessage_t *const *" },
+            { "paramname":"pOutMessageNumberOrResult", "paramtype":"int64 *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "FlushMessagesOnConnection",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_FlushMessagesOnConnection",
+          "params": [
+            { "paramname":"hConn", "paramtype":"HSteamNetConnection" }
+          ],
+          "returntype": "EResult"
+        },
+        {
+          "methodname": "ReceiveMessagesOnConnection",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_ReceiveMessagesOnConnection",
+          "params": [
+            { "paramname":"hConn", "paramtype":"HSteamNetConnection" },
+            { "paramname":"ppOutMessages", "paramtype":"SteamNetworkingMessage_t **" },
+            { "paramname":"nMaxMessages", "paramtype":"int" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetConnectionInfo",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_GetConnectionInfo",
+          "params": [
+            { "paramname":"hConn", "paramtype":"HSteamNetConnection" },
+            { "paramname":"pInfo", "paramtype":"SteamNetConnectionInfo_t *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetQuickConnectionStatus",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_GetQuickConnectionStatus",
+          "params": [
+            { "paramname":"hConn", "paramtype":"HSteamNetConnection" },
+            { "paramname":"pStats", "paramtype":"SteamNetworkingQuickConnectionStatus *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetDetailedConnectionStatus",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_GetDetailedConnectionStatus",
+          "params": [
+            { "paramname":"hConn", "paramtype":"HSteamNetConnection" },
+            { "paramname":"pszBuf", "paramtype":"char *" },
+            { "paramname":"cbBuf", "paramtype":"int" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetListenSocketAddress",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_GetListenSocketAddress",
+          "params": [
+            { "paramname":"hSocket", "paramtype":"HSteamListenSocket" },
+            { "paramname":"address", "paramtype":"SteamNetworkingIPAddr *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "CreateSocketPair",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_CreateSocketPair",
+          "params": [
+            { "paramname":"pOutConnection1", "paramtype":"HSteamNetConnection *" },
+            { "paramname":"pOutConnection2", "paramtype":"HSteamNetConnection *" },
+            { "paramname":"bUseNetworkLoopback", "paramtype":"bool" },
+            { "paramname":"pIdentity1", "paramtype":"const SteamNetworkingIdentity *" },
+            { "paramname":"pIdentity2", "paramtype":"const SteamNetworkingIdentity *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetIdentity",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_GetIdentity",
+          "params": [
+            { "paramname":"pIdentity", "paramtype":"SteamNetworkingIdentity *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "InitAuthentication",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_InitAuthentication",
+          "params": [],
+          "returntype": "ESteamNetworkingAvailability"
+        },
+        {
+          "methodname": "GetAuthenticationStatus",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_GetAuthenticationStatus",
+          "params": [
+            { "paramname":"pDetails", "paramtype":"SteamNetAuthenticationStatus_t *" }
+          ],
+          "returntype": "ESteamNetworkingAvailability"
+        },
+        {
+          "methodname": "CreatePollGroup",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_CreatePollGroup",
+          "params": [],
+          "returntype": "HSteamNetPollGroup"
+        },
+        {
+          "methodname": "DestroyPollGroup",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_DestroyPollGroup",
+          "params": [
+            { "paramname":"hPollGroup", "paramtype":"HSteamNetPollGroup" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetConnectionPollGroup",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_SetConnectionPollGroup",
+          "params": [
+            { "paramname":"hConn", "paramtype":"HSteamNetConnection" },
+            { "paramname":"hPollGroup", "paramtype":"HSteamNetPollGroup" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "ReceiveMessagesOnPollGroup",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_ReceiveMessagesOnPollGroup",
+          "params": [
+            { "paramname":"hPollGroup", "paramtype":"HSteamNetPollGroup" },
+            { "paramname":"ppOutMessages", "paramtype":"SteamNetworkingMessage_t **" },
+            { "paramname":"nMaxMessages", "paramtype":"int" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "ReceivedRelayAuthTicket",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_ReceivedRelayAuthTicket",
+          "params": [
+            { "paramname":"pvTicket", "paramtype":"const void *" },
+            { "paramname":"cbTicket", "paramtype":"int" },
+            { "paramname":"pOutParsedTicket", "paramtype":"SteamDatagramRelayAuthTicket *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "FindRelayAuthTicketForServer",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_FindRelayAuthTicketForServer",
+          "params": [
+            { "paramname":"identityGameServer", "paramtype":"const SteamNetworkingIdentity &" },
+            { "paramname":"nVirtualPort", "paramtype":"int" },
+            { "paramname":"pOutParsedTicket", "paramtype":"SteamDatagramRelayAuthTicket *" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "ConnectToHostedDedicatedServer",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_ConnectToHostedDedicatedServer",
+          "params": [
+            { "paramname":"identityTarget", "paramtype":"const SteamNetworkingIdentity &" },
+            { "paramname":"nVirtualPort", "paramtype":"int" },
+            { "paramname":"nOptions", "paramtype":"int" },
+            { "paramname":"pOptions", "paramtype":"const SteamNetworkingConfigValue_t *" }
+          ],
+          "returntype": "HSteamNetConnection"
+        },
+        {
+          "methodname": "GetHostedDedicatedServerPort",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_GetHostedDedicatedServerPort",
+          "params": [],
+          "returntype": "uint16"
+        },
+        {
+          "methodname": "GetHostedDedicatedServerPOPID",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_GetHostedDedicatedServerPOPID",
+          "params": [],
+          "returntype": "SteamNetworkingPOPID"
+        },
+        {
+          "methodname": "GetHostedDedicatedServerAddress",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_GetHostedDedicatedServerAddress",
+          "params": [
+            { "paramname":"pRouting", "paramtype":"SteamDatagramHostedAddress *" }
+          ],
+          "returntype": "EResult"
+        },
+        {
+          "methodname": "CreateHostedDedicatedServerListenSocket",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_CreateHostedDedicatedServerListenSocket",
+          "params": [
+            { "paramname":"nVirtualPort", "paramtype":"int" },
+            { "paramname":"nOptions", "paramtype":"int" },
+            { "paramname":"pOptions", "paramtype":"const SteamNetworkingConfigValue_t *" }
+          ],
+          "returntype": "HSteamListenSocket"
+        },
+        {
+          "methodname": "GetGameCoordinatorServerLogin",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_GetGameCoordinatorServerLogin",
+          "params": [
+            { "paramname":"pLoginInfo", "paramtype":"SteamDatagramGameCoordinatorServerLogin *" },
+            { "paramname":"pcbSignedBlob", "paramtype":"int *" },
+            { "paramname":"pBlob", "paramtype":"void *" }
+          ],
+          "returntype": "EResult"
+        },
+        {
+          "methodname": "ConnectP2PCustomSignaling",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_ConnectP2PCustomSignaling",
+          "params": [
+            { "paramname":"pSignaling", "paramtype":"ISteamNetworkingConnectionCustomSignaling *" },
+            { "paramname":"pPeerIdentity", "paramtype":"const SteamNetworkingIdentity *" },
+            { "paramname":"nOptions", "paramtype":"int" },
+            { "paramname":"pOptions", "paramtype":"const SteamNetworkingConfigValue_t *" }
+          ],
+          "returntype": "HSteamNetConnection"
+        },
+        {
+          "methodname": "ReceivedP2PCustomSignal",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_ReceivedP2PCustomSignal",
+          "params": [
+            { "paramname":"pMsg", "paramtype":"const void *" },
+            { "paramname":"cbMsg", "paramtype":"int" },
+            { "paramname":"pContext", "paramtype":"ISteamNetworkingCustomSignalingRecvContext *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetCertificateRequest",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_GetCertificateRequest",
+          "params": [
+            { "paramname":"pcbBlob", "paramtype":"int *" },
+            { "paramname":"pBlob", "paramtype":"void *" },
+            { "paramname":"errMsg", "paramtype":"SteamNetworkingErrMsg &" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetCertificate",
+          "methodname_flat": "SteamAPI_ISteamNetworkingSockets_SetCertificate",
+          "params": [
+            { "paramname":"pCertificate", "paramtype":"const void *" },
+            { "paramname":"cbCertificate", "paramtype":"int" },
+            { "paramname":"errMsg", "paramtype":"SteamNetworkingErrMsg &" }
+          ],
+          "returntype": "bool"
+        }
+      ],
+      "version_string": "SteamNetworkingSockets008"
+    },
+    {
+      "classname": "ISteamNetworkingConnectionCustomSignaling",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "SendSignal",
+          "methodname_flat": "SteamAPI_ISteamNetworkingConnectionCustomSignaling_SendSignal",
+          "params": [
+            { "paramname":"hConn", "paramtype":"HSteamNetConnection" },
+            { "paramname":"info", "paramtype":"const SteamNetConnectionInfo_t &" },
+            { "paramname":"pMsg", "paramtype":"const void *" },
+            { "paramname":"cbMsg", "paramtype":"int" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "Release",
+          "methodname_flat": "SteamAPI_ISteamNetworkingConnectionCustomSignaling_Release",
+          "params": [],
+          "returntype": "void"
+        }
+      ]
+    },
+    {
+      "classname": "ISteamNetworkingCustomSignalingRecvContext",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "OnConnectRequest",
+          "methodname_flat": "SteamAPI_ISteamNetworkingCustomSignalingRecvContext_OnConnectRequest",
+          "params": [
+            { "paramname":"hConn", "paramtype":"HSteamNetConnection" },
+            { "paramname":"identityPeer", "paramtype":"const SteamNetworkingIdentity &" }
+          ],
+          "returntype": "ISteamNetworkingConnectionCustomSignaling *"
+        },
+        {
+          "methodname": "SendRejectionSignal",
+          "methodname_flat": "SteamAPI_ISteamNetworkingCustomSignalingRecvContext_SendRejectionSignal",
+          "params": [
+            { "paramname":"identityPeer", "paramtype":"const SteamNetworkingIdentity &" },
+            { "paramname":"pMsg", "paramtype":"const void *" },
+            { "paramname":"cbMsg", "paramtype":"int" }
+          ],
+          "returntype": "void"
+        }
+      ]
+    },
+    {
+      "accessors": [
+        {
+          "kind": "global",
+          "name": "SteamNetworkingUtils",
+          "name_flat": "SteamAPI_SteamNetworkingUtils_v003"
+        }
+      ],
+      "classname": "ISteamNetworkingUtils",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "AllocateMessage",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_AllocateMessage",
+          "params": [
+            { "paramname":"cbAllocateBuffer", "paramtype":"int" }
+          ],
+          "returntype": "SteamNetworkingMessage_t *"
+        },
+        {
+          "methodname": "InitRelayNetworkAccess",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_InitRelayNetworkAccess",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetRelayNetworkStatus",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_GetRelayNetworkStatus",
+          "params": [
+            { "paramname":"pDetails", "paramtype":"SteamRelayNetworkStatus_t *" }
+          ],
+          "returntype": "ESteamNetworkingAvailability"
+        },
+        {
+          "methodname": "GetLocalPingLocation",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_GetLocalPingLocation",
+          "params": [
+            { "paramname":"result", "paramtype":"SteamNetworkPingLocation_t &" }
+          ],
+          "returntype": "float"
+        },
+        {
+          "methodname": "EstimatePingTimeBetweenTwoLocations",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_EstimatePingTimeBetweenTwoLocations",
+          "params": [
+            { "paramname":"location1", "paramtype":"const SteamNetworkPingLocation_t &" },
+            { "paramname":"location2", "paramtype":"const SteamNetworkPingLocation_t &" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "EstimatePingTimeFromLocalHost",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_EstimatePingTimeFromLocalHost",
+          "params": [
+            { "paramname":"remoteLocation", "paramtype":"const SteamNetworkPingLocation_t &" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "ConvertPingLocationToString",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_ConvertPingLocationToString",
+          "params": [
+            { "paramname":"location", "paramtype":"const SteamNetworkPingLocation_t &" },
+            { "paramname":"pszBuf", "paramtype":"char *" },
+            { "paramname":"cchBufSize", "paramtype":"int" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "ParsePingLocationString",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_ParsePingLocationString",
+          "params": [
+            { "paramname":"pszString", "paramtype":"const char *" },
+            { "paramname":"result", "paramtype":"SteamNetworkPingLocation_t &" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "CheckPingDataUpToDate",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_CheckPingDataUpToDate",
+          "params": [
+            { "paramname":"flMaxAgeSeconds", "paramtype":"float" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetPingToDataCenter",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_GetPingToDataCenter",
+          "params": [
+            { "paramname":"popID", "paramtype":"SteamNetworkingPOPID" },
+            { "paramname":"pViaRelayPoP", "paramtype":"SteamNetworkingPOPID *" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetDirectPingToPOP",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_GetDirectPingToPOP",
+          "params": [
+            { "paramname":"popID", "paramtype":"SteamNetworkingPOPID" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetPOPCount",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_GetPOPCount",
+          "params": [],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetPOPList",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_GetPOPList",
+          "params": [
+            { "paramname":"list", "paramtype":"SteamNetworkingPOPID *" },
+            { "paramname":"nListSz", "paramtype":"int" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "GetLocalTimestamp",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_GetLocalTimestamp",
+          "params": [],
+          "returntype": "SteamNetworkingMicroseconds"
+        },
+        {
+          "methodname": "SetDebugOutputFunction",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_SetDebugOutputFunction",
+          "params": [
+            { "paramname":"eDetailLevel", "paramtype":"ESteamNetworkingSocketsDebugOutputType" },
+            { "paramname":"pfnFunc", "paramtype":"FSteamNetworkingSocketsDebugOutput" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetGlobalConfigValueInt32",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_SetGlobalConfigValueInt32",
+          "params": [
+            { "paramname":"eValue", "paramtype":"ESteamNetworkingConfigValue" },
+            { "paramname":"val", "paramtype":"int32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetGlobalConfigValueFloat",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_SetGlobalConfigValueFloat",
+          "params": [
+            { "paramname":"eValue", "paramtype":"ESteamNetworkingConfigValue" },
+            { "paramname":"val", "paramtype":"float" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetGlobalConfigValueString",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_SetGlobalConfigValueString",
+          "params": [
+            { "paramname":"eValue", "paramtype":"ESteamNetworkingConfigValue" },
+            { "paramname":"val", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetConnectionConfigValueInt32",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_SetConnectionConfigValueInt32",
+          "params": [
+            { "paramname":"hConn", "paramtype":"HSteamNetConnection" },
+            { "paramname":"eValue", "paramtype":"ESteamNetworkingConfigValue" },
+            { "paramname":"val", "paramtype":"int32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetConnectionConfigValueFloat",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_SetConnectionConfigValueFloat",
+          "params": [
+            { "paramname":"hConn", "paramtype":"HSteamNetConnection" },
+            { "paramname":"eValue", "paramtype":"ESteamNetworkingConfigValue" },
+            { "paramname":"val", "paramtype":"float" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetConnectionConfigValueString",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_SetConnectionConfigValueString",
+          "params": [
+            { "paramname":"hConn", "paramtype":"HSteamNetConnection" },
+            { "paramname":"eValue", "paramtype":"ESteamNetworkingConfigValue" },
+            { "paramname":"val", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetConfigValue",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_SetConfigValue",
+          "params": [
+            { "paramname":"eValue", "paramtype":"ESteamNetworkingConfigValue" },
+            { "paramname":"eScopeType", "paramtype":"ESteamNetworkingConfigScope" },
+            { "paramname":"scopeObj", "paramtype":"intptr_t" },
+            { "paramname":"eDataType", "paramtype":"ESteamNetworkingConfigDataType" },
+            { "paramname":"pArg", "paramtype":"const void *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetConfigValueStruct",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_SetConfigValueStruct",
+          "params": [
+            { "paramname":"opt", "paramtype":"const SteamNetworkingConfigValue_t &" },
+            { "paramname":"eScopeType", "paramtype":"ESteamNetworkingConfigScope" },
+            { "paramname":"scopeObj", "paramtype":"intptr_t" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetConfigValue",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_GetConfigValue",
+          "params": [
+            { "paramname":"eValue", "paramtype":"ESteamNetworkingConfigValue" },
+            { "paramname":"eScopeType", "paramtype":"ESteamNetworkingConfigScope" },
+            { "paramname":"scopeObj", "paramtype":"intptr_t" },
+            { "paramname":"pOutDataType", "paramtype":"ESteamNetworkingConfigDataType *" },
+            { "paramname":"pResult", "paramtype":"void *" },
+            { "paramname":"cbResult", "paramtype":"size_t *" }
+          ],
+          "returntype": "ESteamNetworkingGetConfigValueResult"
+        },
+        {
+          "methodname": "GetConfigValueInfo",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_GetConfigValueInfo",
+          "params": [
+            { "paramname":"eValue", "paramtype":"ESteamNetworkingConfigValue" },
+            { "paramname":"pOutName", "paramtype":"const char **" },
+            { "paramname":"pOutDataType", "paramtype":"ESteamNetworkingConfigDataType *" },
+            { "paramname":"pOutScope", "paramtype":"ESteamNetworkingConfigScope *" },
+            { "paramname":"pOutNextValue", "paramtype":"ESteamNetworkingConfigValue *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetFirstConfigValue",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_GetFirstConfigValue",
+          "params": [],
+          "returntype": "ESteamNetworkingConfigValue"
+        },
+        {
+          "methodname": "SteamNetworkingIPAddr_ToString",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_SteamNetworkingIPAddr_ToString",
+          "params": [
+            { "paramname":"addr", "paramtype":"const SteamNetworkingIPAddr &" },
+            { "paramname":"buf", "paramtype":"char *" },
+            { "paramname":"cbBuf", "paramtype":"uint32" },
+            { "paramname":"bWithPort", "paramtype":"bool" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SteamNetworkingIPAddr_ParseString",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_SteamNetworkingIPAddr_ParseString",
+          "params": [
+            { "paramname":"pAddr", "paramtype":"SteamNetworkingIPAddr *" },
+            { "paramname":"pszStr", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SteamNetworkingIdentity_ToString",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_SteamNetworkingIdentity_ToString",
+          "params": [
+            { "paramname":"identity", "paramtype":"const SteamNetworkingIdentity &" },
+            { "paramname":"buf", "paramtype":"char *" },
+            { "paramname":"cbBuf", "paramtype":"uint32" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SteamNetworkingIdentity_ParseString",
+          "methodname_flat": "SteamAPI_ISteamNetworkingUtils_SteamNetworkingIdentity_ParseString",
+          "params": [
+            { "paramname":"pIdentity", "paramtype":"SteamNetworkingIdentity *" },
+            { "paramname":"pszStr", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        }
+      ],
+      "version_string": "SteamNetworkingUtils003"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "gameserver",
+          "name": "SteamGameServer",
+          "name_flat": "SteamAPI_SteamGameServer_v013"
+        }
+      ],
+      "classname": "ISteamGameServer",
+      "fields": [],
+      "methods": [
+        {
+          "methodname": "SetProduct",
+          "methodname_flat": "SteamAPI_ISteamGameServer_SetProduct",
+          "params": [
+            { "paramname":"pszProduct", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetGameDescription",
+          "methodname_flat": "SteamAPI_ISteamGameServer_SetGameDescription",
+          "params": [
+            { "paramname":"pszGameDescription", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetModDir",
+          "methodname_flat": "SteamAPI_ISteamGameServer_SetModDir",
+          "params": [
+            { "paramname":"pszModDir", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetDedicatedServer",
+          "methodname_flat": "SteamAPI_ISteamGameServer_SetDedicatedServer",
+          "params": [
+            { "paramname":"bDedicated", "paramtype":"bool" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "LogOn",
+          "methodname_flat": "SteamAPI_ISteamGameServer_LogOn",
+          "params": [
+            { "paramname":"pszToken", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "LogOnAnonymous",
+          "methodname_flat": "SteamAPI_ISteamGameServer_LogOnAnonymous",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "LogOff",
+          "methodname_flat": "SteamAPI_ISteamGameServer_LogOff",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "BLoggedOn",
+          "methodname_flat": "SteamAPI_ISteamGameServer_BLoggedOn",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "BSecure",
+          "methodname_flat": "SteamAPI_ISteamGameServer_BSecure",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetSteamID",
+          "methodname_flat": "SteamAPI_ISteamGameServer_GetSteamID",
+          "params": [],
+          "returntype": "CSteamID",
+          "returntype_flat": "uint64_steamid"
+        },
+        {
+          "methodname": "WasRestartRequested",
+          "methodname_flat": "SteamAPI_ISteamGameServer_WasRestartRequested",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetMaxPlayerCount",
+          "methodname_flat": "SteamAPI_ISteamGameServer_SetMaxPlayerCount",
+          "params": [
+            { "paramname":"cPlayersMax", "paramtype":"int" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetBotPlayerCount",
+          "methodname_flat": "SteamAPI_ISteamGameServer_SetBotPlayerCount",
+          "params": [
+            { "paramname":"cBotplayers", "paramtype":"int" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetServerName",
+          "methodname_flat": "SteamAPI_ISteamGameServer_SetServerName",
+          "params": [
+            { "paramname":"pszServerName", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetMapName",
+          "methodname_flat": "SteamAPI_ISteamGameServer_SetMapName",
+          "params": [
+            { "paramname":"pszMapName", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetPasswordProtected",
+          "methodname_flat": "SteamAPI_ISteamGameServer_SetPasswordProtected",
+          "params": [
+            { "paramname":"bPasswordProtected", "paramtype":"bool" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetSpectatorPort",
+          "methodname_flat": "SteamAPI_ISteamGameServer_SetSpectatorPort",
+          "params": [
+            { "paramname":"unSpectatorPort", "paramtype":"uint16" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetSpectatorServerName",
+          "methodname_flat": "SteamAPI_ISteamGameServer_SetSpectatorServerName",
+          "params": [
+            { "paramname":"pszSpectatorServerName", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "ClearAllKeyValues",
+          "methodname_flat": "SteamAPI_ISteamGameServer_ClearAllKeyValues",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetKeyValue",
+          "methodname_flat": "SteamAPI_ISteamGameServer_SetKeyValue",
+          "params": [
+            { "paramname":"pKey", "paramtype":"const char *" },
+            { "paramname":"pValue", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetGameTags",
+          "methodname_flat": "SteamAPI_ISteamGameServer_SetGameTags",
+          "params": [
+            { "paramname":"pchGameTags", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetGameData",
+          "methodname_flat": "SteamAPI_ISteamGameServer_SetGameData",
+          "params": [
+            { "paramname":"pchGameData", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetRegion",
+          "methodname_flat": "SteamAPI_ISteamGameServer_SetRegion",
+          "params": [
+            { "paramname":"pszRegion", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SendUserConnectAndAuthenticate",
+          "methodname_flat": "SteamAPI_ISteamGameServer_SendUserConnectAndAuthenticate",
+          "params": [
+            { "paramname":"unIPClient", "paramtype":"uint32" },
+            { "paramname":"pvAuthBlob", "paramtype":"const void *" },
+            { "paramname":"cubAuthBlobSize", "paramtype":"uint32" },
+            { "paramname":"pSteamIDUser", "paramtype":"CSteamID *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "CreateUnauthenticatedUserConnection",
+          "methodname_flat": "SteamAPI_ISteamGameServer_CreateUnauthenticatedUserConnection",
+          "params": [],
+          "returntype": "CSteamID",
+          "returntype_flat": "uint64_steamid"
+        },
+        {
+          "methodname": "SendUserDisconnect",
+          "methodname_flat": "SteamAPI_ISteamGameServer_SendUserDisconnect",
+          "params": [
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "BUpdateUserData",
+          "methodname_flat": "SteamAPI_ISteamGameServer_BUpdateUserData",
+          "params": [
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchPlayerName", "paramtype":"const char *" },
+            { "paramname":"uScore", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetAuthSessionTicket",
+          "methodname_flat": "SteamAPI_ISteamGameServer_GetAuthSessionTicket",
+          "params": [
+            { "paramname":"pTicket", "paramtype":"void *" },
+            { "paramname":"cbMaxTicket", "paramtype":"int" },
+            { "paramname":"pcbTicket", "paramtype":"uint32 *" }
+          ],
+          "returntype": "HAuthTicket"
+        },
+        {
+          "methodname": "BeginAuthSession",
+          "methodname_flat": "SteamAPI_ISteamGameServer_BeginAuthSession",
+          "params": [
+            { "paramname":"pAuthTicket", "paramtype":"const void *" },
+            { "paramname":"cbAuthTicket", "paramtype":"int" },
+            { "paramname":"steamID", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "EBeginAuthSessionResult"
+        },
+        {
+          "methodname": "EndAuthSession",
+          "methodname_flat": "SteamAPI_ISteamGameServer_EndAuthSession",
+          "params": [
+            { "paramname":"steamID", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "CancelAuthTicket",
+          "methodname_flat": "SteamAPI_ISteamGameServer_CancelAuthTicket",
+          "params": [
+            { "paramname":"hAuthTicket", "paramtype":"HAuthTicket" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "UserHasLicenseForApp",
+          "methodname_flat": "SteamAPI_ISteamGameServer_UserHasLicenseForApp",
+          "params": [
+            { "paramname":"steamID", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"appID", "paramtype":"AppId_t" }
+          ],
+          "returntype": "EUserHasLicenseForAppResult"
+        },
+        {
+          "methodname": "RequestUserGroupStatus",
+          "methodname_flat": "SteamAPI_ISteamGameServer_RequestUserGroupStatus",
+          "params": [
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"steamIDGroup", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetGameplayStats",
+          "methodname_flat": "SteamAPI_ISteamGameServer_GetGameplayStats",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "callresult": "GSReputation_t",
+          "methodname": "GetServerReputation",
+          "methodname_flat": "SteamAPI_ISteamGameServer_GetServerReputation",
+          "params": [],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "GetPublicIP",
+          "methodname_flat": "SteamAPI_ISteamGameServer_GetPublicIP",
+          "params": [],
+          "returntype": "SteamIPAddress_t"
+        },
+        {
+          "methodname": "HandleIncomingPacket",
+          "methodname_flat": "SteamAPI_ISteamGameServer_HandleIncomingPacket",
+          "params": [
+            { "paramname":"pData", "paramtype":"const void *" },
+            { "paramname":"cbData", "paramtype":"int" },
+            { "paramname":"srcIP", "paramtype":"uint32" },
+            { "paramname":"srcPort", "paramtype":"uint16" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetNextOutgoingPacket",
+          "methodname_flat": "SteamAPI_ISteamGameServer_GetNextOutgoingPacket",
+          "params": [
+            { "paramname":"pOut", "paramtype":"void *" },
+            { "paramname":"cbMaxOut", "paramtype":"int" },
+            { "paramname":"pNetAdr", "paramtype":"uint32 *" },
+            { "paramname":"pPort", "paramtype":"uint16 *" }
+          ],
+          "returntype": "int"
+        },
+        {
+          "methodname": "EnableHeartbeats",
+          "methodname_flat": "SteamAPI_ISteamGameServer_EnableHeartbeats",
+          "params": [
+            { "paramname":"bActive", "paramtype":"bool" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetHeartbeatInterval",
+          "methodname_flat": "SteamAPI_ISteamGameServer_SetHeartbeatInterval",
+          "params": [
+            { "paramname":"iHeartbeatInterval", "paramtype":"int" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "ForceHeartbeat",
+          "methodname_flat": "SteamAPI_ISteamGameServer_ForceHeartbeat",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "callresult": "AssociateWithClanResult_t",
+          "methodname": "AssociateWithClan",
+          "methodname_flat": "SteamAPI_ISteamGameServer_AssociateWithClan",
+          "params": [
+            { "paramname":"steamIDClan", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "callresult": "ComputeNewPlayerCompatibilityResult_t",
+          "methodname": "ComputeNewPlayerCompatibility",
+          "methodname_flat": "SteamAPI_ISteamGameServer_ComputeNewPlayerCompatibility",
+          "params": [
+            { "paramname":"steamIDNewPlayer", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "SteamAPICall_t"
+        }
+      ],
+      "version_string": "SteamGameServer013"
+    },
+    {
+      "accessors": [
+        {
+          "kind": "gameserver",
+          "name": "SteamGameServerStats",
+          "name_flat": "SteamAPI_SteamGameServerStats_v001"
+        }
+      ],
+      "classname": "ISteamGameServerStats",
+      "fields": [],
+      "methods": [
+        {
+          "callresult": "GSStatsReceived_t",
+          "methodname": "RequestUserStats",
+          "methodname_flat": "SteamAPI_ISteamGameServerStats_RequestUserStats",
+          "params": [
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "SteamAPICall_t"
+        },
+        {
+          "methodname": "GetUserStat",
+          "methodname_flat": "SteamAPI_ISteamGameServerStats_GetUserStatInt32",
+          "params": [
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchName", "paramtype":"const char *" },
+            { "paramname":"pData", "paramtype":"int32 *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetUserStat",
+          "methodname_flat": "SteamAPI_ISteamGameServerStats_GetUserStatFloat",
+          "params": [
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchName", "paramtype":"const char *" },
+            { "paramname":"pData", "paramtype":"float *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetUserAchievement",
+          "methodname_flat": "SteamAPI_ISteamGameServerStats_GetUserAchievement",
+          "params": [
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchName", "paramtype":"const char *" },
+            { "paramname":"pbAchieved", "paramtype":"bool *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetUserStat",
+          "methodname_flat": "SteamAPI_ISteamGameServerStats_SetUserStatInt32",
+          "params": [
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchName", "paramtype":"const char *" },
+            { "paramname":"nData", "paramtype":"int32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetUserStat",
+          "methodname_flat": "SteamAPI_ISteamGameServerStats_SetUserStatFloat",
+          "params": [
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchName", "paramtype":"const char *" },
+            { "paramname":"fData", "paramtype":"float" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "UpdateUserAvgRateStat",
+          "methodname_flat": "SteamAPI_ISteamGameServerStats_UpdateUserAvgRateStat",
+          "params": [
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchName", "paramtype":"const char *" },
+            { "paramname":"flCountThisSession", "paramtype":"float" },
+            { "paramname":"dSessionLength", "paramtype":"double" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetUserAchievement",
+          "methodname_flat": "SteamAPI_ISteamGameServerStats_SetUserAchievement",
+          "params": [
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchName", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "ClearUserAchievement",
+          "methodname_flat": "SteamAPI_ISteamGameServerStats_ClearUserAchievement",
+          "params": [
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" },
+            { "paramname":"pchName", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "callresult": "GSStatsStored_t",
+          "methodname": "StoreUserStats",
+          "methodname_flat": "SteamAPI_ISteamGameServerStats_StoreUserStats",
+          "params": [
+            { "paramname":"steamIDUser", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "SteamAPICall_t"
+        }
+      ],
+      "version_string": "SteamGameServerStats001"
+    }
+  ],
+  "structs": [
+    {
+      "fields": [
+        { "fieldname":"m_rgubIPv6", "fieldtype":"uint8 [16]" },
+        { "fieldname":"m_eType", "fieldtype":"ESteamIPType" }
+      ],
+      "methods": [
+        {
+          "methodname": "IsSet",
+          "methodname_flat": "SteamAPI_SteamIPAddress_t_IsSet",
+          "params": [],
+          "returntype": "bool"
+        }
+      ],
+      "struct": "SteamIPAddress_t"
+    },
+    {
+      "fields": [
+        { "fieldname":"m_gameID", "fieldtype":"CGameID" },
+        { "fieldname":"m_unGameIP", "fieldtype":"uint32" },
+        { "fieldname":"m_usGamePort", "fieldtype":"uint16" },
+        { "fieldname":"m_usQueryPort", "fieldtype":"uint16" },
+        { "fieldname":"m_steamIDLobby", "fieldtype":"CSteamID" }
+      ],
+      "struct": "FriendGameInfo_t"
+    },
+    {
+      "fields": [
+        { "fieldname":"m_uiOnlineSessionInstances", "fieldtype":"uint32" },
+        { "fieldname":"m_uiPublishedToFriendsSessionInstance", "fieldtype":"uint8" }
+      ],
+      "struct": "FriendSessionStateInfo_t"
+    },
+    {
+      "fields": [
+        { "fieldname":"m_szKey", "fieldtype":"char [256]" },
+        { "fieldname":"m_szValue", "fieldtype":"char [256]" }
+      ],
+      "methods": [
+        {
+          "methodname": "Construct",
+          "methodname_flat": "SteamAPI_MatchMakingKeyValuePair_t_Construct",
+          "params": [],
+          "returntype": "void"
+        }
+      ],
+      "struct": "MatchMakingKeyValuePair_t"
+    },
+    {
+      "fields": [
+        {
+          "fieldname": "m_usConnectionPort",
+          "fieldtype": "uint16",
+          "private": true
+        },
+        {
+          "fieldname": "m_usQueryPort",
+          "fieldtype": "uint16",
+          "private": true
+        },
+        {
+          "fieldname": "m_unIP",
+          "fieldtype": "uint32",
+          "private": true
+        }
+      ],
+      "methods": [
+        {
+          "methodname": "Construct",
+          "methodname_flat": "SteamAPI_servernetadr_t_Construct",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "Init",
+          "methodname_flat": "SteamAPI_servernetadr_t_Init",
+          "params": [
+            { "paramname":"ip", "paramtype":"unsigned int" },
+            { "paramname":"usQueryPort", "paramtype":"uint16" },
+            { "paramname":"usConnectionPort", "paramtype":"uint16" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetQueryPort",
+          "methodname_flat": "SteamAPI_servernetadr_t_GetQueryPort",
+          "params": [],
+          "returntype": "uint16"
+        },
+        {
+          "methodname": "SetQueryPort",
+          "methodname_flat": "SteamAPI_servernetadr_t_SetQueryPort",
+          "params": [
+            { "paramname":"usPort", "paramtype":"uint16" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetConnectionPort",
+          "methodname_flat": "SteamAPI_servernetadr_t_GetConnectionPort",
+          "params": [],
+          "returntype": "uint16"
+        },
+        {
+          "methodname": "SetConnectionPort",
+          "methodname_flat": "SteamAPI_servernetadr_t_SetConnectionPort",
+          "params": [
+            { "paramname":"usPort", "paramtype":"uint16" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetIP",
+          "methodname_flat": "SteamAPI_servernetadr_t_GetIP",
+          "params": [],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "SetIP",
+          "methodname_flat": "SteamAPI_servernetadr_t_SetIP",
+          "params": [
+            { "paramname":"unIP", "paramtype":"uint32" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetConnectionAddressString",
+          "methodname_flat": "SteamAPI_servernetadr_t_GetConnectionAddressString",
+          "params": [],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "GetQueryAddressString",
+          "methodname_flat": "SteamAPI_servernetadr_t_GetQueryAddressString",
+          "params": [],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "operator<",
+          "methodname_flat": "SteamAPI_servernetadr_t_IsLessThan",
+          "params": [
+            { "paramname":"netadr", "paramtype":"const servernetadr_t &" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "operator=",
+          "methodname_flat": "SteamAPI_servernetadr_t_Assign",
+          "params": [
+            { "paramname":"that", "paramtype":"const servernetadr_t &" }
+          ],
+          "returntype": "void"
+        }
+      ],
+      "struct": "servernetadr_t"
+    },
+    {
+      "fields": [
+        { "fieldname":"m_NetAdr", "fieldtype":"servernetadr_t" },
+        { "fieldname":"m_nPing", "fieldtype":"int" },
+        { "fieldname":"m_bHadSuccessfulResponse", "fieldtype":"bool" },
+        { "fieldname":"m_bDoNotRefresh", "fieldtype":"bool" },
+        { "fieldname":"m_szGameDir", "fieldtype":"char [32]" },
+        { "fieldname":"m_szMap", "fieldtype":"char [32]" },
+        { "fieldname":"m_szGameDescription", "fieldtype":"char [64]" },
+        { "fieldname":"m_nAppID", "fieldtype":"uint32" },
+        { "fieldname":"m_nPlayers", "fieldtype":"int" },
+        { "fieldname":"m_nMaxPlayers", "fieldtype":"int" },
+        { "fieldname":"m_nBotPlayers", "fieldtype":"int" },
+        { "fieldname":"m_bPassword", "fieldtype":"bool" },
+        { "fieldname":"m_bSecure", "fieldtype":"bool" },
+        { "fieldname":"m_ulTimeLastPlayed", "fieldtype":"uint32" },
+        { "fieldname":"m_nServerVersion", "fieldtype":"int" },
+        {
+          "fieldname": "m_szServerName",
+          "fieldtype": "char [64]",
+          "private": true
+        },
+        { "fieldname":"m_szGameTags", "fieldtype":"char [128]" },
+        { "fieldname":"m_steamID", "fieldtype":"CSteamID" }
+      ],
+      "methods": [
+        {
+          "methodname": "Construct",
+          "methodname_flat": "SteamAPI_gameserveritem_t_Construct",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetName",
+          "methodname_flat": "SteamAPI_gameserveritem_t_GetName",
+          "params": [],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "SetName",
+          "methodname_flat": "SteamAPI_gameserveritem_t_SetName",
+          "params": [
+            { "paramname":"pName", "paramtype":"const char *" }
+          ],
+          "returntype": "void"
+        }
+      ],
+      "struct": "gameserveritem_t"
+    },
+    {
+      "fields": [
+        { "fieldname":"m_eType", "fieldtype":"ESteamPartyBeaconLocationType" },
+        { "fieldname":"m_ulLocationID", "fieldtype":"uint64" }
+      ],
+      "struct": "SteamPartyBeaconLocation_t"
+    },
+    {
+      "fields": [
+        { "fieldname":"m_ppStrings", "fieldtype":"const char **" },
+        { "fieldname":"m_nNumStrings", "fieldtype":"int32" }
+      ],
+      "struct": "SteamParamStringArray_t"
+    },
+    {
+      "fields": [
+        { "fieldname":"m_steamIDUser", "fieldtype":"CSteamID" },
+        { "fieldname":"m_nGlobalRank", "fieldtype":"int32" },
+        { "fieldname":"m_nScore", "fieldtype":"int32" },
+        { "fieldname":"m_cDetails", "fieldtype":"int32" },
+        { "fieldname":"m_hUGC", "fieldtype":"UGCHandle_t" }
+      ],
+      "struct": "LeaderboardEntry_t"
+    },
+    {
+      "fields": [
+        { "fieldname":"m_bConnectionActive", "fieldtype":"uint8" },
+        { "fieldname":"m_bConnecting", "fieldtype":"uint8" },
+        { "fieldname":"m_eP2PSessionError", "fieldtype":"uint8" },
+        { "fieldname":"m_bUsingRelay", "fieldtype":"uint8" },
+        { "fieldname":"m_nBytesQueuedForSend", "fieldtype":"int32" },
+        { "fieldname":"m_nPacketsQueuedForSend", "fieldtype":"int32" },
+        { "fieldname":"m_nRemoteIP", "fieldtype":"uint32" },
+        { "fieldname":"m_nRemotePort", "fieldtype":"uint16" }
+      ],
+      "struct": "P2PSessionState_t"
+    },
+    {
+      "fields": [
+        { "fieldname":"eMode", "fieldtype":"EInputSourceMode" },
+        { "fieldname":"x", "fieldtype":"float" },
+        { "fieldname":"y", "fieldtype":"float" },
+        { "fieldname":"bActive", "fieldtype":"bool" }
+      ],
+      "struct": "InputAnalogActionData_t"
+    },
+    {
+      "fields": [
+        { "fieldname":"bState", "fieldtype":"bool" },
+        { "fieldname":"bActive", "fieldtype":"bool" }
+      ],
+      "struct": "InputDigitalActionData_t"
+    },
+    {
+      "fields": [
+        { "fieldname":"rotQuatX", "fieldtype":"float" },
+        { "fieldname":"rotQuatY", "fieldtype":"float" },
+        { "fieldname":"rotQuatZ", "fieldtype":"float" },
+        { "fieldname":"rotQuatW", "fieldtype":"float" },
+        { "fieldname":"posAccelX", "fieldtype":"float" },
+        { "fieldname":"posAccelY", "fieldtype":"float" },
+        { "fieldname":"posAccelZ", "fieldtype":"float" },
+        { "fieldname":"rotVelX", "fieldtype":"float" },
+        { "fieldname":"rotVelY", "fieldtype":"float" },
+        { "fieldname":"rotVelZ", "fieldtype":"float" }
+      ],
+      "struct": "InputMotionData_t"
+    },
+    {
+      "fields": [
+        { "fieldname":"m_nPublishedFileId", "fieldtype":"PublishedFileId_t" },
+        { "fieldname":"m_eResult", "fieldtype":"EResult" },
+        { "fieldname":"m_eFileType", "fieldtype":"EWorkshopFileType" },
+        { "fieldname":"m_nCreatorAppID", "fieldtype":"AppId_t" },
+        { "fieldname":"m_nConsumerAppID", "fieldtype":"AppId_t" },
+        { "fieldname":"m_rgchTitle", "fieldtype":"char [129]" },
+        { "fieldname":"m_rgchDescription", "fieldtype":"char [8000]" },
+        { "fieldname":"m_ulSteamIDOwner", "fieldtype":"uint64" },
+        { "fieldname":"m_rtimeCreated", "fieldtype":"uint32" },
+        { "fieldname":"m_rtimeUpdated", "fieldtype":"uint32" },
+        { "fieldname":"m_rtimeAddedToUserList", "fieldtype":"uint32" },
+        { "fieldname":"m_eVisibility", "fieldtype":"ERemoteStoragePublishedFileVisibility" },
+        { "fieldname":"m_bBanned", "fieldtype":"bool" },
+        { "fieldname":"m_bAcceptedForUse", "fieldtype":"bool" },
+        { "fieldname":"m_bTagsTruncated", "fieldtype":"bool" },
+        { "fieldname":"m_rgchTags", "fieldtype":"char [1025]" },
+        { "fieldname":"m_hFile", "fieldtype":"UGCHandle_t" },
+        { "fieldname":"m_hPreviewFile", "fieldtype":"UGCHandle_t" },
+        { "fieldname":"m_pchFileName", "fieldtype":"char [260]" },
+        { "fieldname":"m_nFileSize", "fieldtype":"int32" },
+        { "fieldname":"m_nPreviewFileSize", "fieldtype":"int32" },
+        { "fieldname":"m_rgchURL", "fieldtype":"char [256]" },
+        { "fieldname":"m_unVotesUp", "fieldtype":"uint32" },
+        { "fieldname":"m_unVotesDown", "fieldtype":"uint32" },
+        { "fieldname":"m_flScore", "fieldtype":"float" },
+        { "fieldname":"m_unNumChildren", "fieldtype":"uint32" }
+      ],
+      "struct": "SteamUGCDetails_t"
+    },
+    {
+      "fields": [
+        { "fieldname":"m_itemId", "fieldtype":"SteamItemInstanceID_t" },
+        { "fieldname":"m_iDefinition", "fieldtype":"SteamItemDef_t" },
+        { "fieldname":"m_unQuantity", "fieldtype":"uint16" },
+        { "fieldname":"m_unFlags", "fieldtype":"uint16" }
+      ],
+      "struct": "SteamItemDetails_t"
+    },
+    {
+      "fields": [
+        { "fieldname":"unMinX", "fieldtype":"uint32" },
+        { "fieldname":"unMinY", "fieldtype":"uint32" },
+        { "fieldname":"unMaxX", "fieldtype":"uint32" },
+        { "fieldname":"unMaxY", "fieldtype":"uint32" }
+      ],
+      "struct": "SteamTVRegion_t"
+    },
+    {
+      "consts": [
+        { "constname":"k_cchMaxString", "consttype":"int", "constval":"48" }
+      ],
+      "fields": [
+        { "fieldname":"m_ipv6", "fieldtype":"uint8 [16]" },
+        { "fieldname":"m_port", "fieldtype":"uint16" }
+      ],
+      "methods": [
+        {
+          "methodname": "Clear",
+          "methodname_flat": "SteamAPI_SteamNetworkingIPAddr_Clear",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "IsIPv6AllZeros",
+          "methodname_flat": "SteamAPI_SteamNetworkingIPAddr_IsIPv6AllZeros",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetIPv6",
+          "methodname_flat": "SteamAPI_SteamNetworkingIPAddr_SetIPv6",
+          "params": [
+            { "paramname":"ipv6", "paramtype":"const uint8 *" },
+            { "paramname":"nPort", "paramtype":"uint16" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "SetIPv4",
+          "methodname_flat": "SteamAPI_SteamNetworkingIPAddr_SetIPv4",
+          "params": [
+            { "paramname":"nIP", "paramtype":"uint32" },
+            { "paramname":"nPort", "paramtype":"uint16" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "IsIPv4",
+          "methodname_flat": "SteamAPI_SteamNetworkingIPAddr_IsIPv4",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetIPv4",
+          "methodname_flat": "SteamAPI_SteamNetworkingIPAddr_GetIPv4",
+          "params": [],
+          "returntype": "uint32"
+        },
+        {
+          "methodname": "SetIPv6LocalHost",
+          "methodname_flat": "SteamAPI_SteamNetworkingIPAddr_SetIPv6LocalHost",
+          "params": [
+            { "paramname":"nPort", "paramtype":"uint16" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "IsLocalHost",
+          "methodname_flat": "SteamAPI_SteamNetworkingIPAddr_IsLocalHost",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "ToString",
+          "methodname_flat": "SteamAPI_SteamNetworkingIPAddr_ToString",
+          "params": [
+            { "paramname":"buf", "paramtype":"char *" },
+            { "paramname":"cbBuf", "paramtype":"uint32" },
+            { "paramname":"bWithPort", "paramtype":"bool" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "ParseString",
+          "methodname_flat": "SteamAPI_SteamNetworkingIPAddr_ParseString",
+          "params": [
+            { "paramname":"pszStr", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "operator==",
+          "methodname_flat": "SteamAPI_SteamNetworkingIPAddr_IsEqualTo",
+          "params": [
+            { "paramname":"x", "paramtype":"const SteamNetworkingIPAddr &" }
+          ],
+          "returntype": "bool"
+        }
+      ],
+      "struct": "SteamNetworkingIPAddr"
+    },
+    {
+      "consts": [
+        { "constname":"k_cchMaxString", "consttype":"int", "constval":"128" },
+        { "constname":"k_cchMaxGenericString", "consttype":"int", "constval":"32" },
+        { "constname":"k_cchMaxXboxPairwiseID", "consttype":"int", "constval":"32" },
+        { "constname":"k_cbMaxGenericBytes", "consttype":"int", "constval":"32" }
+      ],
+      "fields": [
+        { "fieldname":"m_eType", "fieldtype":"ESteamNetworkingIdentityType" },
+        { "fieldname":"m_cbSize", "fieldtype":"int" },
+        { "fieldname":"m_szUnknownRawString", "fieldtype":"char [128]" }
+      ],
+      "methods": [
+        {
+          "methodname": "Clear",
+          "methodname_flat": "SteamAPI_SteamNetworkingIdentity_Clear",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "IsInvalid",
+          "methodname_flat": "SteamAPI_SteamNetworkingIdentity_IsInvalid",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetSteamID",
+          "methodname_flat": "SteamAPI_SteamNetworkingIdentity_SetSteamID",
+          "params": [
+            { "paramname":"steamID", "paramtype":"CSteamID", "paramtype_flat":"uint64_steamid" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetSteamID",
+          "methodname_flat": "SteamAPI_SteamNetworkingIdentity_GetSteamID",
+          "params": [],
+          "returntype": "CSteamID",
+          "returntype_flat": "uint64_steamid"
+        },
+        {
+          "methodname": "SetSteamID64",
+          "methodname_flat": "SteamAPI_SteamNetworkingIdentity_SetSteamID64",
+          "params": [
+            { "paramname":"steamID", "paramtype":"uint64" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetSteamID64",
+          "methodname_flat": "SteamAPI_SteamNetworkingIdentity_GetSteamID64",
+          "params": [],
+          "returntype": "uint64"
+        },
+        {
+          "methodname": "SetXboxPairwiseID",
+          "methodname_flat": "SteamAPI_SteamNetworkingIdentity_SetXboxPairwiseID",
+          "params": [
+            { "paramname":"pszString", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetXboxPairwiseID",
+          "methodname_flat": "SteamAPI_SteamNetworkingIdentity_GetXboxPairwiseID",
+          "params": [],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "SetIPAddr",
+          "methodname_flat": "SteamAPI_SteamNetworkingIdentity_SetIPAddr",
+          "params": [
+            { "paramname":"addr", "paramtype":"const SteamNetworkingIPAddr &" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetIPAddr",
+          "methodname_flat": "SteamAPI_SteamNetworkingIdentity_GetIPAddr",
+          "params": [],
+          "returntype": "const SteamNetworkingIPAddr *"
+        },
+        {
+          "methodname": "SetLocalHost",
+          "methodname_flat": "SteamAPI_SteamNetworkingIdentity_SetLocalHost",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "IsLocalHost",
+          "methodname_flat": "SteamAPI_SteamNetworkingIdentity_IsLocalHost",
+          "params": [],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "SetGenericString",
+          "methodname_flat": "SteamAPI_SteamNetworkingIdentity_SetGenericString",
+          "params": [
+            { "paramname":"pszString", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetGenericString",
+          "methodname_flat": "SteamAPI_SteamNetworkingIdentity_GetGenericString",
+          "params": [],
+          "returntype": "const char *"
+        },
+        {
+          "methodname": "SetGenericBytes",
+          "methodname_flat": "SteamAPI_SteamNetworkingIdentity_SetGenericBytes",
+          "params": [
+            { "paramname":"data", "paramtype":"const void *" },
+            { "paramname":"cbLen", "paramtype":"uint32" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "GetGenericBytes",
+          "methodname_flat": "SteamAPI_SteamNetworkingIdentity_GetGenericBytes",
+          "params": [
+            { "paramname":"cbLen", "paramtype":"int &" }
+          ],
+          "returntype": "const uint8 *"
+        },
+        {
+          "methodname": "operator==",
+          "methodname_flat": "SteamAPI_SteamNetworkingIdentity_IsEqualTo",
+          "params": [
+            { "paramname":"x", "paramtype":"const SteamNetworkingIdentity &" }
+          ],
+          "returntype": "bool"
+        },
+        {
+          "methodname": "ToString",
+          "methodname_flat": "SteamAPI_SteamNetworkingIdentity_ToString",
+          "params": [
+            { "paramname":"buf", "paramtype":"char *" },
+            { "paramname":"cbBuf", "paramtype":"uint32" }
+          ],
+          "returntype": "void"
+        },
+        {
+          "methodname": "ParseString",
+          "methodname_flat": "SteamAPI_SteamNetworkingIdentity_ParseString",
+          "params": [
+            { "paramname":"pszStr", "paramtype":"const char *" }
+          ],
+          "returntype": "bool"
+        }
+      ],
+      "struct": "SteamNetworkingIdentity"
+    },
+    {
+      "fields": [
+        { "fieldname":"m_identityRemote", "fieldtype":"SteamNetworkingIdentity" },
+        { "fieldname":"m_nUserData", "fieldtype":"int64" },
+        { "fieldname":"m_hListenSocket", "fieldtype":"HSteamListenSocket" },
+        { "fieldname":"m_addrRemote", "fieldtype":"SteamNetworkingIPAddr" },
+        { "fieldname":"m__pad1", "fieldtype":"uint16" },
+        { "fieldname":"m_idPOPRemote", "fieldtype":"SteamNetworkingPOPID" },
+        { "fieldname":"m_idPOPRelay", "fieldtype":"SteamNetworkingPOPID" },
+        { "fieldname":"m_eState", "fieldtype":"ESteamNetworkingConnectionState" },
+        { "fieldname":"m_eEndReason", "fieldtype":"int" },
+        { "fieldname":"m_szEndDebug", "fieldtype":"char [128]" },
+        { "fieldname":"m_szConnectionDescription", "fieldtype":"char [128]" },
+        { "fieldname":"reserved", "fieldtype":"uint32 [64]" }
+      ],
+      "struct": "SteamNetConnectionInfo_t"
+    },
+    {
+      "fields": [
+        { "fieldname":"m_eState", "fieldtype":"ESteamNetworkingConnectionState" },
+        { "fieldname":"m_nPing", "fieldtype":"int" },
+        { "fieldname":"m_flConnectionQualityLocal", "fieldtype":"float" },
+        { "fieldname":"m_flConnectionQualityRemote", "fieldtype":"float" },
+        { "fieldname":"m_flOutPacketsPerSec", "fieldtype":"float" },
+        { "fieldname":"m_flOutBytesPerSec", "fieldtype":"float" },
+        { "fieldname":"m_flInPacketsPerSec", "fieldtype":"float" },
+        { "fieldname":"m_flInBytesPerSec", "fieldtype":"float" },
+        { "fieldname":"m_nSendRateBytesPerSecond", "fieldtype":"int" },
+        { "fieldname":"m_cbPendingUnreliable", "fieldtype":"int" },
+        { "fieldname":"m_cbPendingReliable", "fieldtype":"int" },
+        { "fieldname":"m_cbSentUnackedReliable", "fieldtype":"int" },
+        { "fieldname":"m_usecQueueTime", "fieldtype":"SteamNetworkingMicroseconds" },
+        { "fieldname":"reserved", "fieldtype":"uint32 [16]" }
+      ],
+      "struct": "SteamNetworkingQuickConnectionStatus"
+    },
+    {
+      "fields": [
+        { "fieldname":"m_pData", "fieldtype":"void *" },
+        { "fieldname":"m_cbSize", "fieldtype":"int" },
+        { "fieldname":"m_conn", "fieldtype":"HSteamNetConnection" },
+        { "fieldname":"m_identityPeer", "fieldtype":"SteamNetworkingIdentity" },
+        { "fieldname":"m_nConnUserData", "fieldtype":"int64" },
+        { "fieldname":"m_usecTimeReceived", "fieldtype":"SteamNetworkingMicroseconds" },
+        { "fieldname":"m_nMessageNumber", "fieldtype":"int64" },
+        { "fieldname":"m_pfnFreeData", "fieldtype":"void (*)(SteamNetworkingMessage_t *)" },
+        { "fieldname":"m_pfnRelease", "fieldtype":"void (*)(SteamNetworkingMessage_t *)" },
+        { "fieldname":"m_nChannel", "fieldtype":"int" },
+        { "fieldname":"m_nFlags", "fieldtype":"int" },
+        { "fieldname":"m_nUserData", "fieldtype":"int64" }
+      ],
+      "methods": [
+        {
+          "methodname": "Release",
+          "methodname_flat": "SteamAPI_SteamNetworkingMessage_t_Release",
+          "params": [],
+          "returntype": "void"
+        }
+      ],
+      "struct": "SteamNetworkingMessage_t"
+    },
+    {
+      "fields": [
+        { "fieldname":"m_data", "fieldtype":"uint8 [512]" }
+      ],
+      "struct": "SteamNetworkPingLocation_t"
+    },
+    {
+      "fields": [
+        { "fieldname":"m_eValue", "fieldtype":"ESteamNetworkingConfigValue" },
+        { "fieldname":"m_eDataType", "fieldtype":"ESteamNetworkingConfigDataType" },
+        { "fieldname":"m_int64", "fieldtype":"int64_t" }
+      ],
+      "struct": "SteamNetworkingConfigValue_t"
+    },
+    {
+      "fields": [
+        { "fieldname":"m_cbSize", "fieldtype":"int" },
+        { "fieldname":"m_data", "fieldtype":"char [128]" }
+      ],
+      "methods": [
+        {
+          "methodname": "Clear",
+          "methodname_flat": "SteamAPI_SteamDatagramHostedAddress_Clear",
+          "params": [],
+          "returntype": "void"
+        },
+        {
+          "methodname": "GetPopID",
+          "methodname_flat": "SteamAPI_SteamDatagramHostedAddress_GetPopID",
+          "params": [],
+          "returntype": "SteamNetworkingPOPID"
+        },
+        {
+          "methodname": "SetDevAddress",
+          "methodname_flat": "SteamAPI_SteamDatagramHostedAddress_SetDevAddress",
+          "params": [
+            { "paramname":"nIP", "paramtype":"uint32" },
+            { "paramname":"nPort", "paramtype":"uint16" },
+            { "paramname":"popid", "paramtype":"SteamNetworkingPOPID" }
+          ],
+          "returntype": "void"
+        }
+      ],
+      "struct": "SteamDatagramHostedAddress"
+    },
+    {
+      "fields": [
+        { "fieldname":"m_identity", "fieldtype":"SteamNetworkingIdentity" },
+        { "fieldname":"m_routing", "fieldtype":"SteamDatagramHostedAddress" },
+        { "fieldname":"m_nAppID", "fieldtype":"AppId_t" },
+        { "fieldname":"m_rtime", "fieldtype":"RTime32" },
+        { "fieldname":"m_cbAppData", "fieldtype":"int" },
+        { "fieldname":"m_appData", "fieldtype":"char [2048]" }
+      ],
+      "struct": "SteamDatagramGameCoordinatorServerLogin"
+    }
+  ],
+  "typedefs": [
+    { "typedef":"uint8", "type":"unsigned char" },
+    { "typedef":"int8", "type":"signed char" },
+    { "typedef":"int16", "type":"short" },
+    { "typedef":"uint16", "type":"unsigned short" },
+    { "typedef":"int32", "type":"int" },
+    { "typedef":"uint32", "type":"unsigned int" },
+    { "typedef":"int64", "type":"long long" },
+    { "typedef":"uint64", "type":"unsigned long long" },
+    { "typedef":"lint64", "type":"long long" },
+    { "typedef":"ulint64", "type":"unsigned long long" },
+    { "typedef":"intp", "type":"long long" },
+    { "typedef":"uintp", "type":"unsigned long long" },
+    { "typedef":"Salt_t", "type":"unsigned char [8]" },
+    { "typedef":"GID_t", "type":"unsigned long long" },
+    { "typedef":"JobID_t", "type":"unsigned long long" },
+    { "typedef":"TxnID_t", "type":"unsigned long long" },
+    { "typedef":"PackageId_t", "type":"unsigned int" },
+    { "typedef":"BundleId_t", "type":"unsigned int" },
+    { "typedef":"AppId_t", "type":"unsigned int" },
+    { "typedef":"AssetClassId_t", "type":"unsigned long long" },
+    { "typedef":"PhysicalItemId_t", "type":"unsigned int" },
+    { "typedef":"DepotId_t", "type":"unsigned int" },
+    { "typedef":"RTime32", "type":"unsigned int" },
+    { "typedef":"CellID_t", "type":"unsigned int" },
+    { "typedef":"SteamAPICall_t", "type":"unsigned long long" },
+    { "typedef":"AccountID_t", "type":"unsigned int" },
+    { "typedef":"PartnerId_t", "type":"unsigned int" },
+    { "typedef":"ManifestId_t", "type":"unsigned long long" },
+    { "typedef":"SiteId_t", "type":"unsigned long long" },
+    { "typedef":"PartyBeaconID_t", "type":"unsigned long long" },
+    { "typedef":"HAuthTicket", "type":"unsigned int" },
+    { "typedef":"PFNLegacyKeyRegistration", "type":"void (*)(const char *, const char *)" },
+    { "typedef":"PFNLegacyKeyInstalled", "type":"bool (*)()" },
+    { "typedef":"PFNPreMinidumpCallback", "type":"void (*)(void *)" },
+    { "typedef":"BREAKPAD_HANDLE", "type":"void *" },
+    { "typedef":"HSteamPipe", "type":"int" },
+    { "typedef":"HSteamUser", "type":"int" },
+    { "typedef":"FriendsGroupID_t", "type":"short" },
+    { "typedef":"HServerListRequest", "type":"void *" },
+    { "typedef":"HServerQuery", "type":"int" },
+    { "typedef":"UGCHandle_t", "type":"unsigned long long" },
+    { "typedef":"PublishedFileUpdateHandle_t", "type":"unsigned long long" },
+    { "typedef":"PublishedFileId_t", "type":"unsigned long long" },
+    { "typedef":"UGCFileWriteStreamHandle_t", "type":"unsigned long long" },
+    { "typedef":"SteamLeaderboard_t", "type":"unsigned long long" },
+    { "typedef":"SteamLeaderboardEntries_t", "type":"unsigned long long" },
+    { "typedef":"SNetSocket_t", "type":"unsigned int" },
+    { "typedef":"SNetListenSocket_t", "type":"unsigned int" },
+    { "typedef":"ScreenshotHandle", "type":"unsigned int" },
+    { "typedef":"HTTPRequestHandle", "type":"unsigned int" },
+    { "typedef":"HTTPCookieContainerHandle", "type":"unsigned int" },
+    { "typedef":"InputHandle_t", "type":"unsigned long long" },
+    { "typedef":"InputActionSetHandle_t", "type":"unsigned long long" },
+    { "typedef":"InputDigitalActionHandle_t", "type":"unsigned long long" },
+    { "typedef":"InputAnalogActionHandle_t", "type":"unsigned long long" },
+    { "typedef":"ControllerHandle_t", "type":"unsigned long long" },
+    { "typedef":"ControllerActionSetHandle_t", "type":"unsigned long long" },
+    { "typedef":"ControllerDigitalActionHandle_t", "type":"unsigned long long" },
+    { "typedef":"ControllerAnalogActionHandle_t", "type":"unsigned long long" },
+    { "typedef":"UGCQueryHandle_t", "type":"unsigned long long" },
+    { "typedef":"UGCUpdateHandle_t", "type":"unsigned long long" },
+    { "typedef":"HHTMLBrowser", "type":"unsigned int" },
+    { "typedef":"SteamItemInstanceID_t", "type":"unsigned long long" },
+    { "typedef":"SteamItemDef_t", "type":"int" },
+    { "typedef":"SteamInventoryResult_t", "type":"int" },
+    { "typedef":"SteamInventoryUpdateHandle_t", "type":"unsigned long long" },
+    { "typedef":"RemotePlaySessionID_t", "type":"unsigned int" },
+    { "typedef":"HSteamNetConnection", "type":"unsigned int" },
+    { "typedef":"HSteamListenSocket", "type":"unsigned int" },
+    { "typedef":"HSteamNetPollGroup", "type":"unsigned int" },
+    { "typedef":"SteamNetworkingErrMsg", "type":"char [1024]" },
+    { "typedef":"SteamNetworkingPOPID", "type":"unsigned int" },
+    { "typedef":"SteamNetworkingMicroseconds", "type":"long long" },
+    { "typedef":"FSteamNetworkingSocketsDebugOutput", "type":"void (*)(ESteamNetworkingSocketsDebugOutputType, const char *)" }
+  ]
+}

--- a/lsteamclient/steamworks_sdk_148a/steam_api_common.h
+++ b/lsteamclient/steamworks_sdk_148a/steam_api_common.h
@@ -1,0 +1,235 @@
+//====== Copyright Valve Corporation, All rights reserved. ====================
+//
+// Steamworks SDK minimal include
+//
+// Defines the minimal set of things we need to use any single interface
+// or register for any callback.
+//
+//=============================================================================
+
+#ifndef STEAM_API_COMMON_H
+#define STEAM_API_COMMON_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steamtypes.h"
+#include "steamclientpublic.h"
+
+// S_API defines the linkage and calling conventions for steam_api.dll exports
+#if defined( _WIN32 ) && !defined( _X360 )
+	#if defined( STEAM_API_EXPORTS )
+	#define S_API extern "C" __declspec( dllexport ) 
+	#elif defined( STEAM_API_NODLL )
+	#define S_API extern "C"
+	#else
+	#define S_API extern "C" __declspec( dllimport ) 
+	#endif // STEAM_API_EXPORTS
+#elif defined( GNUC )
+	#if defined( STEAM_API_EXPORTS )
+	#define S_API extern "C" __attribute__ ((visibility("default"))) 
+	#else
+	#define S_API extern "C" 
+	#endif // STEAM_API_EXPORTS
+#else // !WIN32
+	#if defined( STEAM_API_EXPORTS )
+	#define S_API extern "C"  
+	#else
+	#define S_API extern "C" 
+	#endif // STEAM_API_EXPORTS
+#endif
+
+#if ( defined(STEAM_API_EXPORTS) || defined(STEAM_API_NODLL) ) && !defined(API_GEN)
+#define STEAM_PRIVATE_API( ... ) __VA_ARGS__
+#elif defined(STEAM_API_EXPORTS) && defined(API_GEN)
+#define STEAM_PRIVATE_API( ... )
+#else
+#define STEAM_PRIVATE_API( ... ) protected: __VA_ARGS__ public:
+#endif
+
+// handle to a communication pipe to the Steam client
+typedef int32 HSteamPipe;
+// handle to single instance of a steam user
+typedef int32 HSteamUser;
+// function prototype
+#if defined( POSIX )
+#define __cdecl
+#endif
+extern "C" typedef void (__cdecl *SteamAPIWarningMessageHook_t)(int, const char *);
+extern "C" typedef uint32 ( *SteamAPI_CheckCallbackRegistered_t )( int iCallbackNum );
+#if defined( __SNC__ )
+	#pragma diag_suppress=1700	   // warning 1700: class "%s" has virtual functions but non-virtual destructor
+#endif
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+//	steam callback and call-result helpers
+//
+//	The following macros and classes are used to register your application for
+//	callbacks and call-results, which are delivered in a predictable manner.
+//
+//	STEAM_CALLBACK macros are meant for use inside of a C++ class definition.
+//	They map a Steam notification callback directly to a class member function
+//	which is automatically prototyped as "void func( callback_type *pParam )".
+//
+//	CCallResult is used with specific Steam APIs that return "result handles".
+//	The handle can be passed to a CCallResult object's Set function, along with
+//	an object pointer and member-function pointer. The member function will
+//	be executed once the results of the Steam API call are available.
+//
+//	CCallback and CCallbackManual classes can be used instead of STEAM_CALLBACK
+//	macros if you require finer control over registration and unregistration.
+//
+//	Callbacks and call-results are queued automatically and are only
+//	delivered/executed when your application calls SteamAPI_RunCallbacks().
+//
+//  Note that there is an alternative, lower level callback dispatch mechanism.
+//  See SteamAPI_ManualDispatch_Init
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+
+// Dispatch all queued Steamworks callbacks.
+//
+// This is safe to call from multiple threads simultaneously,
+// but if you choose to do this, callback code could be executed on any thread.
+// One alternative is to call SteamAPI_RunCallbacks from the main thread only,
+// and call SteamAPI_ReleaseCurrentThreadMemory regularly on other threads.
+S_API void S_CALLTYPE SteamAPI_RunCallbacks();
+
+// Declares a callback member function plus a helper member variable which
+// registers the callback on object creation and unregisters on destruction.
+// The optional fourth 'var' param exists only for backwards-compatibility
+// and can be ignored.
+#define STEAM_CALLBACK( thisclass, func, .../*callback_type, [deprecated] var*/ ) \
+	_STEAM_CALLBACK_SELECT( ( __VA_ARGS__, 4, 3 ), ( /**/, thisclass, func, __VA_ARGS__ ) )
+
+// Declares a callback function and a named CCallbackManual variable which
+// has Register and Unregister functions instead of automatic registration.
+#define STEAM_CALLBACK_MANUAL( thisclass, func, callback_type, var )	\
+	CCallbackManual< thisclass, callback_type > var; void func( callback_type *pParam )
+
+// Dispatch callbacks relevant to the gameserver client and interfaces.
+// To register for these, you need to use STEAM_GAMESERVER_CALLBACK.
+// (Or call SetGameserverFlag on your CCallbackBase object.)
+S_API void S_CALLTYPE SteamGameServer_RunCallbacks();
+
+// Same as STEAM_CALLBACK, but for callbacks on the gameserver interface.
+// These will be dispatched during SteamGameServer_RunCallbacks
+#define STEAM_GAMESERVER_CALLBACK( thisclass, func, /*callback_type, [deprecated] var*/... ) \
+	_STEAM_CALLBACK_SELECT( ( __VA_ARGS__, GS, 3 ), ( this->SetGameserverFlag();, thisclass, func, __VA_ARGS__ ) )
+#define STEAM_GAMESERVER_CALLBACK_MANUAL( thisclass, func, callback_type, var ) \
+	CCallbackManual< thisclass, callback_type, true > var; void func( callback_type *pParam )
+
+//-----------------------------------------------------------------------------
+// Purpose: base for callbacks and call results - internal implementation detail
+//-----------------------------------------------------------------------------
+class CCallbackBase
+{
+public:
+	CCallbackBase() { m_nCallbackFlags = 0; m_iCallback = 0; }
+	// don't add a virtual destructor because we export this binary interface across dll's
+	virtual void Run( void *pvParam ) = 0;
+	virtual void Run( void *pvParam, bool bIOFailure, SteamAPICall_t hSteamAPICall ) = 0;
+	int GetICallback() { return m_iCallback; }
+	virtual int GetCallbackSizeBytes() = 0;
+
+protected:
+	enum { k_ECallbackFlagsRegistered = 0x01, k_ECallbackFlagsGameServer = 0x02 };
+	uint8 m_nCallbackFlags;
+	int m_iCallback;
+	friend class CCallbackMgr;
+
+private:
+	CCallbackBase( const CCallbackBase& );
+	CCallbackBase& operator=( const CCallbackBase& );
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: templated base for callbacks - internal implementation detail
+//-----------------------------------------------------------------------------
+template< int sizeof_P >
+class CCallbackImpl : protected CCallbackBase
+{
+public:
+	virtual ~CCallbackImpl() { if ( m_nCallbackFlags & k_ECallbackFlagsRegistered ) SteamAPI_UnregisterCallback( this ); }
+	void SetGameserverFlag() { m_nCallbackFlags |= k_ECallbackFlagsGameServer; }
+
+protected:
+	friend class CCallbackMgr;
+	virtual void Run( void *pvParam ) = 0;
+	virtual void Run( void *pvParam, bool /*bIOFailure*/, SteamAPICall_t /*hSteamAPICall*/ ) { Run( pvParam ); }
+	virtual int GetCallbackSizeBytes() { return sizeof_P; }
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: maps a steam async call result to a class member function
+//			template params: T = local class, P = parameter struct
+//-----------------------------------------------------------------------------
+template< class T, class P >
+class CCallResult : private CCallbackBase
+{
+public:
+	typedef void (T::*func_t)( P*, bool );
+
+	CCallResult();
+	~CCallResult();
+	
+	void Set( SteamAPICall_t hAPICall, T *p, func_t func );
+	bool IsActive() const;
+	void Cancel();
+
+	void SetGameserverFlag() { m_nCallbackFlags |= k_ECallbackFlagsGameServer; }
+private:
+	virtual void Run( void *pvParam );
+	virtual void Run( void *pvParam, bool bIOFailure, SteamAPICall_t hSteamAPICall );
+	virtual int GetCallbackSizeBytes() { return sizeof( P ); }
+
+	SteamAPICall_t m_hAPICall;
+	T *m_pObj;
+	func_t m_Func;
+};
+
+
+
+//-----------------------------------------------------------------------------
+// Purpose: maps a steam callback to a class member function
+//			template params: T = local class, P = parameter struct,
+//			bGameserver = listen for gameserver callbacks instead of client callbacks
+//-----------------------------------------------------------------------------
+template< class T, class P, bool bGameserver = false >
+class CCallback : public CCallbackImpl< sizeof( P ) >
+{
+public:
+	typedef void (T::*func_t)(P*);
+
+	// NOTE: If you can't provide the correct parameters at construction time, you should
+	// use the CCallbackManual callback object (STEAM_CALLBACK_MANUAL macro) instead.
+	CCallback( T *pObj, func_t func );
+
+	void Register( T *pObj, func_t func );
+	void Unregister();
+
+protected:
+	virtual void Run( void *pvParam );
+	
+	T *m_pObj;
+	func_t m_Func;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: subclass of CCallback which allows default-construction in
+//			an unregistered state; you must call Register manually
+//-----------------------------------------------------------------------------
+template< class T, class P, bool bGameServer = false >
+class CCallbackManual : public CCallback< T, P, bGameServer >
+{
+public:
+	CCallbackManual() : CCallback< T, P, bGameServer >( nullptr, nullptr ) {}
+
+	// Inherits public Register and Unregister functions from base class
+};
+
+// Internal implementation details for all of the above
+#include "steam_api_internal.h"
+
+#endif // STEAM_API_COMMON_H

--- a/lsteamclient/steamworks_sdk_148a/steam_api_flat.h
+++ b/lsteamclient/steamworks_sdk_148a/steam_api_flat.h
@@ -1,0 +1,1060 @@
+//====== Copyright Valve Corporation, All rights reserved. ====================
+//
+// Purpose: Header for "flat" SteamAPI. Use this for binding to other languages.
+// This file is auto-generated, do not edit it.
+//
+//=============================================================================
+
+#ifndef STEAMAPIFLAT_H
+#define STEAMAPIFLAT_H
+
+#include "steam/steam_api.h"
+#include "steam/isteamgameserver.h"
+#include "steam/isteamgameserverstats.h"
+
+typedef uint64 uint64_steamid; // Used when passing or returning CSteamID
+typedef uint64 uint64_gameid; // Used when passing or return CGameID
+
+
+
+// ISteamClient
+S_API HSteamPipe SteamAPI_ISteamClient_CreateSteamPipe( ISteamClient* self );
+S_API bool SteamAPI_ISteamClient_BReleaseSteamPipe( ISteamClient* self, HSteamPipe hSteamPipe );
+S_API HSteamUser SteamAPI_ISteamClient_ConnectToGlobalUser( ISteamClient* self, HSteamPipe hSteamPipe );
+S_API HSteamUser SteamAPI_ISteamClient_CreateLocalUser( ISteamClient* self, HSteamPipe * phSteamPipe, EAccountType eAccountType );
+S_API void SteamAPI_ISteamClient_ReleaseUser( ISteamClient* self, HSteamPipe hSteamPipe, HSteamUser hUser );
+S_API ISteamUser * SteamAPI_ISteamClient_GetISteamUser( ISteamClient* self, HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamGameServer * SteamAPI_ISteamClient_GetISteamGameServer( ISteamClient* self, HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API void SteamAPI_ISteamClient_SetLocalIPBinding( ISteamClient* self, const SteamIPAddress_t & unIP, uint16 usPort );
+S_API ISteamFriends * SteamAPI_ISteamClient_GetISteamFriends( ISteamClient* self, HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamUtils * SteamAPI_ISteamClient_GetISteamUtils( ISteamClient* self, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamMatchmaking * SteamAPI_ISteamClient_GetISteamMatchmaking( ISteamClient* self, HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamMatchmakingServers * SteamAPI_ISteamClient_GetISteamMatchmakingServers( ISteamClient* self, HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API void * SteamAPI_ISteamClient_GetISteamGenericInterface( ISteamClient* self, HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamUserStats * SteamAPI_ISteamClient_GetISteamUserStats( ISteamClient* self, HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamGameServerStats * SteamAPI_ISteamClient_GetISteamGameServerStats( ISteamClient* self, HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamApps * SteamAPI_ISteamClient_GetISteamApps( ISteamClient* self, HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamNetworking * SteamAPI_ISteamClient_GetISteamNetworking( ISteamClient* self, HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamRemoteStorage * SteamAPI_ISteamClient_GetISteamRemoteStorage( ISteamClient* self, HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamScreenshots * SteamAPI_ISteamClient_GetISteamScreenshots( ISteamClient* self, HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamGameSearch * SteamAPI_ISteamClient_GetISteamGameSearch( ISteamClient* self, HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API uint32 SteamAPI_ISteamClient_GetIPCCallCount( ISteamClient* self );
+S_API void SteamAPI_ISteamClient_SetWarningMessageHook( ISteamClient* self, SteamAPIWarningMessageHook_t pFunction );
+S_API bool SteamAPI_ISteamClient_BShutdownIfAllPipesClosed( ISteamClient* self );
+S_API ISteamHTTP * SteamAPI_ISteamClient_GetISteamHTTP( ISteamClient* self, HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamController * SteamAPI_ISteamClient_GetISteamController( ISteamClient* self, HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamUGC * SteamAPI_ISteamClient_GetISteamUGC( ISteamClient* self, HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamAppList * SteamAPI_ISteamClient_GetISteamAppList( ISteamClient* self, HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamMusic * SteamAPI_ISteamClient_GetISteamMusic( ISteamClient* self, HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamMusicRemote * SteamAPI_ISteamClient_GetISteamMusicRemote( ISteamClient* self, HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamHTMLSurface * SteamAPI_ISteamClient_GetISteamHTMLSurface( ISteamClient* self, HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamInventory * SteamAPI_ISteamClient_GetISteamInventory( ISteamClient* self, HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamVideo * SteamAPI_ISteamClient_GetISteamVideo( ISteamClient* self, HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamParentalSettings * SteamAPI_ISteamClient_GetISteamParentalSettings( ISteamClient* self, HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamInput * SteamAPI_ISteamClient_GetISteamInput( ISteamClient* self, HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamParties * SteamAPI_ISteamClient_GetISteamParties( ISteamClient* self, HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char * pchVersion );
+S_API ISteamRemotePlay * SteamAPI_ISteamClient_GetISteamRemotePlay( ISteamClient* self, HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char * pchVersion );
+
+// ISteamUser
+S_API ISteamUser *SteamAPI_SteamUser_v020();
+S_API HSteamUser SteamAPI_ISteamUser_GetHSteamUser( ISteamUser* self );
+S_API bool SteamAPI_ISteamUser_BLoggedOn( ISteamUser* self );
+S_API uint64_steamid SteamAPI_ISteamUser_GetSteamID( ISteamUser* self );
+S_API int SteamAPI_ISteamUser_InitiateGameConnection( ISteamUser* self, void * pAuthBlob, int cbMaxAuthBlob, uint64_steamid steamIDGameServer, uint32 unIPServer, uint16 usPortServer, bool bSecure );
+S_API void SteamAPI_ISteamUser_TerminateGameConnection( ISteamUser* self, uint32 unIPServer, uint16 usPortServer );
+S_API void SteamAPI_ISteamUser_TrackAppUsageEvent( ISteamUser* self, uint64_gameid gameID, int eAppUsageEvent, const char * pchExtraInfo );
+S_API bool SteamAPI_ISteamUser_GetUserDataFolder( ISteamUser* self, char * pchBuffer, int cubBuffer );
+S_API void SteamAPI_ISteamUser_StartVoiceRecording( ISteamUser* self );
+S_API void SteamAPI_ISteamUser_StopVoiceRecording( ISteamUser* self );
+S_API EVoiceResult SteamAPI_ISteamUser_GetAvailableVoice( ISteamUser* self, uint32 * pcbCompressed, uint32 * pcbUncompressed_Deprecated, uint32 nUncompressedVoiceDesiredSampleRate_Deprecated );
+S_API EVoiceResult SteamAPI_ISteamUser_GetVoice( ISteamUser* self, bool bWantCompressed, void * pDestBuffer, uint32 cbDestBufferSize, uint32 * nBytesWritten, bool bWantUncompressed_Deprecated, void * pUncompressedDestBuffer_Deprecated, uint32 cbUncompressedDestBufferSize_Deprecated, uint32 * nUncompressBytesWritten_Deprecated, uint32 nUncompressedVoiceDesiredSampleRate_Deprecated );
+S_API EVoiceResult SteamAPI_ISteamUser_DecompressVoice( ISteamUser* self, const void * pCompressed, uint32 cbCompressed, void * pDestBuffer, uint32 cbDestBufferSize, uint32 * nBytesWritten, uint32 nDesiredSampleRate );
+S_API uint32 SteamAPI_ISteamUser_GetVoiceOptimalSampleRate( ISteamUser* self );
+S_API HAuthTicket SteamAPI_ISteamUser_GetAuthSessionTicket( ISteamUser* self, void * pTicket, int cbMaxTicket, uint32 * pcbTicket );
+S_API EBeginAuthSessionResult SteamAPI_ISteamUser_BeginAuthSession( ISteamUser* self, const void * pAuthTicket, int cbAuthTicket, uint64_steamid steamID );
+S_API void SteamAPI_ISteamUser_EndAuthSession( ISteamUser* self, uint64_steamid steamID );
+S_API void SteamAPI_ISteamUser_CancelAuthTicket( ISteamUser* self, HAuthTicket hAuthTicket );
+S_API EUserHasLicenseForAppResult SteamAPI_ISteamUser_UserHasLicenseForApp( ISteamUser* self, uint64_steamid steamID, AppId_t appID );
+S_API bool SteamAPI_ISteamUser_BIsBehindNAT( ISteamUser* self );
+S_API void SteamAPI_ISteamUser_AdvertiseGame( ISteamUser* self, uint64_steamid steamIDGameServer, uint32 unIPServer, uint16 usPortServer );
+S_API SteamAPICall_t SteamAPI_ISteamUser_RequestEncryptedAppTicket( ISteamUser* self, void * pDataToInclude, int cbDataToInclude );
+S_API bool SteamAPI_ISteamUser_GetEncryptedAppTicket( ISteamUser* self, void * pTicket, int cbMaxTicket, uint32 * pcbTicket );
+S_API int SteamAPI_ISteamUser_GetGameBadgeLevel( ISteamUser* self, int nSeries, bool bFoil );
+S_API int SteamAPI_ISteamUser_GetPlayerSteamLevel( ISteamUser* self );
+S_API SteamAPICall_t SteamAPI_ISteamUser_RequestStoreAuthURL( ISteamUser* self, const char * pchRedirectURL );
+S_API bool SteamAPI_ISteamUser_BIsPhoneVerified( ISteamUser* self );
+S_API bool SteamAPI_ISteamUser_BIsTwoFactorEnabled( ISteamUser* self );
+S_API bool SteamAPI_ISteamUser_BIsPhoneIdentifying( ISteamUser* self );
+S_API bool SteamAPI_ISteamUser_BIsPhoneRequiringVerification( ISteamUser* self );
+S_API SteamAPICall_t SteamAPI_ISteamUser_GetMarketEligibility( ISteamUser* self );
+S_API SteamAPICall_t SteamAPI_ISteamUser_GetDurationControl( ISteamUser* self );
+
+// ISteamFriends
+S_API ISteamFriends *SteamAPI_SteamFriends_v017();
+S_API const char * SteamAPI_ISteamFriends_GetPersonaName( ISteamFriends* self );
+S_API SteamAPICall_t SteamAPI_ISteamFriends_SetPersonaName( ISteamFriends* self, const char * pchPersonaName );
+S_API EPersonaState SteamAPI_ISteamFriends_GetPersonaState( ISteamFriends* self );
+S_API int SteamAPI_ISteamFriends_GetFriendCount( ISteamFriends* self, int iFriendFlags );
+S_API uint64_steamid SteamAPI_ISteamFriends_GetFriendByIndex( ISteamFriends* self, int iFriend, int iFriendFlags );
+S_API EFriendRelationship SteamAPI_ISteamFriends_GetFriendRelationship( ISteamFriends* self, uint64_steamid steamIDFriend );
+S_API EPersonaState SteamAPI_ISteamFriends_GetFriendPersonaState( ISteamFriends* self, uint64_steamid steamIDFriend );
+S_API const char * SteamAPI_ISteamFriends_GetFriendPersonaName( ISteamFriends* self, uint64_steamid steamIDFriend );
+S_API bool SteamAPI_ISteamFriends_GetFriendGamePlayed( ISteamFriends* self, uint64_steamid steamIDFriend, FriendGameInfo_t * pFriendGameInfo );
+S_API const char * SteamAPI_ISteamFriends_GetFriendPersonaNameHistory( ISteamFriends* self, uint64_steamid steamIDFriend, int iPersonaName );
+S_API int SteamAPI_ISteamFriends_GetFriendSteamLevel( ISteamFriends* self, uint64_steamid steamIDFriend );
+S_API const char * SteamAPI_ISteamFriends_GetPlayerNickname( ISteamFriends* self, uint64_steamid steamIDPlayer );
+S_API int SteamAPI_ISteamFriends_GetFriendsGroupCount( ISteamFriends* self );
+S_API FriendsGroupID_t SteamAPI_ISteamFriends_GetFriendsGroupIDByIndex( ISteamFriends* self, int iFG );
+S_API const char * SteamAPI_ISteamFriends_GetFriendsGroupName( ISteamFriends* self, FriendsGroupID_t friendsGroupID );
+S_API int SteamAPI_ISteamFriends_GetFriendsGroupMembersCount( ISteamFriends* self, FriendsGroupID_t friendsGroupID );
+S_API void SteamAPI_ISteamFriends_GetFriendsGroupMembersList( ISteamFriends* self, FriendsGroupID_t friendsGroupID, CSteamID * pOutSteamIDMembers, int nMembersCount );
+S_API bool SteamAPI_ISteamFriends_HasFriend( ISteamFriends* self, uint64_steamid steamIDFriend, int iFriendFlags );
+S_API int SteamAPI_ISteamFriends_GetClanCount( ISteamFriends* self );
+S_API uint64_steamid SteamAPI_ISteamFriends_GetClanByIndex( ISteamFriends* self, int iClan );
+S_API const char * SteamAPI_ISteamFriends_GetClanName( ISteamFriends* self, uint64_steamid steamIDClan );
+S_API const char * SteamAPI_ISteamFriends_GetClanTag( ISteamFriends* self, uint64_steamid steamIDClan );
+S_API bool SteamAPI_ISteamFriends_GetClanActivityCounts( ISteamFriends* self, uint64_steamid steamIDClan, int * pnOnline, int * pnInGame, int * pnChatting );
+S_API SteamAPICall_t SteamAPI_ISteamFriends_DownloadClanActivityCounts( ISteamFriends* self, CSteamID * psteamIDClans, int cClansToRequest );
+S_API int SteamAPI_ISteamFriends_GetFriendCountFromSource( ISteamFriends* self, uint64_steamid steamIDSource );
+S_API uint64_steamid SteamAPI_ISteamFriends_GetFriendFromSourceByIndex( ISteamFriends* self, uint64_steamid steamIDSource, int iFriend );
+S_API bool SteamAPI_ISteamFriends_IsUserInSource( ISteamFriends* self, uint64_steamid steamIDUser, uint64_steamid steamIDSource );
+S_API void SteamAPI_ISteamFriends_SetInGameVoiceSpeaking( ISteamFriends* self, uint64_steamid steamIDUser, bool bSpeaking );
+S_API void SteamAPI_ISteamFriends_ActivateGameOverlay( ISteamFriends* self, const char * pchDialog );
+S_API void SteamAPI_ISteamFriends_ActivateGameOverlayToUser( ISteamFriends* self, const char * pchDialog, uint64_steamid steamID );
+S_API void SteamAPI_ISteamFriends_ActivateGameOverlayToWebPage( ISteamFriends* self, const char * pchURL, EActivateGameOverlayToWebPageMode eMode );
+S_API void SteamAPI_ISteamFriends_ActivateGameOverlayToStore( ISteamFriends* self, AppId_t nAppID, EOverlayToStoreFlag eFlag );
+S_API void SteamAPI_ISteamFriends_SetPlayedWith( ISteamFriends* self, uint64_steamid steamIDUserPlayedWith );
+S_API void SteamAPI_ISteamFriends_ActivateGameOverlayInviteDialog( ISteamFriends* self, uint64_steamid steamIDLobby );
+S_API int SteamAPI_ISteamFriends_GetSmallFriendAvatar( ISteamFriends* self, uint64_steamid steamIDFriend );
+S_API int SteamAPI_ISteamFriends_GetMediumFriendAvatar( ISteamFriends* self, uint64_steamid steamIDFriend );
+S_API int SteamAPI_ISteamFriends_GetLargeFriendAvatar( ISteamFriends* self, uint64_steamid steamIDFriend );
+S_API bool SteamAPI_ISteamFriends_RequestUserInformation( ISteamFriends* self, uint64_steamid steamIDUser, bool bRequireNameOnly );
+S_API SteamAPICall_t SteamAPI_ISteamFriends_RequestClanOfficerList( ISteamFriends* self, uint64_steamid steamIDClan );
+S_API uint64_steamid SteamAPI_ISteamFriends_GetClanOwner( ISteamFriends* self, uint64_steamid steamIDClan );
+S_API int SteamAPI_ISteamFriends_GetClanOfficerCount( ISteamFriends* self, uint64_steamid steamIDClan );
+S_API uint64_steamid SteamAPI_ISteamFriends_GetClanOfficerByIndex( ISteamFriends* self, uint64_steamid steamIDClan, int iOfficer );
+S_API uint32 SteamAPI_ISteamFriends_GetUserRestrictions( ISteamFriends* self );
+S_API bool SteamAPI_ISteamFriends_SetRichPresence( ISteamFriends* self, const char * pchKey, const char * pchValue );
+S_API void SteamAPI_ISteamFriends_ClearRichPresence( ISteamFriends* self );
+S_API const char * SteamAPI_ISteamFriends_GetFriendRichPresence( ISteamFriends* self, uint64_steamid steamIDFriend, const char * pchKey );
+S_API int SteamAPI_ISteamFriends_GetFriendRichPresenceKeyCount( ISteamFriends* self, uint64_steamid steamIDFriend );
+S_API const char * SteamAPI_ISteamFriends_GetFriendRichPresenceKeyByIndex( ISteamFriends* self, uint64_steamid steamIDFriend, int iKey );
+S_API void SteamAPI_ISteamFriends_RequestFriendRichPresence( ISteamFriends* self, uint64_steamid steamIDFriend );
+S_API bool SteamAPI_ISteamFriends_InviteUserToGame( ISteamFriends* self, uint64_steamid steamIDFriend, const char * pchConnectString );
+S_API int SteamAPI_ISteamFriends_GetCoplayFriendCount( ISteamFriends* self );
+S_API uint64_steamid SteamAPI_ISteamFriends_GetCoplayFriend( ISteamFriends* self, int iCoplayFriend );
+S_API int SteamAPI_ISteamFriends_GetFriendCoplayTime( ISteamFriends* self, uint64_steamid steamIDFriend );
+S_API AppId_t SteamAPI_ISteamFriends_GetFriendCoplayGame( ISteamFriends* self, uint64_steamid steamIDFriend );
+S_API SteamAPICall_t SteamAPI_ISteamFriends_JoinClanChatRoom( ISteamFriends* self, uint64_steamid steamIDClan );
+S_API bool SteamAPI_ISteamFriends_LeaveClanChatRoom( ISteamFriends* self, uint64_steamid steamIDClan );
+S_API int SteamAPI_ISteamFriends_GetClanChatMemberCount( ISteamFriends* self, uint64_steamid steamIDClan );
+S_API uint64_steamid SteamAPI_ISteamFriends_GetChatMemberByIndex( ISteamFriends* self, uint64_steamid steamIDClan, int iUser );
+S_API bool SteamAPI_ISteamFriends_SendClanChatMessage( ISteamFriends* self, uint64_steamid steamIDClanChat, const char * pchText );
+S_API int SteamAPI_ISteamFriends_GetClanChatMessage( ISteamFriends* self, uint64_steamid steamIDClanChat, int iMessage, void * prgchText, int cchTextMax, EChatEntryType * peChatEntryType, CSteamID * psteamidChatter );
+S_API bool SteamAPI_ISteamFriends_IsClanChatAdmin( ISteamFriends* self, uint64_steamid steamIDClanChat, uint64_steamid steamIDUser );
+S_API bool SteamAPI_ISteamFriends_IsClanChatWindowOpenInSteam( ISteamFriends* self, uint64_steamid steamIDClanChat );
+S_API bool SteamAPI_ISteamFriends_OpenClanChatWindowInSteam( ISteamFriends* self, uint64_steamid steamIDClanChat );
+S_API bool SteamAPI_ISteamFriends_CloseClanChatWindowInSteam( ISteamFriends* self, uint64_steamid steamIDClanChat );
+S_API bool SteamAPI_ISteamFriends_SetListenForFriendsMessages( ISteamFriends* self, bool bInterceptEnabled );
+S_API bool SteamAPI_ISteamFriends_ReplyToFriendMessage( ISteamFriends* self, uint64_steamid steamIDFriend, const char * pchMsgToSend );
+S_API int SteamAPI_ISteamFriends_GetFriendMessage( ISteamFriends* self, uint64_steamid steamIDFriend, int iMessageID, void * pvData, int cubData, EChatEntryType * peChatEntryType );
+S_API SteamAPICall_t SteamAPI_ISteamFriends_GetFollowerCount( ISteamFriends* self, uint64_steamid steamID );
+S_API SteamAPICall_t SteamAPI_ISteamFriends_IsFollowing( ISteamFriends* self, uint64_steamid steamID );
+S_API SteamAPICall_t SteamAPI_ISteamFriends_EnumerateFollowingList( ISteamFriends* self, uint32 unStartIndex );
+S_API bool SteamAPI_ISteamFriends_IsClanPublic( ISteamFriends* self, uint64_steamid steamIDClan );
+S_API bool SteamAPI_ISteamFriends_IsClanOfficialGameGroup( ISteamFriends* self, uint64_steamid steamIDClan );
+S_API int SteamAPI_ISteamFriends_GetNumChatsWithUnreadPriorityMessages( ISteamFriends* self );
+S_API void SteamAPI_ISteamFriends_ActivateGameOverlayRemotePlayTogetherInviteDialog( ISteamFriends* self, uint64_steamid steamIDLobby );
+
+// ISteamUtils
+S_API ISteamUtils *SteamAPI_SteamUtils_v009();
+S_API ISteamUtils *SteamAPI_SteamGameServerUtils_v009();
+S_API uint32 SteamAPI_ISteamUtils_GetSecondsSinceAppActive( ISteamUtils* self );
+S_API uint32 SteamAPI_ISteamUtils_GetSecondsSinceComputerActive( ISteamUtils* self );
+S_API EUniverse SteamAPI_ISteamUtils_GetConnectedUniverse( ISteamUtils* self );
+S_API uint32 SteamAPI_ISteamUtils_GetServerRealTime( ISteamUtils* self );
+S_API const char * SteamAPI_ISteamUtils_GetIPCountry( ISteamUtils* self );
+S_API bool SteamAPI_ISteamUtils_GetImageSize( ISteamUtils* self, int iImage, uint32 * pnWidth, uint32 * pnHeight );
+S_API bool SteamAPI_ISteamUtils_GetImageRGBA( ISteamUtils* self, int iImage, uint8 * pubDest, int nDestBufferSize );
+S_API bool SteamAPI_ISteamUtils_GetCSERIPPort( ISteamUtils* self, uint32 * unIP, uint16 * usPort );
+S_API uint8 SteamAPI_ISteamUtils_GetCurrentBatteryPower( ISteamUtils* self );
+S_API uint32 SteamAPI_ISteamUtils_GetAppID( ISteamUtils* self );
+S_API void SteamAPI_ISteamUtils_SetOverlayNotificationPosition( ISteamUtils* self, ENotificationPosition eNotificationPosition );
+S_API bool SteamAPI_ISteamUtils_IsAPICallCompleted( ISteamUtils* self, SteamAPICall_t hSteamAPICall, bool * pbFailed );
+S_API ESteamAPICallFailure SteamAPI_ISteamUtils_GetAPICallFailureReason( ISteamUtils* self, SteamAPICall_t hSteamAPICall );
+S_API bool SteamAPI_ISteamUtils_GetAPICallResult( ISteamUtils* self, SteamAPICall_t hSteamAPICall, void * pCallback, int cubCallback, int iCallbackExpected, bool * pbFailed );
+S_API uint32 SteamAPI_ISteamUtils_GetIPCCallCount( ISteamUtils* self );
+S_API void SteamAPI_ISteamUtils_SetWarningMessageHook( ISteamUtils* self, SteamAPIWarningMessageHook_t pFunction );
+S_API bool SteamAPI_ISteamUtils_IsOverlayEnabled( ISteamUtils* self );
+S_API bool SteamAPI_ISteamUtils_BOverlayNeedsPresent( ISteamUtils* self );
+S_API SteamAPICall_t SteamAPI_ISteamUtils_CheckFileSignature( ISteamUtils* self, const char * szFileName );
+S_API bool SteamAPI_ISteamUtils_ShowGamepadTextInput( ISteamUtils* self, EGamepadTextInputMode eInputMode, EGamepadTextInputLineMode eLineInputMode, const char * pchDescription, uint32 unCharMax, const char * pchExistingText );
+S_API uint32 SteamAPI_ISteamUtils_GetEnteredGamepadTextLength( ISteamUtils* self );
+S_API bool SteamAPI_ISteamUtils_GetEnteredGamepadTextInput( ISteamUtils* self, char * pchText, uint32 cchText );
+S_API const char * SteamAPI_ISteamUtils_GetSteamUILanguage( ISteamUtils* self );
+S_API bool SteamAPI_ISteamUtils_IsSteamRunningInVR( ISteamUtils* self );
+S_API void SteamAPI_ISteamUtils_SetOverlayNotificationInset( ISteamUtils* self, int nHorizontalInset, int nVerticalInset );
+S_API bool SteamAPI_ISteamUtils_IsSteamInBigPictureMode( ISteamUtils* self );
+S_API void SteamAPI_ISteamUtils_StartVRDashboard( ISteamUtils* self );
+S_API bool SteamAPI_ISteamUtils_IsVRHeadsetStreamingEnabled( ISteamUtils* self );
+S_API void SteamAPI_ISteamUtils_SetVRHeadsetStreamingEnabled( ISteamUtils* self, bool bEnabled );
+S_API bool SteamAPI_ISteamUtils_IsSteamChinaLauncher( ISteamUtils* self );
+S_API bool SteamAPI_ISteamUtils_InitFilterText( ISteamUtils* self );
+S_API int SteamAPI_ISteamUtils_FilterText( ISteamUtils* self, char * pchOutFilteredText, uint32 nByteSizeOutFilteredText, const char * pchInputMessage, bool bLegalOnly );
+S_API ESteamIPv6ConnectivityState SteamAPI_ISteamUtils_GetIPv6ConnectivityState( ISteamUtils* self, ESteamIPv6ConnectivityProtocol eProtocol );
+
+// ISteamMatchmaking
+S_API ISteamMatchmaking *SteamAPI_SteamMatchmaking_v009();
+S_API int SteamAPI_ISteamMatchmaking_GetFavoriteGameCount( ISteamMatchmaking* self );
+S_API bool SteamAPI_ISteamMatchmaking_GetFavoriteGame( ISteamMatchmaking* self, int iGame, AppId_t * pnAppID, uint32 * pnIP, uint16 * pnConnPort, uint16 * pnQueryPort, uint32 * punFlags, uint32 * pRTime32LastPlayedOnServer );
+S_API int SteamAPI_ISteamMatchmaking_AddFavoriteGame( ISteamMatchmaking* self, AppId_t nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags, uint32 rTime32LastPlayedOnServer );
+S_API bool SteamAPI_ISteamMatchmaking_RemoveFavoriteGame( ISteamMatchmaking* self, AppId_t nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags );
+S_API SteamAPICall_t SteamAPI_ISteamMatchmaking_RequestLobbyList( ISteamMatchmaking* self );
+S_API void SteamAPI_ISteamMatchmaking_AddRequestLobbyListStringFilter( ISteamMatchmaking* self, const char * pchKeyToMatch, const char * pchValueToMatch, ELobbyComparison eComparisonType );
+S_API void SteamAPI_ISteamMatchmaking_AddRequestLobbyListNumericalFilter( ISteamMatchmaking* self, const char * pchKeyToMatch, int nValueToMatch, ELobbyComparison eComparisonType );
+S_API void SteamAPI_ISteamMatchmaking_AddRequestLobbyListNearValueFilter( ISteamMatchmaking* self, const char * pchKeyToMatch, int nValueToBeCloseTo );
+S_API void SteamAPI_ISteamMatchmaking_AddRequestLobbyListFilterSlotsAvailable( ISteamMatchmaking* self, int nSlotsAvailable );
+S_API void SteamAPI_ISteamMatchmaking_AddRequestLobbyListDistanceFilter( ISteamMatchmaking* self, ELobbyDistanceFilter eLobbyDistanceFilter );
+S_API void SteamAPI_ISteamMatchmaking_AddRequestLobbyListResultCountFilter( ISteamMatchmaking* self, int cMaxResults );
+S_API void SteamAPI_ISteamMatchmaking_AddRequestLobbyListCompatibleMembersFilter( ISteamMatchmaking* self, uint64_steamid steamIDLobby );
+S_API uint64_steamid SteamAPI_ISteamMatchmaking_GetLobbyByIndex( ISteamMatchmaking* self, int iLobby );
+S_API SteamAPICall_t SteamAPI_ISteamMatchmaking_CreateLobby( ISteamMatchmaking* self, ELobbyType eLobbyType, int cMaxMembers );
+S_API SteamAPICall_t SteamAPI_ISteamMatchmaking_JoinLobby( ISteamMatchmaking* self, uint64_steamid steamIDLobby );
+S_API void SteamAPI_ISteamMatchmaking_LeaveLobby( ISteamMatchmaking* self, uint64_steamid steamIDLobby );
+S_API bool SteamAPI_ISteamMatchmaking_InviteUserToLobby( ISteamMatchmaking* self, uint64_steamid steamIDLobby, uint64_steamid steamIDInvitee );
+S_API int SteamAPI_ISteamMatchmaking_GetNumLobbyMembers( ISteamMatchmaking* self, uint64_steamid steamIDLobby );
+S_API uint64_steamid SteamAPI_ISteamMatchmaking_GetLobbyMemberByIndex( ISteamMatchmaking* self, uint64_steamid steamIDLobby, int iMember );
+S_API const char * SteamAPI_ISteamMatchmaking_GetLobbyData( ISteamMatchmaking* self, uint64_steamid steamIDLobby, const char * pchKey );
+S_API bool SteamAPI_ISteamMatchmaking_SetLobbyData( ISteamMatchmaking* self, uint64_steamid steamIDLobby, const char * pchKey, const char * pchValue );
+S_API int SteamAPI_ISteamMatchmaking_GetLobbyDataCount( ISteamMatchmaking* self, uint64_steamid steamIDLobby );
+S_API bool SteamAPI_ISteamMatchmaking_GetLobbyDataByIndex( ISteamMatchmaking* self, uint64_steamid steamIDLobby, int iLobbyData, char * pchKey, int cchKeyBufferSize, char * pchValue, int cchValueBufferSize );
+S_API bool SteamAPI_ISteamMatchmaking_DeleteLobbyData( ISteamMatchmaking* self, uint64_steamid steamIDLobby, const char * pchKey );
+S_API const char * SteamAPI_ISteamMatchmaking_GetLobbyMemberData( ISteamMatchmaking* self, uint64_steamid steamIDLobby, uint64_steamid steamIDUser, const char * pchKey );
+S_API void SteamAPI_ISteamMatchmaking_SetLobbyMemberData( ISteamMatchmaking* self, uint64_steamid steamIDLobby, const char * pchKey, const char * pchValue );
+S_API bool SteamAPI_ISteamMatchmaking_SendLobbyChatMsg( ISteamMatchmaking* self, uint64_steamid steamIDLobby, const void * pvMsgBody, int cubMsgBody );
+S_API int SteamAPI_ISteamMatchmaking_GetLobbyChatEntry( ISteamMatchmaking* self, uint64_steamid steamIDLobby, int iChatID, CSteamID * pSteamIDUser, void * pvData, int cubData, EChatEntryType * peChatEntryType );
+S_API bool SteamAPI_ISteamMatchmaking_RequestLobbyData( ISteamMatchmaking* self, uint64_steamid steamIDLobby );
+S_API void SteamAPI_ISteamMatchmaking_SetLobbyGameServer( ISteamMatchmaking* self, uint64_steamid steamIDLobby, uint32 unGameServerIP, uint16 unGameServerPort, uint64_steamid steamIDGameServer );
+S_API bool SteamAPI_ISteamMatchmaking_GetLobbyGameServer( ISteamMatchmaking* self, uint64_steamid steamIDLobby, uint32 * punGameServerIP, uint16 * punGameServerPort, CSteamID * psteamIDGameServer );
+S_API bool SteamAPI_ISteamMatchmaking_SetLobbyMemberLimit( ISteamMatchmaking* self, uint64_steamid steamIDLobby, int cMaxMembers );
+S_API int SteamAPI_ISteamMatchmaking_GetLobbyMemberLimit( ISteamMatchmaking* self, uint64_steamid steamIDLobby );
+S_API bool SteamAPI_ISteamMatchmaking_SetLobbyType( ISteamMatchmaking* self, uint64_steamid steamIDLobby, ELobbyType eLobbyType );
+S_API bool SteamAPI_ISteamMatchmaking_SetLobbyJoinable( ISteamMatchmaking* self, uint64_steamid steamIDLobby, bool bLobbyJoinable );
+S_API uint64_steamid SteamAPI_ISteamMatchmaking_GetLobbyOwner( ISteamMatchmaking* self, uint64_steamid steamIDLobby );
+S_API bool SteamAPI_ISteamMatchmaking_SetLobbyOwner( ISteamMatchmaking* self, uint64_steamid steamIDLobby, uint64_steamid steamIDNewOwner );
+S_API bool SteamAPI_ISteamMatchmaking_SetLinkedLobby( ISteamMatchmaking* self, uint64_steamid steamIDLobby, uint64_steamid steamIDLobbyDependent );
+
+// ISteamMatchmakingServerListResponse
+S_API void SteamAPI_ISteamMatchmakingServerListResponse_ServerResponded( ISteamMatchmakingServerListResponse* self, HServerListRequest hRequest, int iServer );
+S_API void SteamAPI_ISteamMatchmakingServerListResponse_ServerFailedToRespond( ISteamMatchmakingServerListResponse* self, HServerListRequest hRequest, int iServer );
+S_API void SteamAPI_ISteamMatchmakingServerListResponse_RefreshComplete( ISteamMatchmakingServerListResponse* self, HServerListRequest hRequest, EMatchMakingServerResponse response );
+
+// ISteamMatchmakingPingResponse
+S_API void SteamAPI_ISteamMatchmakingPingResponse_ServerResponded( ISteamMatchmakingPingResponse* self, gameserveritem_t & server );
+S_API void SteamAPI_ISteamMatchmakingPingResponse_ServerFailedToRespond( ISteamMatchmakingPingResponse* self );
+
+// ISteamMatchmakingPlayersResponse
+S_API void SteamAPI_ISteamMatchmakingPlayersResponse_AddPlayerToList( ISteamMatchmakingPlayersResponse* self, const char * pchName, int nScore, float flTimePlayed );
+S_API void SteamAPI_ISteamMatchmakingPlayersResponse_PlayersFailedToRespond( ISteamMatchmakingPlayersResponse* self );
+S_API void SteamAPI_ISteamMatchmakingPlayersResponse_PlayersRefreshComplete( ISteamMatchmakingPlayersResponse* self );
+
+// ISteamMatchmakingRulesResponse
+S_API void SteamAPI_ISteamMatchmakingRulesResponse_RulesResponded( ISteamMatchmakingRulesResponse* self, const char * pchRule, const char * pchValue );
+S_API void SteamAPI_ISteamMatchmakingRulesResponse_RulesFailedToRespond( ISteamMatchmakingRulesResponse* self );
+S_API void SteamAPI_ISteamMatchmakingRulesResponse_RulesRefreshComplete( ISteamMatchmakingRulesResponse* self );
+
+// ISteamMatchmakingServers
+S_API ISteamMatchmakingServers *SteamAPI_SteamMatchmakingServers_v002();
+S_API HServerListRequest SteamAPI_ISteamMatchmakingServers_RequestInternetServerList( ISteamMatchmakingServers* self, AppId_t iApp, MatchMakingKeyValuePair_t ** ppchFilters, uint32 nFilters, ISteamMatchmakingServerListResponse * pRequestServersResponse );
+S_API HServerListRequest SteamAPI_ISteamMatchmakingServers_RequestLANServerList( ISteamMatchmakingServers* self, AppId_t iApp, ISteamMatchmakingServerListResponse * pRequestServersResponse );
+S_API HServerListRequest SteamAPI_ISteamMatchmakingServers_RequestFriendsServerList( ISteamMatchmakingServers* self, AppId_t iApp, MatchMakingKeyValuePair_t ** ppchFilters, uint32 nFilters, ISteamMatchmakingServerListResponse * pRequestServersResponse );
+S_API HServerListRequest SteamAPI_ISteamMatchmakingServers_RequestFavoritesServerList( ISteamMatchmakingServers* self, AppId_t iApp, MatchMakingKeyValuePair_t ** ppchFilters, uint32 nFilters, ISteamMatchmakingServerListResponse * pRequestServersResponse );
+S_API HServerListRequest SteamAPI_ISteamMatchmakingServers_RequestHistoryServerList( ISteamMatchmakingServers* self, AppId_t iApp, MatchMakingKeyValuePair_t ** ppchFilters, uint32 nFilters, ISteamMatchmakingServerListResponse * pRequestServersResponse );
+S_API HServerListRequest SteamAPI_ISteamMatchmakingServers_RequestSpectatorServerList( ISteamMatchmakingServers* self, AppId_t iApp, MatchMakingKeyValuePair_t ** ppchFilters, uint32 nFilters, ISteamMatchmakingServerListResponse * pRequestServersResponse );
+S_API void SteamAPI_ISteamMatchmakingServers_ReleaseRequest( ISteamMatchmakingServers* self, HServerListRequest hServerListRequest );
+S_API gameserveritem_t * SteamAPI_ISteamMatchmakingServers_GetServerDetails( ISteamMatchmakingServers* self, HServerListRequest hRequest, int iServer );
+S_API void SteamAPI_ISteamMatchmakingServers_CancelQuery( ISteamMatchmakingServers* self, HServerListRequest hRequest );
+S_API void SteamAPI_ISteamMatchmakingServers_RefreshQuery( ISteamMatchmakingServers* self, HServerListRequest hRequest );
+S_API bool SteamAPI_ISteamMatchmakingServers_IsRefreshing( ISteamMatchmakingServers* self, HServerListRequest hRequest );
+S_API int SteamAPI_ISteamMatchmakingServers_GetServerCount( ISteamMatchmakingServers* self, HServerListRequest hRequest );
+S_API void SteamAPI_ISteamMatchmakingServers_RefreshServer( ISteamMatchmakingServers* self, HServerListRequest hRequest, int iServer );
+S_API HServerQuery SteamAPI_ISteamMatchmakingServers_PingServer( ISteamMatchmakingServers* self, uint32 unIP, uint16 usPort, ISteamMatchmakingPingResponse * pRequestServersResponse );
+S_API HServerQuery SteamAPI_ISteamMatchmakingServers_PlayerDetails( ISteamMatchmakingServers* self, uint32 unIP, uint16 usPort, ISteamMatchmakingPlayersResponse * pRequestServersResponse );
+S_API HServerQuery SteamAPI_ISteamMatchmakingServers_ServerRules( ISteamMatchmakingServers* self, uint32 unIP, uint16 usPort, ISteamMatchmakingRulesResponse * pRequestServersResponse );
+S_API void SteamAPI_ISteamMatchmakingServers_CancelServerQuery( ISteamMatchmakingServers* self, HServerQuery hServerQuery );
+
+// ISteamGameSearch
+S_API ISteamGameSearch *SteamAPI_SteamGameSearch_v001();
+S_API EGameSearchErrorCode_t SteamAPI_ISteamGameSearch_AddGameSearchParams( ISteamGameSearch* self, const char * pchKeyToFind, const char * pchValuesToFind );
+S_API EGameSearchErrorCode_t SteamAPI_ISteamGameSearch_SearchForGameWithLobby( ISteamGameSearch* self, uint64_steamid steamIDLobby, int nPlayerMin, int nPlayerMax );
+S_API EGameSearchErrorCode_t SteamAPI_ISteamGameSearch_SearchForGameSolo( ISteamGameSearch* self, int nPlayerMin, int nPlayerMax );
+S_API EGameSearchErrorCode_t SteamAPI_ISteamGameSearch_AcceptGame( ISteamGameSearch* self );
+S_API EGameSearchErrorCode_t SteamAPI_ISteamGameSearch_DeclineGame( ISteamGameSearch* self );
+S_API EGameSearchErrorCode_t SteamAPI_ISteamGameSearch_RetrieveConnectionDetails( ISteamGameSearch* self, uint64_steamid steamIDHost, char * pchConnectionDetails, int cubConnectionDetails );
+S_API EGameSearchErrorCode_t SteamAPI_ISteamGameSearch_EndGameSearch( ISteamGameSearch* self );
+S_API EGameSearchErrorCode_t SteamAPI_ISteamGameSearch_SetGameHostParams( ISteamGameSearch* self, const char * pchKey, const char * pchValue );
+S_API EGameSearchErrorCode_t SteamAPI_ISteamGameSearch_SetConnectionDetails( ISteamGameSearch* self, const char * pchConnectionDetails, int cubConnectionDetails );
+S_API EGameSearchErrorCode_t SteamAPI_ISteamGameSearch_RequestPlayersForGame( ISteamGameSearch* self, int nPlayerMin, int nPlayerMax, int nMaxTeamSize );
+S_API EGameSearchErrorCode_t SteamAPI_ISteamGameSearch_HostConfirmGameStart( ISteamGameSearch* self, uint64 ullUniqueGameID );
+S_API EGameSearchErrorCode_t SteamAPI_ISteamGameSearch_CancelRequestPlayersForGame( ISteamGameSearch* self );
+S_API EGameSearchErrorCode_t SteamAPI_ISteamGameSearch_SubmitPlayerResult( ISteamGameSearch* self, uint64 ullUniqueGameID, uint64_steamid steamIDPlayer, EPlayerResult_t EPlayerResult );
+S_API EGameSearchErrorCode_t SteamAPI_ISteamGameSearch_EndGame( ISteamGameSearch* self, uint64 ullUniqueGameID );
+
+// ISteamParties
+S_API ISteamParties *SteamAPI_SteamParties_v002();
+S_API uint32 SteamAPI_ISteamParties_GetNumActiveBeacons( ISteamParties* self );
+S_API PartyBeaconID_t SteamAPI_ISteamParties_GetBeaconByIndex( ISteamParties* self, uint32 unIndex );
+S_API bool SteamAPI_ISteamParties_GetBeaconDetails( ISteamParties* self, PartyBeaconID_t ulBeaconID, CSteamID * pSteamIDBeaconOwner, SteamPartyBeaconLocation_t * pLocation, char * pchMetadata, int cchMetadata );
+S_API SteamAPICall_t SteamAPI_ISteamParties_JoinParty( ISteamParties* self, PartyBeaconID_t ulBeaconID );
+S_API bool SteamAPI_ISteamParties_GetNumAvailableBeaconLocations( ISteamParties* self, uint32 * puNumLocations );
+S_API bool SteamAPI_ISteamParties_GetAvailableBeaconLocations( ISteamParties* self, SteamPartyBeaconLocation_t * pLocationList, uint32 uMaxNumLocations );
+S_API SteamAPICall_t SteamAPI_ISteamParties_CreateBeacon( ISteamParties* self, uint32 unOpenSlots, SteamPartyBeaconLocation_t * pBeaconLocation, const char * pchConnectString, const char * pchMetadata );
+S_API void SteamAPI_ISteamParties_OnReservationCompleted( ISteamParties* self, PartyBeaconID_t ulBeacon, uint64_steamid steamIDUser );
+S_API void SteamAPI_ISteamParties_CancelReservation( ISteamParties* self, PartyBeaconID_t ulBeacon, uint64_steamid steamIDUser );
+S_API SteamAPICall_t SteamAPI_ISteamParties_ChangeNumOpenSlots( ISteamParties* self, PartyBeaconID_t ulBeacon, uint32 unOpenSlots );
+S_API bool SteamAPI_ISteamParties_DestroyBeacon( ISteamParties* self, PartyBeaconID_t ulBeacon );
+S_API bool SteamAPI_ISteamParties_GetBeaconLocationData( ISteamParties* self, SteamPartyBeaconLocation_t BeaconLocation, ESteamPartyBeaconLocationData eData, char * pchDataStringOut, int cchDataStringOut );
+
+// ISteamRemoteStorage
+S_API ISteamRemoteStorage *SteamAPI_SteamRemoteStorage_v014();
+S_API bool SteamAPI_ISteamRemoteStorage_FileWrite( ISteamRemoteStorage* self, const char * pchFile, const void * pvData, int32 cubData );
+S_API int32 SteamAPI_ISteamRemoteStorage_FileRead( ISteamRemoteStorage* self, const char * pchFile, void * pvData, int32 cubDataToRead );
+S_API SteamAPICall_t SteamAPI_ISteamRemoteStorage_FileWriteAsync( ISteamRemoteStorage* self, const char * pchFile, const void * pvData, uint32 cubData );
+S_API SteamAPICall_t SteamAPI_ISteamRemoteStorage_FileReadAsync( ISteamRemoteStorage* self, const char * pchFile, uint32 nOffset, uint32 cubToRead );
+S_API bool SteamAPI_ISteamRemoteStorage_FileReadAsyncComplete( ISteamRemoteStorage* self, SteamAPICall_t hReadCall, void * pvBuffer, uint32 cubToRead );
+S_API bool SteamAPI_ISteamRemoteStorage_FileForget( ISteamRemoteStorage* self, const char * pchFile );
+S_API bool SteamAPI_ISteamRemoteStorage_FileDelete( ISteamRemoteStorage* self, const char * pchFile );
+S_API SteamAPICall_t SteamAPI_ISteamRemoteStorage_FileShare( ISteamRemoteStorage* self, const char * pchFile );
+S_API bool SteamAPI_ISteamRemoteStorage_SetSyncPlatforms( ISteamRemoteStorage* self, const char * pchFile, ERemoteStoragePlatform eRemoteStoragePlatform );
+S_API UGCFileWriteStreamHandle_t SteamAPI_ISteamRemoteStorage_FileWriteStreamOpen( ISteamRemoteStorage* self, const char * pchFile );
+S_API bool SteamAPI_ISteamRemoteStorage_FileWriteStreamWriteChunk( ISteamRemoteStorage* self, UGCFileWriteStreamHandle_t writeHandle, const void * pvData, int32 cubData );
+S_API bool SteamAPI_ISteamRemoteStorage_FileWriteStreamClose( ISteamRemoteStorage* self, UGCFileWriteStreamHandle_t writeHandle );
+S_API bool SteamAPI_ISteamRemoteStorage_FileWriteStreamCancel( ISteamRemoteStorage* self, UGCFileWriteStreamHandle_t writeHandle );
+S_API bool SteamAPI_ISteamRemoteStorage_FileExists( ISteamRemoteStorage* self, const char * pchFile );
+S_API bool SteamAPI_ISteamRemoteStorage_FilePersisted( ISteamRemoteStorage* self, const char * pchFile );
+S_API int32 SteamAPI_ISteamRemoteStorage_GetFileSize( ISteamRemoteStorage* self, const char * pchFile );
+S_API int64 SteamAPI_ISteamRemoteStorage_GetFileTimestamp( ISteamRemoteStorage* self, const char * pchFile );
+S_API ERemoteStoragePlatform SteamAPI_ISteamRemoteStorage_GetSyncPlatforms( ISteamRemoteStorage* self, const char * pchFile );
+S_API int32 SteamAPI_ISteamRemoteStorage_GetFileCount( ISteamRemoteStorage* self );
+S_API const char * SteamAPI_ISteamRemoteStorage_GetFileNameAndSize( ISteamRemoteStorage* self, int iFile, int32 * pnFileSizeInBytes );
+S_API bool SteamAPI_ISteamRemoteStorage_GetQuota( ISteamRemoteStorage* self, uint64 * pnTotalBytes, uint64 * puAvailableBytes );
+S_API bool SteamAPI_ISteamRemoteStorage_IsCloudEnabledForAccount( ISteamRemoteStorage* self );
+S_API bool SteamAPI_ISteamRemoteStorage_IsCloudEnabledForApp( ISteamRemoteStorage* self );
+S_API void SteamAPI_ISteamRemoteStorage_SetCloudEnabledForApp( ISteamRemoteStorage* self, bool bEnabled );
+S_API SteamAPICall_t SteamAPI_ISteamRemoteStorage_UGCDownload( ISteamRemoteStorage* self, UGCHandle_t hContent, uint32 unPriority );
+S_API bool SteamAPI_ISteamRemoteStorage_GetUGCDownloadProgress( ISteamRemoteStorage* self, UGCHandle_t hContent, int32 * pnBytesDownloaded, int32 * pnBytesExpected );
+S_API bool SteamAPI_ISteamRemoteStorage_GetUGCDetails( ISteamRemoteStorage* self, UGCHandle_t hContent, AppId_t * pnAppID, char ** ppchName, int32 * pnFileSizeInBytes, CSteamID * pSteamIDOwner );
+S_API int32 SteamAPI_ISteamRemoteStorage_UGCRead( ISteamRemoteStorage* self, UGCHandle_t hContent, void * pvData, int32 cubDataToRead, uint32 cOffset, EUGCReadAction eAction );
+S_API int32 SteamAPI_ISteamRemoteStorage_GetCachedUGCCount( ISteamRemoteStorage* self );
+S_API UGCHandle_t SteamAPI_ISteamRemoteStorage_GetCachedUGCHandle( ISteamRemoteStorage* self, int32 iCachedContent );
+S_API SteamAPICall_t SteamAPI_ISteamRemoteStorage_PublishWorkshopFile( ISteamRemoteStorage* self, const char * pchFile, const char * pchPreviewFile, AppId_t nConsumerAppId, const char * pchTitle, const char * pchDescription, ERemoteStoragePublishedFileVisibility eVisibility, SteamParamStringArray_t * pTags, EWorkshopFileType eWorkshopFileType );
+S_API PublishedFileUpdateHandle_t SteamAPI_ISteamRemoteStorage_CreatePublishedFileUpdateRequest( ISteamRemoteStorage* self, PublishedFileId_t unPublishedFileId );
+S_API bool SteamAPI_ISteamRemoteStorage_UpdatePublishedFileFile( ISteamRemoteStorage* self, PublishedFileUpdateHandle_t updateHandle, const char * pchFile );
+S_API bool SteamAPI_ISteamRemoteStorage_UpdatePublishedFilePreviewFile( ISteamRemoteStorage* self, PublishedFileUpdateHandle_t updateHandle, const char * pchPreviewFile );
+S_API bool SteamAPI_ISteamRemoteStorage_UpdatePublishedFileTitle( ISteamRemoteStorage* self, PublishedFileUpdateHandle_t updateHandle, const char * pchTitle );
+S_API bool SteamAPI_ISteamRemoteStorage_UpdatePublishedFileDescription( ISteamRemoteStorage* self, PublishedFileUpdateHandle_t updateHandle, const char * pchDescription );
+S_API bool SteamAPI_ISteamRemoteStorage_UpdatePublishedFileVisibility( ISteamRemoteStorage* self, PublishedFileUpdateHandle_t updateHandle, ERemoteStoragePublishedFileVisibility eVisibility );
+S_API bool SteamAPI_ISteamRemoteStorage_UpdatePublishedFileTags( ISteamRemoteStorage* self, PublishedFileUpdateHandle_t updateHandle, SteamParamStringArray_t * pTags );
+S_API SteamAPICall_t SteamAPI_ISteamRemoteStorage_CommitPublishedFileUpdate( ISteamRemoteStorage* self, PublishedFileUpdateHandle_t updateHandle );
+S_API SteamAPICall_t SteamAPI_ISteamRemoteStorage_GetPublishedFileDetails( ISteamRemoteStorage* self, PublishedFileId_t unPublishedFileId, uint32 unMaxSecondsOld );
+S_API SteamAPICall_t SteamAPI_ISteamRemoteStorage_DeletePublishedFile( ISteamRemoteStorage* self, PublishedFileId_t unPublishedFileId );
+S_API SteamAPICall_t SteamAPI_ISteamRemoteStorage_EnumerateUserPublishedFiles( ISteamRemoteStorage* self, uint32 unStartIndex );
+S_API SteamAPICall_t SteamAPI_ISteamRemoteStorage_SubscribePublishedFile( ISteamRemoteStorage* self, PublishedFileId_t unPublishedFileId );
+S_API SteamAPICall_t SteamAPI_ISteamRemoteStorage_EnumerateUserSubscribedFiles( ISteamRemoteStorage* self, uint32 unStartIndex );
+S_API SteamAPICall_t SteamAPI_ISteamRemoteStorage_UnsubscribePublishedFile( ISteamRemoteStorage* self, PublishedFileId_t unPublishedFileId );
+S_API bool SteamAPI_ISteamRemoteStorage_UpdatePublishedFileSetChangeDescription( ISteamRemoteStorage* self, PublishedFileUpdateHandle_t updateHandle, const char * pchChangeDescription );
+S_API SteamAPICall_t SteamAPI_ISteamRemoteStorage_GetPublishedItemVoteDetails( ISteamRemoteStorage* self, PublishedFileId_t unPublishedFileId );
+S_API SteamAPICall_t SteamAPI_ISteamRemoteStorage_UpdateUserPublishedItemVote( ISteamRemoteStorage* self, PublishedFileId_t unPublishedFileId, bool bVoteUp );
+S_API SteamAPICall_t SteamAPI_ISteamRemoteStorage_GetUserPublishedItemVoteDetails( ISteamRemoteStorage* self, PublishedFileId_t unPublishedFileId );
+S_API SteamAPICall_t SteamAPI_ISteamRemoteStorage_EnumerateUserSharedWorkshopFiles( ISteamRemoteStorage* self, uint64_steamid steamId, uint32 unStartIndex, SteamParamStringArray_t * pRequiredTags, SteamParamStringArray_t * pExcludedTags );
+S_API SteamAPICall_t SteamAPI_ISteamRemoteStorage_PublishVideo( ISteamRemoteStorage* self, EWorkshopVideoProvider eVideoProvider, const char * pchVideoAccount, const char * pchVideoIdentifier, const char * pchPreviewFile, AppId_t nConsumerAppId, const char * pchTitle, const char * pchDescription, ERemoteStoragePublishedFileVisibility eVisibility, SteamParamStringArray_t * pTags );
+S_API SteamAPICall_t SteamAPI_ISteamRemoteStorage_SetUserPublishedFileAction( ISteamRemoteStorage* self, PublishedFileId_t unPublishedFileId, EWorkshopFileAction eAction );
+S_API SteamAPICall_t SteamAPI_ISteamRemoteStorage_EnumeratePublishedFilesByUserAction( ISteamRemoteStorage* self, EWorkshopFileAction eAction, uint32 unStartIndex );
+S_API SteamAPICall_t SteamAPI_ISteamRemoteStorage_EnumeratePublishedWorkshopFiles( ISteamRemoteStorage* self, EWorkshopEnumerationType eEnumerationType, uint32 unStartIndex, uint32 unCount, uint32 unDays, SteamParamStringArray_t * pTags, SteamParamStringArray_t * pUserTags );
+S_API SteamAPICall_t SteamAPI_ISteamRemoteStorage_UGCDownloadToLocation( ISteamRemoteStorage* self, UGCHandle_t hContent, const char * pchLocation, uint32 unPriority );
+
+// ISteamUserStats
+S_API ISteamUserStats *SteamAPI_SteamUserStats_v011();
+S_API bool SteamAPI_ISteamUserStats_RequestCurrentStats( ISteamUserStats* self );
+S_API bool SteamAPI_ISteamUserStats_GetStatInt32( ISteamUserStats* self, const char * pchName, int32 * pData );
+S_API bool SteamAPI_ISteamUserStats_GetStatFloat( ISteamUserStats* self, const char * pchName, float * pData );
+S_API bool SteamAPI_ISteamUserStats_SetStatInt32( ISteamUserStats* self, const char * pchName, int32 nData );
+S_API bool SteamAPI_ISteamUserStats_SetStatFloat( ISteamUserStats* self, const char * pchName, float fData );
+S_API bool SteamAPI_ISteamUserStats_UpdateAvgRateStat( ISteamUserStats* self, const char * pchName, float flCountThisSession, double dSessionLength );
+S_API bool SteamAPI_ISteamUserStats_GetAchievement( ISteamUserStats* self, const char * pchName, bool * pbAchieved );
+S_API bool SteamAPI_ISteamUserStats_SetAchievement( ISteamUserStats* self, const char * pchName );
+S_API bool SteamAPI_ISteamUserStats_ClearAchievement( ISteamUserStats* self, const char * pchName );
+S_API bool SteamAPI_ISteamUserStats_GetAchievementAndUnlockTime( ISteamUserStats* self, const char * pchName, bool * pbAchieved, uint32 * punUnlockTime );
+S_API bool SteamAPI_ISteamUserStats_StoreStats( ISteamUserStats* self );
+S_API int SteamAPI_ISteamUserStats_GetAchievementIcon( ISteamUserStats* self, const char * pchName );
+S_API const char * SteamAPI_ISteamUserStats_GetAchievementDisplayAttribute( ISteamUserStats* self, const char * pchName, const char * pchKey );
+S_API bool SteamAPI_ISteamUserStats_IndicateAchievementProgress( ISteamUserStats* self, const char * pchName, uint32 nCurProgress, uint32 nMaxProgress );
+S_API uint32 SteamAPI_ISteamUserStats_GetNumAchievements( ISteamUserStats* self );
+S_API const char * SteamAPI_ISteamUserStats_GetAchievementName( ISteamUserStats* self, uint32 iAchievement );
+S_API SteamAPICall_t SteamAPI_ISteamUserStats_RequestUserStats( ISteamUserStats* self, uint64_steamid steamIDUser );
+S_API bool SteamAPI_ISteamUserStats_GetUserStatInt32( ISteamUserStats* self, uint64_steamid steamIDUser, const char * pchName, int32 * pData );
+S_API bool SteamAPI_ISteamUserStats_GetUserStatFloat( ISteamUserStats* self, uint64_steamid steamIDUser, const char * pchName, float * pData );
+S_API bool SteamAPI_ISteamUserStats_GetUserAchievement( ISteamUserStats* self, uint64_steamid steamIDUser, const char * pchName, bool * pbAchieved );
+S_API bool SteamAPI_ISteamUserStats_GetUserAchievementAndUnlockTime( ISteamUserStats* self, uint64_steamid steamIDUser, const char * pchName, bool * pbAchieved, uint32 * punUnlockTime );
+S_API bool SteamAPI_ISteamUserStats_ResetAllStats( ISteamUserStats* self, bool bAchievementsToo );
+S_API SteamAPICall_t SteamAPI_ISteamUserStats_FindOrCreateLeaderboard( ISteamUserStats* self, const char * pchLeaderboardName, ELeaderboardSortMethod eLeaderboardSortMethod, ELeaderboardDisplayType eLeaderboardDisplayType );
+S_API SteamAPICall_t SteamAPI_ISteamUserStats_FindLeaderboard( ISteamUserStats* self, const char * pchLeaderboardName );
+S_API const char * SteamAPI_ISteamUserStats_GetLeaderboardName( ISteamUserStats* self, SteamLeaderboard_t hSteamLeaderboard );
+S_API int SteamAPI_ISteamUserStats_GetLeaderboardEntryCount( ISteamUserStats* self, SteamLeaderboard_t hSteamLeaderboard );
+S_API ELeaderboardSortMethod SteamAPI_ISteamUserStats_GetLeaderboardSortMethod( ISteamUserStats* self, SteamLeaderboard_t hSteamLeaderboard );
+S_API ELeaderboardDisplayType SteamAPI_ISteamUserStats_GetLeaderboardDisplayType( ISteamUserStats* self, SteamLeaderboard_t hSteamLeaderboard );
+S_API SteamAPICall_t SteamAPI_ISteamUserStats_DownloadLeaderboardEntries( ISteamUserStats* self, SteamLeaderboard_t hSteamLeaderboard, ELeaderboardDataRequest eLeaderboardDataRequest, int nRangeStart, int nRangeEnd );
+S_API SteamAPICall_t SteamAPI_ISteamUserStats_DownloadLeaderboardEntriesForUsers( ISteamUserStats* self, SteamLeaderboard_t hSteamLeaderboard, CSteamID * prgUsers, int cUsers );
+S_API bool SteamAPI_ISteamUserStats_GetDownloadedLeaderboardEntry( ISteamUserStats* self, SteamLeaderboardEntries_t hSteamLeaderboardEntries, int index, LeaderboardEntry_t * pLeaderboardEntry, int32 * pDetails, int cDetailsMax );
+S_API SteamAPICall_t SteamAPI_ISteamUserStats_UploadLeaderboardScore( ISteamUserStats* self, SteamLeaderboard_t hSteamLeaderboard, ELeaderboardUploadScoreMethod eLeaderboardUploadScoreMethod, int32 nScore, const int32 * pScoreDetails, int cScoreDetailsCount );
+S_API SteamAPICall_t SteamAPI_ISteamUserStats_AttachLeaderboardUGC( ISteamUserStats* self, SteamLeaderboard_t hSteamLeaderboard, UGCHandle_t hUGC );
+S_API SteamAPICall_t SteamAPI_ISteamUserStats_GetNumberOfCurrentPlayers( ISteamUserStats* self );
+S_API SteamAPICall_t SteamAPI_ISteamUserStats_RequestGlobalAchievementPercentages( ISteamUserStats* self );
+S_API int SteamAPI_ISteamUserStats_GetMostAchievedAchievementInfo( ISteamUserStats* self, char * pchName, uint32 unNameBufLen, float * pflPercent, bool * pbAchieved );
+S_API int SteamAPI_ISteamUserStats_GetNextMostAchievedAchievementInfo( ISteamUserStats* self, int iIteratorPrevious, char * pchName, uint32 unNameBufLen, float * pflPercent, bool * pbAchieved );
+S_API bool SteamAPI_ISteamUserStats_GetAchievementAchievedPercent( ISteamUserStats* self, const char * pchName, float * pflPercent );
+S_API SteamAPICall_t SteamAPI_ISteamUserStats_RequestGlobalStats( ISteamUserStats* self, int nHistoryDays );
+S_API bool SteamAPI_ISteamUserStats_GetGlobalStatInt64( ISteamUserStats* self, const char * pchStatName, int64 * pData );
+S_API bool SteamAPI_ISteamUserStats_GetGlobalStatDouble( ISteamUserStats* self, const char * pchStatName, double * pData );
+S_API int32 SteamAPI_ISteamUserStats_GetGlobalStatHistoryInt64( ISteamUserStats* self, const char * pchStatName, int64 * pData, uint32 cubData );
+S_API int32 SteamAPI_ISteamUserStats_GetGlobalStatHistoryDouble( ISteamUserStats* self, const char * pchStatName, double * pData, uint32 cubData );
+
+// ISteamApps
+S_API ISteamApps *SteamAPI_SteamApps_v008();
+S_API ISteamApps *SteamAPI_SteamGameServerApps_v008();
+S_API bool SteamAPI_ISteamApps_BIsSubscribed( ISteamApps* self );
+S_API bool SteamAPI_ISteamApps_BIsLowViolence( ISteamApps* self );
+S_API bool SteamAPI_ISteamApps_BIsCybercafe( ISteamApps* self );
+S_API bool SteamAPI_ISteamApps_BIsVACBanned( ISteamApps* self );
+S_API const char * SteamAPI_ISteamApps_GetCurrentGameLanguage( ISteamApps* self );
+S_API const char * SteamAPI_ISteamApps_GetAvailableGameLanguages( ISteamApps* self );
+S_API bool SteamAPI_ISteamApps_BIsSubscribedApp( ISteamApps* self, AppId_t appID );
+S_API bool SteamAPI_ISteamApps_BIsDlcInstalled( ISteamApps* self, AppId_t appID );
+S_API uint32 SteamAPI_ISteamApps_GetEarliestPurchaseUnixTime( ISteamApps* self, AppId_t nAppID );
+S_API bool SteamAPI_ISteamApps_BIsSubscribedFromFreeWeekend( ISteamApps* self );
+S_API int SteamAPI_ISteamApps_GetDLCCount( ISteamApps* self );
+S_API bool SteamAPI_ISteamApps_BGetDLCDataByIndex( ISteamApps* self, int iDLC, AppId_t * pAppID, bool * pbAvailable, char * pchName, int cchNameBufferSize );
+S_API void SteamAPI_ISteamApps_InstallDLC( ISteamApps* self, AppId_t nAppID );
+S_API void SteamAPI_ISteamApps_UninstallDLC( ISteamApps* self, AppId_t nAppID );
+S_API void SteamAPI_ISteamApps_RequestAppProofOfPurchaseKey( ISteamApps* self, AppId_t nAppID );
+S_API bool SteamAPI_ISteamApps_GetCurrentBetaName( ISteamApps* self, char * pchName, int cchNameBufferSize );
+S_API bool SteamAPI_ISteamApps_MarkContentCorrupt( ISteamApps* self, bool bMissingFilesOnly );
+S_API uint32 SteamAPI_ISteamApps_GetInstalledDepots( ISteamApps* self, AppId_t appID, DepotId_t * pvecDepots, uint32 cMaxDepots );
+S_API uint32 SteamAPI_ISteamApps_GetAppInstallDir( ISteamApps* self, AppId_t appID, char * pchFolder, uint32 cchFolderBufferSize );
+S_API bool SteamAPI_ISteamApps_BIsAppInstalled( ISteamApps* self, AppId_t appID );
+S_API uint64_steamid SteamAPI_ISteamApps_GetAppOwner( ISteamApps* self );
+S_API const char * SteamAPI_ISteamApps_GetLaunchQueryParam( ISteamApps* self, const char * pchKey );
+S_API bool SteamAPI_ISteamApps_GetDlcDownloadProgress( ISteamApps* self, AppId_t nAppID, uint64 * punBytesDownloaded, uint64 * punBytesTotal );
+S_API int SteamAPI_ISteamApps_GetAppBuildId( ISteamApps* self );
+S_API void SteamAPI_ISteamApps_RequestAllProofOfPurchaseKeys( ISteamApps* self );
+S_API SteamAPICall_t SteamAPI_ISteamApps_GetFileDetails( ISteamApps* self, const char * pszFileName );
+S_API int SteamAPI_ISteamApps_GetLaunchCommandLine( ISteamApps* self, char * pszCommandLine, int cubCommandLine );
+S_API bool SteamAPI_ISteamApps_BIsSubscribedFromFamilySharing( ISteamApps* self );
+
+// ISteamNetworking
+S_API ISteamNetworking *SteamAPI_SteamNetworking_v006();
+S_API ISteamNetworking *SteamAPI_SteamGameServerNetworking_v006();
+S_API bool SteamAPI_ISteamNetworking_SendP2PPacket( ISteamNetworking* self, uint64_steamid steamIDRemote, const void * pubData, uint32 cubData, EP2PSend eP2PSendType, int nChannel );
+S_API bool SteamAPI_ISteamNetworking_IsP2PPacketAvailable( ISteamNetworking* self, uint32 * pcubMsgSize, int nChannel );
+S_API bool SteamAPI_ISteamNetworking_ReadP2PPacket( ISteamNetworking* self, void * pubDest, uint32 cubDest, uint32 * pcubMsgSize, CSteamID * psteamIDRemote, int nChannel );
+S_API bool SteamAPI_ISteamNetworking_AcceptP2PSessionWithUser( ISteamNetworking* self, uint64_steamid steamIDRemote );
+S_API bool SteamAPI_ISteamNetworking_CloseP2PSessionWithUser( ISteamNetworking* self, uint64_steamid steamIDRemote );
+S_API bool SteamAPI_ISteamNetworking_CloseP2PChannelWithUser( ISteamNetworking* self, uint64_steamid steamIDRemote, int nChannel );
+S_API bool SteamAPI_ISteamNetworking_GetP2PSessionState( ISteamNetworking* self, uint64_steamid steamIDRemote, P2PSessionState_t * pConnectionState );
+S_API bool SteamAPI_ISteamNetworking_AllowP2PPacketRelay( ISteamNetworking* self, bool bAllow );
+S_API SNetListenSocket_t SteamAPI_ISteamNetworking_CreateListenSocket( ISteamNetworking* self, int nVirtualP2PPort, SteamIPAddress_t nIP, uint16 nPort, bool bAllowUseOfPacketRelay );
+S_API SNetSocket_t SteamAPI_ISteamNetworking_CreateP2PConnectionSocket( ISteamNetworking* self, uint64_steamid steamIDTarget, int nVirtualPort, int nTimeoutSec, bool bAllowUseOfPacketRelay );
+S_API SNetSocket_t SteamAPI_ISteamNetworking_CreateConnectionSocket( ISteamNetworking* self, SteamIPAddress_t nIP, uint16 nPort, int nTimeoutSec );
+S_API bool SteamAPI_ISteamNetworking_DestroySocket( ISteamNetworking* self, SNetSocket_t hSocket, bool bNotifyRemoteEnd );
+S_API bool SteamAPI_ISteamNetworking_DestroyListenSocket( ISteamNetworking* self, SNetListenSocket_t hSocket, bool bNotifyRemoteEnd );
+S_API bool SteamAPI_ISteamNetworking_SendDataOnSocket( ISteamNetworking* self, SNetSocket_t hSocket, void * pubData, uint32 cubData, bool bReliable );
+S_API bool SteamAPI_ISteamNetworking_IsDataAvailableOnSocket( ISteamNetworking* self, SNetSocket_t hSocket, uint32 * pcubMsgSize );
+S_API bool SteamAPI_ISteamNetworking_RetrieveDataFromSocket( ISteamNetworking* self, SNetSocket_t hSocket, void * pubDest, uint32 cubDest, uint32 * pcubMsgSize );
+S_API bool SteamAPI_ISteamNetworking_IsDataAvailable( ISteamNetworking* self, SNetListenSocket_t hListenSocket, uint32 * pcubMsgSize, SNetSocket_t * phSocket );
+S_API bool SteamAPI_ISteamNetworking_RetrieveData( ISteamNetworking* self, SNetListenSocket_t hListenSocket, void * pubDest, uint32 cubDest, uint32 * pcubMsgSize, SNetSocket_t * phSocket );
+S_API bool SteamAPI_ISteamNetworking_GetSocketInfo( ISteamNetworking* self, SNetSocket_t hSocket, CSteamID * pSteamIDRemote, int * peSocketStatus, SteamIPAddress_t * punIPRemote, uint16 * punPortRemote );
+S_API bool SteamAPI_ISteamNetworking_GetListenSocketInfo( ISteamNetworking* self, SNetListenSocket_t hListenSocket, SteamIPAddress_t * pnIP, uint16 * pnPort );
+S_API ESNetSocketConnectionType SteamAPI_ISteamNetworking_GetSocketConnectionType( ISteamNetworking* self, SNetSocket_t hSocket );
+S_API int SteamAPI_ISteamNetworking_GetMaxPacketSize( ISteamNetworking* self, SNetSocket_t hSocket );
+
+// ISteamScreenshots
+S_API ISteamScreenshots *SteamAPI_SteamScreenshots_v003();
+S_API ScreenshotHandle SteamAPI_ISteamScreenshots_WriteScreenshot( ISteamScreenshots* self, void * pubRGB, uint32 cubRGB, int nWidth, int nHeight );
+S_API ScreenshotHandle SteamAPI_ISteamScreenshots_AddScreenshotToLibrary( ISteamScreenshots* self, const char * pchFilename, const char * pchThumbnailFilename, int nWidth, int nHeight );
+S_API void SteamAPI_ISteamScreenshots_TriggerScreenshot( ISteamScreenshots* self );
+S_API void SteamAPI_ISteamScreenshots_HookScreenshots( ISteamScreenshots* self, bool bHook );
+S_API bool SteamAPI_ISteamScreenshots_SetLocation( ISteamScreenshots* self, ScreenshotHandle hScreenshot, const char * pchLocation );
+S_API bool SteamAPI_ISteamScreenshots_TagUser( ISteamScreenshots* self, ScreenshotHandle hScreenshot, uint64_steamid steamID );
+S_API bool SteamAPI_ISteamScreenshots_TagPublishedFile( ISteamScreenshots* self, ScreenshotHandle hScreenshot, PublishedFileId_t unPublishedFileID );
+S_API bool SteamAPI_ISteamScreenshots_IsScreenshotsHooked( ISteamScreenshots* self );
+S_API ScreenshotHandle SteamAPI_ISteamScreenshots_AddVRScreenshotToLibrary( ISteamScreenshots* self, EVRScreenshotType eType, const char * pchFilename, const char * pchVRFilename );
+
+// ISteamMusic
+S_API ISteamMusic *SteamAPI_SteamMusic_v001();
+S_API bool SteamAPI_ISteamMusic_BIsEnabled( ISteamMusic* self );
+S_API bool SteamAPI_ISteamMusic_BIsPlaying( ISteamMusic* self );
+S_API AudioPlayback_Status SteamAPI_ISteamMusic_GetPlaybackStatus( ISteamMusic* self );
+S_API void SteamAPI_ISteamMusic_Play( ISteamMusic* self );
+S_API void SteamAPI_ISteamMusic_Pause( ISteamMusic* self );
+S_API void SteamAPI_ISteamMusic_PlayPrevious( ISteamMusic* self );
+S_API void SteamAPI_ISteamMusic_PlayNext( ISteamMusic* self );
+S_API void SteamAPI_ISteamMusic_SetVolume( ISteamMusic* self, float flVolume );
+S_API float SteamAPI_ISteamMusic_GetVolume( ISteamMusic* self );
+
+// ISteamMusicRemote
+S_API ISteamMusicRemote *SteamAPI_SteamMusicRemote_v001();
+S_API bool SteamAPI_ISteamMusicRemote_RegisterSteamMusicRemote( ISteamMusicRemote* self, const char * pchName );
+S_API bool SteamAPI_ISteamMusicRemote_DeregisterSteamMusicRemote( ISteamMusicRemote* self );
+S_API bool SteamAPI_ISteamMusicRemote_BIsCurrentMusicRemote( ISteamMusicRemote* self );
+S_API bool SteamAPI_ISteamMusicRemote_BActivationSuccess( ISteamMusicRemote* self, bool bValue );
+S_API bool SteamAPI_ISteamMusicRemote_SetDisplayName( ISteamMusicRemote* self, const char * pchDisplayName );
+S_API bool SteamAPI_ISteamMusicRemote_SetPNGIcon_64x64( ISteamMusicRemote* self, void * pvBuffer, uint32 cbBufferLength );
+S_API bool SteamAPI_ISteamMusicRemote_EnablePlayPrevious( ISteamMusicRemote* self, bool bValue );
+S_API bool SteamAPI_ISteamMusicRemote_EnablePlayNext( ISteamMusicRemote* self, bool bValue );
+S_API bool SteamAPI_ISteamMusicRemote_EnableShuffled( ISteamMusicRemote* self, bool bValue );
+S_API bool SteamAPI_ISteamMusicRemote_EnableLooped( ISteamMusicRemote* self, bool bValue );
+S_API bool SteamAPI_ISteamMusicRemote_EnableQueue( ISteamMusicRemote* self, bool bValue );
+S_API bool SteamAPI_ISteamMusicRemote_EnablePlaylists( ISteamMusicRemote* self, bool bValue );
+S_API bool SteamAPI_ISteamMusicRemote_UpdatePlaybackStatus( ISteamMusicRemote* self, AudioPlayback_Status nStatus );
+S_API bool SteamAPI_ISteamMusicRemote_UpdateShuffled( ISteamMusicRemote* self, bool bValue );
+S_API bool SteamAPI_ISteamMusicRemote_UpdateLooped( ISteamMusicRemote* self, bool bValue );
+S_API bool SteamAPI_ISteamMusicRemote_UpdateVolume( ISteamMusicRemote* self, float flValue );
+S_API bool SteamAPI_ISteamMusicRemote_CurrentEntryWillChange( ISteamMusicRemote* self );
+S_API bool SteamAPI_ISteamMusicRemote_CurrentEntryIsAvailable( ISteamMusicRemote* self, bool bAvailable );
+S_API bool SteamAPI_ISteamMusicRemote_UpdateCurrentEntryText( ISteamMusicRemote* self, const char * pchText );
+S_API bool SteamAPI_ISteamMusicRemote_UpdateCurrentEntryElapsedSeconds( ISteamMusicRemote* self, int nValue );
+S_API bool SteamAPI_ISteamMusicRemote_UpdateCurrentEntryCoverArt( ISteamMusicRemote* self, void * pvBuffer, uint32 cbBufferLength );
+S_API bool SteamAPI_ISteamMusicRemote_CurrentEntryDidChange( ISteamMusicRemote* self );
+S_API bool SteamAPI_ISteamMusicRemote_QueueWillChange( ISteamMusicRemote* self );
+S_API bool SteamAPI_ISteamMusicRemote_ResetQueueEntries( ISteamMusicRemote* self );
+S_API bool SteamAPI_ISteamMusicRemote_SetQueueEntry( ISteamMusicRemote* self, int nID, int nPosition, const char * pchEntryText );
+S_API bool SteamAPI_ISteamMusicRemote_SetCurrentQueueEntry( ISteamMusicRemote* self, int nID );
+S_API bool SteamAPI_ISteamMusicRemote_QueueDidChange( ISteamMusicRemote* self );
+S_API bool SteamAPI_ISteamMusicRemote_PlaylistWillChange( ISteamMusicRemote* self );
+S_API bool SteamAPI_ISteamMusicRemote_ResetPlaylistEntries( ISteamMusicRemote* self );
+S_API bool SteamAPI_ISteamMusicRemote_SetPlaylistEntry( ISteamMusicRemote* self, int nID, int nPosition, const char * pchEntryText );
+S_API bool SteamAPI_ISteamMusicRemote_SetCurrentPlaylistEntry( ISteamMusicRemote* self, int nID );
+S_API bool SteamAPI_ISteamMusicRemote_PlaylistDidChange( ISteamMusicRemote* self );
+
+// ISteamHTTP
+S_API ISteamHTTP *SteamAPI_SteamHTTP_v003();
+S_API ISteamHTTP *SteamAPI_SteamGameServerHTTP_v003();
+S_API HTTPRequestHandle SteamAPI_ISteamHTTP_CreateHTTPRequest( ISteamHTTP* self, EHTTPMethod eHTTPRequestMethod, const char * pchAbsoluteURL );
+S_API bool SteamAPI_ISteamHTTP_SetHTTPRequestContextValue( ISteamHTTP* self, HTTPRequestHandle hRequest, uint64 ulContextValue );
+S_API bool SteamAPI_ISteamHTTP_SetHTTPRequestNetworkActivityTimeout( ISteamHTTP* self, HTTPRequestHandle hRequest, uint32 unTimeoutSeconds );
+S_API bool SteamAPI_ISteamHTTP_SetHTTPRequestHeaderValue( ISteamHTTP* self, HTTPRequestHandle hRequest, const char * pchHeaderName, const char * pchHeaderValue );
+S_API bool SteamAPI_ISteamHTTP_SetHTTPRequestGetOrPostParameter( ISteamHTTP* self, HTTPRequestHandle hRequest, const char * pchParamName, const char * pchParamValue );
+S_API bool SteamAPI_ISteamHTTP_SendHTTPRequest( ISteamHTTP* self, HTTPRequestHandle hRequest, SteamAPICall_t * pCallHandle );
+S_API bool SteamAPI_ISteamHTTP_SendHTTPRequestAndStreamResponse( ISteamHTTP* self, HTTPRequestHandle hRequest, SteamAPICall_t * pCallHandle );
+S_API bool SteamAPI_ISteamHTTP_DeferHTTPRequest( ISteamHTTP* self, HTTPRequestHandle hRequest );
+S_API bool SteamAPI_ISteamHTTP_PrioritizeHTTPRequest( ISteamHTTP* self, HTTPRequestHandle hRequest );
+S_API bool SteamAPI_ISteamHTTP_GetHTTPResponseHeaderSize( ISteamHTTP* self, HTTPRequestHandle hRequest, const char * pchHeaderName, uint32 * unResponseHeaderSize );
+S_API bool SteamAPI_ISteamHTTP_GetHTTPResponseHeaderValue( ISteamHTTP* self, HTTPRequestHandle hRequest, const char * pchHeaderName, uint8 * pHeaderValueBuffer, uint32 unBufferSize );
+S_API bool SteamAPI_ISteamHTTP_GetHTTPResponseBodySize( ISteamHTTP* self, HTTPRequestHandle hRequest, uint32 * unBodySize );
+S_API bool SteamAPI_ISteamHTTP_GetHTTPResponseBodyData( ISteamHTTP* self, HTTPRequestHandle hRequest, uint8 * pBodyDataBuffer, uint32 unBufferSize );
+S_API bool SteamAPI_ISteamHTTP_GetHTTPStreamingResponseBodyData( ISteamHTTP* self, HTTPRequestHandle hRequest, uint32 cOffset, uint8 * pBodyDataBuffer, uint32 unBufferSize );
+S_API bool SteamAPI_ISteamHTTP_ReleaseHTTPRequest( ISteamHTTP* self, HTTPRequestHandle hRequest );
+S_API bool SteamAPI_ISteamHTTP_GetHTTPDownloadProgressPct( ISteamHTTP* self, HTTPRequestHandle hRequest, float * pflPercentOut );
+S_API bool SteamAPI_ISteamHTTP_SetHTTPRequestRawPostBody( ISteamHTTP* self, HTTPRequestHandle hRequest, const char * pchContentType, uint8 * pubBody, uint32 unBodyLen );
+S_API HTTPCookieContainerHandle SteamAPI_ISteamHTTP_CreateCookieContainer( ISteamHTTP* self, bool bAllowResponsesToModify );
+S_API bool SteamAPI_ISteamHTTP_ReleaseCookieContainer( ISteamHTTP* self, HTTPCookieContainerHandle hCookieContainer );
+S_API bool SteamAPI_ISteamHTTP_SetCookie( ISteamHTTP* self, HTTPCookieContainerHandle hCookieContainer, const char * pchHost, const char * pchUrl, const char * pchCookie );
+S_API bool SteamAPI_ISteamHTTP_SetHTTPRequestCookieContainer( ISteamHTTP* self, HTTPRequestHandle hRequest, HTTPCookieContainerHandle hCookieContainer );
+S_API bool SteamAPI_ISteamHTTP_SetHTTPRequestUserAgentInfo( ISteamHTTP* self, HTTPRequestHandle hRequest, const char * pchUserAgentInfo );
+S_API bool SteamAPI_ISteamHTTP_SetHTTPRequestRequiresVerifiedCertificate( ISteamHTTP* self, HTTPRequestHandle hRequest, bool bRequireVerifiedCertificate );
+S_API bool SteamAPI_ISteamHTTP_SetHTTPRequestAbsoluteTimeoutMS( ISteamHTTP* self, HTTPRequestHandle hRequest, uint32 unMilliseconds );
+S_API bool SteamAPI_ISteamHTTP_GetHTTPRequestWasTimedOut( ISteamHTTP* self, HTTPRequestHandle hRequest, bool * pbWasTimedOut );
+
+// ISteamInput
+S_API ISteamInput *SteamAPI_SteamInput_v001();
+S_API bool SteamAPI_ISteamInput_Init( ISteamInput* self );
+S_API bool SteamAPI_ISteamInput_Shutdown( ISteamInput* self );
+S_API void SteamAPI_ISteamInput_RunFrame( ISteamInput* self );
+S_API int SteamAPI_ISteamInput_GetConnectedControllers( ISteamInput* self, InputHandle_t * handlesOut );
+S_API InputActionSetHandle_t SteamAPI_ISteamInput_GetActionSetHandle( ISteamInput* self, const char * pszActionSetName );
+S_API void SteamAPI_ISteamInput_ActivateActionSet( ISteamInput* self, InputHandle_t inputHandle, InputActionSetHandle_t actionSetHandle );
+S_API InputActionSetHandle_t SteamAPI_ISteamInput_GetCurrentActionSet( ISteamInput* self, InputHandle_t inputHandle );
+S_API void SteamAPI_ISteamInput_ActivateActionSetLayer( ISteamInput* self, InputHandle_t inputHandle, InputActionSetHandle_t actionSetLayerHandle );
+S_API void SteamAPI_ISteamInput_DeactivateActionSetLayer( ISteamInput* self, InputHandle_t inputHandle, InputActionSetHandle_t actionSetLayerHandle );
+S_API void SteamAPI_ISteamInput_DeactivateAllActionSetLayers( ISteamInput* self, InputHandle_t inputHandle );
+S_API int SteamAPI_ISteamInput_GetActiveActionSetLayers( ISteamInput* self, InputHandle_t inputHandle, InputActionSetHandle_t * handlesOut );
+S_API InputDigitalActionHandle_t SteamAPI_ISteamInput_GetDigitalActionHandle( ISteamInput* self, const char * pszActionName );
+S_API InputDigitalActionData_t SteamAPI_ISteamInput_GetDigitalActionData( ISteamInput* self, InputHandle_t inputHandle, InputDigitalActionHandle_t digitalActionHandle );
+S_API int SteamAPI_ISteamInput_GetDigitalActionOrigins( ISteamInput* self, InputHandle_t inputHandle, InputActionSetHandle_t actionSetHandle, InputDigitalActionHandle_t digitalActionHandle, EInputActionOrigin * originsOut );
+S_API InputAnalogActionHandle_t SteamAPI_ISteamInput_GetAnalogActionHandle( ISteamInput* self, const char * pszActionName );
+S_API InputAnalogActionData_t SteamAPI_ISteamInput_GetAnalogActionData( ISteamInput* self, InputHandle_t inputHandle, InputAnalogActionHandle_t analogActionHandle );
+S_API int SteamAPI_ISteamInput_GetAnalogActionOrigins( ISteamInput* self, InputHandle_t inputHandle, InputActionSetHandle_t actionSetHandle, InputAnalogActionHandle_t analogActionHandle, EInputActionOrigin * originsOut );
+S_API const char * SteamAPI_ISteamInput_GetGlyphForActionOrigin( ISteamInput* self, EInputActionOrigin eOrigin );
+S_API const char * SteamAPI_ISteamInput_GetStringForActionOrigin( ISteamInput* self, EInputActionOrigin eOrigin );
+S_API void SteamAPI_ISteamInput_StopAnalogActionMomentum( ISteamInput* self, InputHandle_t inputHandle, InputAnalogActionHandle_t eAction );
+S_API InputMotionData_t SteamAPI_ISteamInput_GetMotionData( ISteamInput* self, InputHandle_t inputHandle );
+S_API void SteamAPI_ISteamInput_TriggerVibration( ISteamInput* self, InputHandle_t inputHandle, unsigned short usLeftSpeed, unsigned short usRightSpeed );
+S_API void SteamAPI_ISteamInput_SetLEDColor( ISteamInput* self, InputHandle_t inputHandle, uint8 nColorR, uint8 nColorG, uint8 nColorB, unsigned int nFlags );
+S_API void SteamAPI_ISteamInput_TriggerHapticPulse( ISteamInput* self, InputHandle_t inputHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec );
+S_API void SteamAPI_ISteamInput_TriggerRepeatedHapticPulse( ISteamInput* self, InputHandle_t inputHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec, unsigned short usOffMicroSec, unsigned short unRepeat, unsigned int nFlags );
+S_API bool SteamAPI_ISteamInput_ShowBindingPanel( ISteamInput* self, InputHandle_t inputHandle );
+S_API ESteamInputType SteamAPI_ISteamInput_GetInputTypeForHandle( ISteamInput* self, InputHandle_t inputHandle );
+S_API InputHandle_t SteamAPI_ISteamInput_GetControllerForGamepadIndex( ISteamInput* self, int nIndex );
+S_API int SteamAPI_ISteamInput_GetGamepadIndexForController( ISteamInput* self, InputHandle_t ulinputHandle );
+S_API const char * SteamAPI_ISteamInput_GetStringForXboxOrigin( ISteamInput* self, EXboxOrigin eOrigin );
+S_API const char * SteamAPI_ISteamInput_GetGlyphForXboxOrigin( ISteamInput* self, EXboxOrigin eOrigin );
+S_API EInputActionOrigin SteamAPI_ISteamInput_GetActionOriginFromXboxOrigin( ISteamInput* self, InputHandle_t inputHandle, EXboxOrigin eOrigin );
+S_API EInputActionOrigin SteamAPI_ISteamInput_TranslateActionOrigin( ISteamInput* self, ESteamInputType eDestinationInputType, EInputActionOrigin eSourceOrigin );
+S_API bool SteamAPI_ISteamInput_GetDeviceBindingRevision( ISteamInput* self, InputHandle_t inputHandle, int * pMajor, int * pMinor );
+S_API uint32 SteamAPI_ISteamInput_GetRemotePlaySessionID( ISteamInput* self, InputHandle_t inputHandle );
+
+// ISteamController
+S_API ISteamController *SteamAPI_SteamController_v007();
+S_API bool SteamAPI_ISteamController_Init( ISteamController* self );
+S_API bool SteamAPI_ISteamController_Shutdown( ISteamController* self );
+S_API void SteamAPI_ISteamController_RunFrame( ISteamController* self );
+S_API int SteamAPI_ISteamController_GetConnectedControllers( ISteamController* self, ControllerHandle_t * handlesOut );
+S_API ControllerActionSetHandle_t SteamAPI_ISteamController_GetActionSetHandle( ISteamController* self, const char * pszActionSetName );
+S_API void SteamAPI_ISteamController_ActivateActionSet( ISteamController* self, ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetHandle );
+S_API ControllerActionSetHandle_t SteamAPI_ISteamController_GetCurrentActionSet( ISteamController* self, ControllerHandle_t controllerHandle );
+S_API void SteamAPI_ISteamController_ActivateActionSetLayer( ISteamController* self, ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetLayerHandle );
+S_API void SteamAPI_ISteamController_DeactivateActionSetLayer( ISteamController* self, ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetLayerHandle );
+S_API void SteamAPI_ISteamController_DeactivateAllActionSetLayers( ISteamController* self, ControllerHandle_t controllerHandle );
+S_API int SteamAPI_ISteamController_GetActiveActionSetLayers( ISteamController* self, ControllerHandle_t controllerHandle, ControllerActionSetHandle_t * handlesOut );
+S_API ControllerDigitalActionHandle_t SteamAPI_ISteamController_GetDigitalActionHandle( ISteamController* self, const char * pszActionName );
+S_API InputDigitalActionData_t SteamAPI_ISteamController_GetDigitalActionData( ISteamController* self, ControllerHandle_t controllerHandle, ControllerDigitalActionHandle_t digitalActionHandle );
+S_API int SteamAPI_ISteamController_GetDigitalActionOrigins( ISteamController* self, ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetHandle, ControllerDigitalActionHandle_t digitalActionHandle, EControllerActionOrigin * originsOut );
+S_API ControllerAnalogActionHandle_t SteamAPI_ISteamController_GetAnalogActionHandle( ISteamController* self, const char * pszActionName );
+S_API InputAnalogActionData_t SteamAPI_ISteamController_GetAnalogActionData( ISteamController* self, ControllerHandle_t controllerHandle, ControllerAnalogActionHandle_t analogActionHandle );
+S_API int SteamAPI_ISteamController_GetAnalogActionOrigins( ISteamController* self, ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetHandle, ControllerAnalogActionHandle_t analogActionHandle, EControllerActionOrigin * originsOut );
+S_API const char * SteamAPI_ISteamController_GetGlyphForActionOrigin( ISteamController* self, EControllerActionOrigin eOrigin );
+S_API const char * SteamAPI_ISteamController_GetStringForActionOrigin( ISteamController* self, EControllerActionOrigin eOrigin );
+S_API void SteamAPI_ISteamController_StopAnalogActionMomentum( ISteamController* self, ControllerHandle_t controllerHandle, ControllerAnalogActionHandle_t eAction );
+S_API InputMotionData_t SteamAPI_ISteamController_GetMotionData( ISteamController* self, ControllerHandle_t controllerHandle );
+S_API void SteamAPI_ISteamController_TriggerHapticPulse( ISteamController* self, ControllerHandle_t controllerHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec );
+S_API void SteamAPI_ISteamController_TriggerRepeatedHapticPulse( ISteamController* self, ControllerHandle_t controllerHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec, unsigned short usOffMicroSec, unsigned short unRepeat, unsigned int nFlags );
+S_API void SteamAPI_ISteamController_TriggerVibration( ISteamController* self, ControllerHandle_t controllerHandle, unsigned short usLeftSpeed, unsigned short usRightSpeed );
+S_API void SteamAPI_ISteamController_SetLEDColor( ISteamController* self, ControllerHandle_t controllerHandle, uint8 nColorR, uint8 nColorG, uint8 nColorB, unsigned int nFlags );
+S_API bool SteamAPI_ISteamController_ShowBindingPanel( ISteamController* self, ControllerHandle_t controllerHandle );
+S_API ESteamInputType SteamAPI_ISteamController_GetInputTypeForHandle( ISteamController* self, ControllerHandle_t controllerHandle );
+S_API ControllerHandle_t SteamAPI_ISteamController_GetControllerForGamepadIndex( ISteamController* self, int nIndex );
+S_API int SteamAPI_ISteamController_GetGamepadIndexForController( ISteamController* self, ControllerHandle_t ulControllerHandle );
+S_API const char * SteamAPI_ISteamController_GetStringForXboxOrigin( ISteamController* self, EXboxOrigin eOrigin );
+S_API const char * SteamAPI_ISteamController_GetGlyphForXboxOrigin( ISteamController* self, EXboxOrigin eOrigin );
+S_API EControllerActionOrigin SteamAPI_ISteamController_GetActionOriginFromXboxOrigin( ISteamController* self, ControllerHandle_t controllerHandle, EXboxOrigin eOrigin );
+S_API EControllerActionOrigin SteamAPI_ISteamController_TranslateActionOrigin( ISteamController* self, ESteamInputType eDestinationInputType, EControllerActionOrigin eSourceOrigin );
+S_API bool SteamAPI_ISteamController_GetControllerBindingRevision( ISteamController* self, ControllerHandle_t controllerHandle, int * pMajor, int * pMinor );
+
+// ISteamUGC
+S_API ISteamUGC *SteamAPI_SteamUGC_v014();
+S_API ISteamUGC *SteamAPI_SteamGameServerUGC_v014();
+S_API UGCQueryHandle_t SteamAPI_ISteamUGC_CreateQueryUserUGCRequest( ISteamUGC* self, AccountID_t unAccountID, EUserUGCList eListType, EUGCMatchingUGCType eMatchingUGCType, EUserUGCListSortOrder eSortOrder, AppId_t nCreatorAppID, AppId_t nConsumerAppID, uint32 unPage );
+S_API UGCQueryHandle_t SteamAPI_ISteamUGC_CreateQueryAllUGCRequestPage( ISteamUGC* self, EUGCQuery eQueryType, EUGCMatchingUGCType eMatchingeMatchingUGCTypeFileType, AppId_t nCreatorAppID, AppId_t nConsumerAppID, uint32 unPage );
+S_API UGCQueryHandle_t SteamAPI_ISteamUGC_CreateQueryAllUGCRequestCursor( ISteamUGC* self, EUGCQuery eQueryType, EUGCMatchingUGCType eMatchingeMatchingUGCTypeFileType, AppId_t nCreatorAppID, AppId_t nConsumerAppID, const char * pchCursor );
+S_API UGCQueryHandle_t SteamAPI_ISteamUGC_CreateQueryUGCDetailsRequest( ISteamUGC* self, PublishedFileId_t * pvecPublishedFileID, uint32 unNumPublishedFileIDs );
+S_API SteamAPICall_t SteamAPI_ISteamUGC_SendQueryUGCRequest( ISteamUGC* self, UGCQueryHandle_t handle );
+S_API bool SteamAPI_ISteamUGC_GetQueryUGCResult( ISteamUGC* self, UGCQueryHandle_t handle, uint32 index, SteamUGCDetails_t * pDetails );
+S_API bool SteamAPI_ISteamUGC_GetQueryUGCPreviewURL( ISteamUGC* self, UGCQueryHandle_t handle, uint32 index, char * pchURL, uint32 cchURLSize );
+S_API bool SteamAPI_ISteamUGC_GetQueryUGCMetadata( ISteamUGC* self, UGCQueryHandle_t handle, uint32 index, char * pchMetadata, uint32 cchMetadatasize );
+S_API bool SteamAPI_ISteamUGC_GetQueryUGCChildren( ISteamUGC* self, UGCQueryHandle_t handle, uint32 index, PublishedFileId_t * pvecPublishedFileID, uint32 cMaxEntries );
+S_API bool SteamAPI_ISteamUGC_GetQueryUGCStatistic( ISteamUGC* self, UGCQueryHandle_t handle, uint32 index, EItemStatistic eStatType, uint64 * pStatValue );
+S_API uint32 SteamAPI_ISteamUGC_GetQueryUGCNumAdditionalPreviews( ISteamUGC* self, UGCQueryHandle_t handle, uint32 index );
+S_API bool SteamAPI_ISteamUGC_GetQueryUGCAdditionalPreview( ISteamUGC* self, UGCQueryHandle_t handle, uint32 index, uint32 previewIndex, char * pchURLOrVideoID, uint32 cchURLSize, char * pchOriginalFileName, uint32 cchOriginalFileNameSize, EItemPreviewType * pPreviewType );
+S_API uint32 SteamAPI_ISteamUGC_GetQueryUGCNumKeyValueTags( ISteamUGC* self, UGCQueryHandle_t handle, uint32 index );
+S_API bool SteamAPI_ISteamUGC_GetQueryUGCKeyValueTag( ISteamUGC* self, UGCQueryHandle_t handle, uint32 index, uint32 keyValueTagIndex, char * pchKey, uint32 cchKeySize, char * pchValue, uint32 cchValueSize );
+S_API bool SteamAPI_ISteamUGC_GetQueryFirstUGCKeyValueTag( ISteamUGC* self, UGCQueryHandle_t handle, uint32 index, const char * pchKey, char * pchValue, uint32 cchValueSize );
+S_API bool SteamAPI_ISteamUGC_ReleaseQueryUGCRequest( ISteamUGC* self, UGCQueryHandle_t handle );
+S_API bool SteamAPI_ISteamUGC_AddRequiredTag( ISteamUGC* self, UGCQueryHandle_t handle, const char * pTagName );
+S_API bool SteamAPI_ISteamUGC_AddRequiredTagGroup( ISteamUGC* self, UGCQueryHandle_t handle, const SteamParamStringArray_t * pTagGroups );
+S_API bool SteamAPI_ISteamUGC_AddExcludedTag( ISteamUGC* self, UGCQueryHandle_t handle, const char * pTagName );
+S_API bool SteamAPI_ISteamUGC_SetReturnOnlyIDs( ISteamUGC* self, UGCQueryHandle_t handle, bool bReturnOnlyIDs );
+S_API bool SteamAPI_ISteamUGC_SetReturnKeyValueTags( ISteamUGC* self, UGCQueryHandle_t handle, bool bReturnKeyValueTags );
+S_API bool SteamAPI_ISteamUGC_SetReturnLongDescription( ISteamUGC* self, UGCQueryHandle_t handle, bool bReturnLongDescription );
+S_API bool SteamAPI_ISteamUGC_SetReturnMetadata( ISteamUGC* self, UGCQueryHandle_t handle, bool bReturnMetadata );
+S_API bool SteamAPI_ISteamUGC_SetReturnChildren( ISteamUGC* self, UGCQueryHandle_t handle, bool bReturnChildren );
+S_API bool SteamAPI_ISteamUGC_SetReturnAdditionalPreviews( ISteamUGC* self, UGCQueryHandle_t handle, bool bReturnAdditionalPreviews );
+S_API bool SteamAPI_ISteamUGC_SetReturnTotalOnly( ISteamUGC* self, UGCQueryHandle_t handle, bool bReturnTotalOnly );
+S_API bool SteamAPI_ISteamUGC_SetReturnPlaytimeStats( ISteamUGC* self, UGCQueryHandle_t handle, uint32 unDays );
+S_API bool SteamAPI_ISteamUGC_SetLanguage( ISteamUGC* self, UGCQueryHandle_t handle, const char * pchLanguage );
+S_API bool SteamAPI_ISteamUGC_SetAllowCachedResponse( ISteamUGC* self, UGCQueryHandle_t handle, uint32 unMaxAgeSeconds );
+S_API bool SteamAPI_ISteamUGC_SetCloudFileNameFilter( ISteamUGC* self, UGCQueryHandle_t handle, const char * pMatchCloudFileName );
+S_API bool SteamAPI_ISteamUGC_SetMatchAnyTag( ISteamUGC* self, UGCQueryHandle_t handle, bool bMatchAnyTag );
+S_API bool SteamAPI_ISteamUGC_SetSearchText( ISteamUGC* self, UGCQueryHandle_t handle, const char * pSearchText );
+S_API bool SteamAPI_ISteamUGC_SetRankedByTrendDays( ISteamUGC* self, UGCQueryHandle_t handle, uint32 unDays );
+S_API bool SteamAPI_ISteamUGC_AddRequiredKeyValueTag( ISteamUGC* self, UGCQueryHandle_t handle, const char * pKey, const char * pValue );
+S_API SteamAPICall_t SteamAPI_ISteamUGC_RequestUGCDetails( ISteamUGC* self, PublishedFileId_t nPublishedFileID, uint32 unMaxAgeSeconds );
+S_API SteamAPICall_t SteamAPI_ISteamUGC_CreateItem( ISteamUGC* self, AppId_t nConsumerAppId, EWorkshopFileType eFileType );
+S_API UGCUpdateHandle_t SteamAPI_ISteamUGC_StartItemUpdate( ISteamUGC* self, AppId_t nConsumerAppId, PublishedFileId_t nPublishedFileID );
+S_API bool SteamAPI_ISteamUGC_SetItemTitle( ISteamUGC* self, UGCUpdateHandle_t handle, const char * pchTitle );
+S_API bool SteamAPI_ISteamUGC_SetItemDescription( ISteamUGC* self, UGCUpdateHandle_t handle, const char * pchDescription );
+S_API bool SteamAPI_ISteamUGC_SetItemUpdateLanguage( ISteamUGC* self, UGCUpdateHandle_t handle, const char * pchLanguage );
+S_API bool SteamAPI_ISteamUGC_SetItemMetadata( ISteamUGC* self, UGCUpdateHandle_t handle, const char * pchMetaData );
+S_API bool SteamAPI_ISteamUGC_SetItemVisibility( ISteamUGC* self, UGCUpdateHandle_t handle, ERemoteStoragePublishedFileVisibility eVisibility );
+S_API bool SteamAPI_ISteamUGC_SetItemTags( ISteamUGC* self, UGCUpdateHandle_t updateHandle, const SteamParamStringArray_t * pTags );
+S_API bool SteamAPI_ISteamUGC_SetItemContent( ISteamUGC* self, UGCUpdateHandle_t handle, const char * pszContentFolder );
+S_API bool SteamAPI_ISteamUGC_SetItemPreview( ISteamUGC* self, UGCUpdateHandle_t handle, const char * pszPreviewFile );
+S_API bool SteamAPI_ISteamUGC_SetAllowLegacyUpload( ISteamUGC* self, UGCUpdateHandle_t handle, bool bAllowLegacyUpload );
+S_API bool SteamAPI_ISteamUGC_RemoveAllItemKeyValueTags( ISteamUGC* self, UGCUpdateHandle_t handle );
+S_API bool SteamAPI_ISteamUGC_RemoveItemKeyValueTags( ISteamUGC* self, UGCUpdateHandle_t handle, const char * pchKey );
+S_API bool SteamAPI_ISteamUGC_AddItemKeyValueTag( ISteamUGC* self, UGCUpdateHandle_t handle, const char * pchKey, const char * pchValue );
+S_API bool SteamAPI_ISteamUGC_AddItemPreviewFile( ISteamUGC* self, UGCUpdateHandle_t handle, const char * pszPreviewFile, EItemPreviewType type );
+S_API bool SteamAPI_ISteamUGC_AddItemPreviewVideo( ISteamUGC* self, UGCUpdateHandle_t handle, const char * pszVideoID );
+S_API bool SteamAPI_ISteamUGC_UpdateItemPreviewFile( ISteamUGC* self, UGCUpdateHandle_t handle, uint32 index, const char * pszPreviewFile );
+S_API bool SteamAPI_ISteamUGC_UpdateItemPreviewVideo( ISteamUGC* self, UGCUpdateHandle_t handle, uint32 index, const char * pszVideoID );
+S_API bool SteamAPI_ISteamUGC_RemoveItemPreview( ISteamUGC* self, UGCUpdateHandle_t handle, uint32 index );
+S_API SteamAPICall_t SteamAPI_ISteamUGC_SubmitItemUpdate( ISteamUGC* self, UGCUpdateHandle_t handle, const char * pchChangeNote );
+S_API EItemUpdateStatus SteamAPI_ISteamUGC_GetItemUpdateProgress( ISteamUGC* self, UGCUpdateHandle_t handle, uint64 * punBytesProcessed, uint64 * punBytesTotal );
+S_API SteamAPICall_t SteamAPI_ISteamUGC_SetUserItemVote( ISteamUGC* self, PublishedFileId_t nPublishedFileID, bool bVoteUp );
+S_API SteamAPICall_t SteamAPI_ISteamUGC_GetUserItemVote( ISteamUGC* self, PublishedFileId_t nPublishedFileID );
+S_API SteamAPICall_t SteamAPI_ISteamUGC_AddItemToFavorites( ISteamUGC* self, AppId_t nAppId, PublishedFileId_t nPublishedFileID );
+S_API SteamAPICall_t SteamAPI_ISteamUGC_RemoveItemFromFavorites( ISteamUGC* self, AppId_t nAppId, PublishedFileId_t nPublishedFileID );
+S_API SteamAPICall_t SteamAPI_ISteamUGC_SubscribeItem( ISteamUGC* self, PublishedFileId_t nPublishedFileID );
+S_API SteamAPICall_t SteamAPI_ISteamUGC_UnsubscribeItem( ISteamUGC* self, PublishedFileId_t nPublishedFileID );
+S_API uint32 SteamAPI_ISteamUGC_GetNumSubscribedItems( ISteamUGC* self );
+S_API uint32 SteamAPI_ISteamUGC_GetSubscribedItems( ISteamUGC* self, PublishedFileId_t * pvecPublishedFileID, uint32 cMaxEntries );
+S_API uint32 SteamAPI_ISteamUGC_GetItemState( ISteamUGC* self, PublishedFileId_t nPublishedFileID );
+S_API bool SteamAPI_ISteamUGC_GetItemInstallInfo( ISteamUGC* self, PublishedFileId_t nPublishedFileID, uint64 * punSizeOnDisk, char * pchFolder, uint32 cchFolderSize, uint32 * punTimeStamp );
+S_API bool SteamAPI_ISteamUGC_GetItemDownloadInfo( ISteamUGC* self, PublishedFileId_t nPublishedFileID, uint64 * punBytesDownloaded, uint64 * punBytesTotal );
+S_API bool SteamAPI_ISteamUGC_DownloadItem( ISteamUGC* self, PublishedFileId_t nPublishedFileID, bool bHighPriority );
+S_API bool SteamAPI_ISteamUGC_BInitWorkshopForGameServer( ISteamUGC* self, DepotId_t unWorkshopDepotID, const char * pszFolder );
+S_API void SteamAPI_ISteamUGC_SuspendDownloads( ISteamUGC* self, bool bSuspend );
+S_API SteamAPICall_t SteamAPI_ISteamUGC_StartPlaytimeTracking( ISteamUGC* self, PublishedFileId_t * pvecPublishedFileID, uint32 unNumPublishedFileIDs );
+S_API SteamAPICall_t SteamAPI_ISteamUGC_StopPlaytimeTracking( ISteamUGC* self, PublishedFileId_t * pvecPublishedFileID, uint32 unNumPublishedFileIDs );
+S_API SteamAPICall_t SteamAPI_ISteamUGC_StopPlaytimeTrackingForAllItems( ISteamUGC* self );
+S_API SteamAPICall_t SteamAPI_ISteamUGC_AddDependency( ISteamUGC* self, PublishedFileId_t nParentPublishedFileID, PublishedFileId_t nChildPublishedFileID );
+S_API SteamAPICall_t SteamAPI_ISteamUGC_RemoveDependency( ISteamUGC* self, PublishedFileId_t nParentPublishedFileID, PublishedFileId_t nChildPublishedFileID );
+S_API SteamAPICall_t SteamAPI_ISteamUGC_AddAppDependency( ISteamUGC* self, PublishedFileId_t nPublishedFileID, AppId_t nAppID );
+S_API SteamAPICall_t SteamAPI_ISteamUGC_RemoveAppDependency( ISteamUGC* self, PublishedFileId_t nPublishedFileID, AppId_t nAppID );
+S_API SteamAPICall_t SteamAPI_ISteamUGC_GetAppDependencies( ISteamUGC* self, PublishedFileId_t nPublishedFileID );
+S_API SteamAPICall_t SteamAPI_ISteamUGC_DeleteItem( ISteamUGC* self, PublishedFileId_t nPublishedFileID );
+
+// ISteamAppList
+S_API ISteamAppList *SteamAPI_SteamAppList_v001();
+S_API uint32 SteamAPI_ISteamAppList_GetNumInstalledApps( ISteamAppList* self );
+S_API uint32 SteamAPI_ISteamAppList_GetInstalledApps( ISteamAppList* self, AppId_t * pvecAppID, uint32 unMaxAppIDs );
+S_API int SteamAPI_ISteamAppList_GetAppName( ISteamAppList* self, AppId_t nAppID, char * pchName, int cchNameMax );
+S_API int SteamAPI_ISteamAppList_GetAppInstallDir( ISteamAppList* self, AppId_t nAppID, char * pchDirectory, int cchNameMax );
+S_API int SteamAPI_ISteamAppList_GetAppBuildId( ISteamAppList* self, AppId_t nAppID );
+
+// ISteamHTMLSurface
+S_API ISteamHTMLSurface *SteamAPI_SteamHTMLSurface_v005();
+S_API bool SteamAPI_ISteamHTMLSurface_Init( ISteamHTMLSurface* self );
+S_API bool SteamAPI_ISteamHTMLSurface_Shutdown( ISteamHTMLSurface* self );
+S_API SteamAPICall_t SteamAPI_ISteamHTMLSurface_CreateBrowser( ISteamHTMLSurface* self, const char * pchUserAgent, const char * pchUserCSS );
+S_API void SteamAPI_ISteamHTMLSurface_RemoveBrowser( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle );
+S_API void SteamAPI_ISteamHTMLSurface_LoadURL( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, const char * pchURL, const char * pchPostData );
+S_API void SteamAPI_ISteamHTMLSurface_SetSize( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, uint32 unWidth, uint32 unHeight );
+S_API void SteamAPI_ISteamHTMLSurface_StopLoad( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle );
+S_API void SteamAPI_ISteamHTMLSurface_Reload( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle );
+S_API void SteamAPI_ISteamHTMLSurface_GoBack( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle );
+S_API void SteamAPI_ISteamHTMLSurface_GoForward( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle );
+S_API void SteamAPI_ISteamHTMLSurface_AddHeader( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, const char * pchKey, const char * pchValue );
+S_API void SteamAPI_ISteamHTMLSurface_ExecuteJavascript( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, const char * pchScript );
+S_API void SteamAPI_ISteamHTMLSurface_MouseUp( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, ISteamHTMLSurface::EHTMLMouseButton eMouseButton );
+S_API void SteamAPI_ISteamHTMLSurface_MouseDown( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, ISteamHTMLSurface::EHTMLMouseButton eMouseButton );
+S_API void SteamAPI_ISteamHTMLSurface_MouseDoubleClick( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, ISteamHTMLSurface::EHTMLMouseButton eMouseButton );
+S_API void SteamAPI_ISteamHTMLSurface_MouseMove( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, int x, int y );
+S_API void SteamAPI_ISteamHTMLSurface_MouseWheel( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, int32 nDelta );
+S_API void SteamAPI_ISteamHTMLSurface_KeyDown( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, uint32 nNativeKeyCode, ISteamHTMLSurface::EHTMLKeyModifiers eHTMLKeyModifiers, bool bIsSystemKey );
+S_API void SteamAPI_ISteamHTMLSurface_KeyUp( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, uint32 nNativeKeyCode, ISteamHTMLSurface::EHTMLKeyModifiers eHTMLKeyModifiers );
+S_API void SteamAPI_ISteamHTMLSurface_KeyChar( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, uint32 cUnicodeChar, ISteamHTMLSurface::EHTMLKeyModifiers eHTMLKeyModifiers );
+S_API void SteamAPI_ISteamHTMLSurface_SetHorizontalScroll( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, uint32 nAbsolutePixelScroll );
+S_API void SteamAPI_ISteamHTMLSurface_SetVerticalScroll( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, uint32 nAbsolutePixelScroll );
+S_API void SteamAPI_ISteamHTMLSurface_SetKeyFocus( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, bool bHasKeyFocus );
+S_API void SteamAPI_ISteamHTMLSurface_ViewSource( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle );
+S_API void SteamAPI_ISteamHTMLSurface_CopyToClipboard( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle );
+S_API void SteamAPI_ISteamHTMLSurface_PasteFromClipboard( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle );
+S_API void SteamAPI_ISteamHTMLSurface_Find( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, const char * pchSearchStr, bool bCurrentlyInFind, bool bReverse );
+S_API void SteamAPI_ISteamHTMLSurface_StopFind( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle );
+S_API void SteamAPI_ISteamHTMLSurface_GetLinkAtPosition( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, int x, int y );
+S_API void SteamAPI_ISteamHTMLSurface_SetCookie( ISteamHTMLSurface* self, const char * pchHostname, const char * pchKey, const char * pchValue, const char * pchPath, RTime32 nExpires, bool bSecure, bool bHTTPOnly );
+S_API void SteamAPI_ISteamHTMLSurface_SetPageScaleFactor( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, float flZoom, int nPointX, int nPointY );
+S_API void SteamAPI_ISteamHTMLSurface_SetBackgroundMode( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, bool bBackgroundMode );
+S_API void SteamAPI_ISteamHTMLSurface_SetDPIScalingFactor( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, float flDPIScaling );
+S_API void SteamAPI_ISteamHTMLSurface_OpenDeveloperTools( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle );
+S_API void SteamAPI_ISteamHTMLSurface_AllowStartRequest( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, bool bAllowed );
+S_API void SteamAPI_ISteamHTMLSurface_JSDialogResponse( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, bool bResult );
+S_API void SteamAPI_ISteamHTMLSurface_FileLoadDialogResponse( ISteamHTMLSurface* self, HHTMLBrowser unBrowserHandle, const char ** pchSelectedFiles );
+
+// ISteamInventory
+S_API ISteamInventory *SteamAPI_SteamInventory_v003();
+S_API ISteamInventory *SteamAPI_SteamGameServerInventory_v003();
+S_API EResult SteamAPI_ISteamInventory_GetResultStatus( ISteamInventory* self, SteamInventoryResult_t resultHandle );
+S_API bool SteamAPI_ISteamInventory_GetResultItems( ISteamInventory* self, SteamInventoryResult_t resultHandle, SteamItemDetails_t * pOutItemsArray, uint32 * punOutItemsArraySize );
+S_API bool SteamAPI_ISteamInventory_GetResultItemProperty( ISteamInventory* self, SteamInventoryResult_t resultHandle, uint32 unItemIndex, const char * pchPropertyName, char * pchValueBuffer, uint32 * punValueBufferSizeOut );
+S_API uint32 SteamAPI_ISteamInventory_GetResultTimestamp( ISteamInventory* self, SteamInventoryResult_t resultHandle );
+S_API bool SteamAPI_ISteamInventory_CheckResultSteamID( ISteamInventory* self, SteamInventoryResult_t resultHandle, uint64_steamid steamIDExpected );
+S_API void SteamAPI_ISteamInventory_DestroyResult( ISteamInventory* self, SteamInventoryResult_t resultHandle );
+S_API bool SteamAPI_ISteamInventory_GetAllItems( ISteamInventory* self, SteamInventoryResult_t * pResultHandle );
+S_API bool SteamAPI_ISteamInventory_GetItemsByID( ISteamInventory* self, SteamInventoryResult_t * pResultHandle, const SteamItemInstanceID_t * pInstanceIDs, uint32 unCountInstanceIDs );
+S_API bool SteamAPI_ISteamInventory_SerializeResult( ISteamInventory* self, SteamInventoryResult_t resultHandle, void * pOutBuffer, uint32 * punOutBufferSize );
+S_API bool SteamAPI_ISteamInventory_DeserializeResult( ISteamInventory* self, SteamInventoryResult_t * pOutResultHandle, const void * pBuffer, uint32 unBufferSize, bool bRESERVED_MUST_BE_FALSE );
+S_API bool SteamAPI_ISteamInventory_GenerateItems( ISteamInventory* self, SteamInventoryResult_t * pResultHandle, const SteamItemDef_t * pArrayItemDefs, const uint32 * punArrayQuantity, uint32 unArrayLength );
+S_API bool SteamAPI_ISteamInventory_GrantPromoItems( ISteamInventory* self, SteamInventoryResult_t * pResultHandle );
+S_API bool SteamAPI_ISteamInventory_AddPromoItem( ISteamInventory* self, SteamInventoryResult_t * pResultHandle, SteamItemDef_t itemDef );
+S_API bool SteamAPI_ISteamInventory_AddPromoItems( ISteamInventory* self, SteamInventoryResult_t * pResultHandle, const SteamItemDef_t * pArrayItemDefs, uint32 unArrayLength );
+S_API bool SteamAPI_ISteamInventory_ConsumeItem( ISteamInventory* self, SteamInventoryResult_t * pResultHandle, SteamItemInstanceID_t itemConsume, uint32 unQuantity );
+S_API bool SteamAPI_ISteamInventory_ExchangeItems( ISteamInventory* self, SteamInventoryResult_t * pResultHandle, const SteamItemDef_t * pArrayGenerate, const uint32 * punArrayGenerateQuantity, uint32 unArrayGenerateLength, const SteamItemInstanceID_t * pArrayDestroy, const uint32 * punArrayDestroyQuantity, uint32 unArrayDestroyLength );
+S_API bool SteamAPI_ISteamInventory_TransferItemQuantity( ISteamInventory* self, SteamInventoryResult_t * pResultHandle, SteamItemInstanceID_t itemIdSource, uint32 unQuantity, SteamItemInstanceID_t itemIdDest );
+S_API void SteamAPI_ISteamInventory_SendItemDropHeartbeat( ISteamInventory* self );
+S_API bool SteamAPI_ISteamInventory_TriggerItemDrop( ISteamInventory* self, SteamInventoryResult_t * pResultHandle, SteamItemDef_t dropListDefinition );
+S_API bool SteamAPI_ISteamInventory_TradeItems( ISteamInventory* self, SteamInventoryResult_t * pResultHandle, uint64_steamid steamIDTradePartner, const SteamItemInstanceID_t * pArrayGive, const uint32 * pArrayGiveQuantity, uint32 nArrayGiveLength, const SteamItemInstanceID_t * pArrayGet, const uint32 * pArrayGetQuantity, uint32 nArrayGetLength );
+S_API bool SteamAPI_ISteamInventory_LoadItemDefinitions( ISteamInventory* self );
+S_API bool SteamAPI_ISteamInventory_GetItemDefinitionIDs( ISteamInventory* self, SteamItemDef_t * pItemDefIDs, uint32 * punItemDefIDsArraySize );
+S_API bool SteamAPI_ISteamInventory_GetItemDefinitionProperty( ISteamInventory* self, SteamItemDef_t iDefinition, const char * pchPropertyName, char * pchValueBuffer, uint32 * punValueBufferSizeOut );
+S_API SteamAPICall_t SteamAPI_ISteamInventory_RequestEligiblePromoItemDefinitionsIDs( ISteamInventory* self, uint64_steamid steamID );
+S_API bool SteamAPI_ISteamInventory_GetEligiblePromoItemDefinitionIDs( ISteamInventory* self, uint64_steamid steamID, SteamItemDef_t * pItemDefIDs, uint32 * punItemDefIDsArraySize );
+S_API SteamAPICall_t SteamAPI_ISteamInventory_StartPurchase( ISteamInventory* self, const SteamItemDef_t * pArrayItemDefs, const uint32 * punArrayQuantity, uint32 unArrayLength );
+S_API SteamAPICall_t SteamAPI_ISteamInventory_RequestPrices( ISteamInventory* self );
+S_API uint32 SteamAPI_ISteamInventory_GetNumItemsWithPrices( ISteamInventory* self );
+S_API bool SteamAPI_ISteamInventory_GetItemsWithPrices( ISteamInventory* self, SteamItemDef_t * pArrayItemDefs, uint64 * pCurrentPrices, uint64 * pBasePrices, uint32 unArrayLength );
+S_API bool SteamAPI_ISteamInventory_GetItemPrice( ISteamInventory* self, SteamItemDef_t iDefinition, uint64 * pCurrentPrice, uint64 * pBasePrice );
+S_API SteamInventoryUpdateHandle_t SteamAPI_ISteamInventory_StartUpdateProperties( ISteamInventory* self );
+S_API bool SteamAPI_ISteamInventory_RemoveProperty( ISteamInventory* self, SteamInventoryUpdateHandle_t handle, SteamItemInstanceID_t nItemID, const char * pchPropertyName );
+S_API bool SteamAPI_ISteamInventory_SetPropertyString( ISteamInventory* self, SteamInventoryUpdateHandle_t handle, SteamItemInstanceID_t nItemID, const char * pchPropertyName, const char * pchPropertyValue );
+S_API bool SteamAPI_ISteamInventory_SetPropertyBool( ISteamInventory* self, SteamInventoryUpdateHandle_t handle, SteamItemInstanceID_t nItemID, const char * pchPropertyName, bool bValue );
+S_API bool SteamAPI_ISteamInventory_SetPropertyInt64( ISteamInventory* self, SteamInventoryUpdateHandle_t handle, SteamItemInstanceID_t nItemID, const char * pchPropertyName, int64 nValue );
+S_API bool SteamAPI_ISteamInventory_SetPropertyFloat( ISteamInventory* self, SteamInventoryUpdateHandle_t handle, SteamItemInstanceID_t nItemID, const char * pchPropertyName, float flValue );
+S_API bool SteamAPI_ISteamInventory_SubmitUpdateProperties( ISteamInventory* self, SteamInventoryUpdateHandle_t handle, SteamInventoryResult_t * pResultHandle );
+
+// ISteamVideo
+S_API ISteamVideo *SteamAPI_SteamVideo_v002();
+S_API void SteamAPI_ISteamVideo_GetVideoURL( ISteamVideo* self, AppId_t unVideoAppID );
+S_API bool SteamAPI_ISteamVideo_IsBroadcasting( ISteamVideo* self, int * pnNumViewers );
+S_API void SteamAPI_ISteamVideo_GetOPFSettings( ISteamVideo* self, AppId_t unVideoAppID );
+S_API bool SteamAPI_ISteamVideo_GetOPFStringForApp( ISteamVideo* self, AppId_t unVideoAppID, char * pchBuffer, int32 * pnBufferSize );
+
+// ISteamTV
+S_API ISteamTV *SteamAPI_SteamTV_v001();
+S_API bool SteamAPI_ISteamTV_IsBroadcasting( ISteamTV* self, int * pnNumViewers );
+S_API void SteamAPI_ISteamTV_AddBroadcastGameData( ISteamTV* self, const char * pchKey, const char * pchValue );
+S_API void SteamAPI_ISteamTV_RemoveBroadcastGameData( ISteamTV* self, const char * pchKey );
+S_API void SteamAPI_ISteamTV_AddTimelineMarker( ISteamTV* self, const char * pchTemplateName, bool bPersistent, uint8 nColorR, uint8 nColorG, uint8 nColorB );
+S_API void SteamAPI_ISteamTV_RemoveTimelineMarker( ISteamTV* self );
+S_API uint32 SteamAPI_ISteamTV_AddRegion( ISteamTV* self, const char * pchElementName, const char * pchTimelineDataSection, const SteamTVRegion_t * pSteamTVRegion, ESteamTVRegionBehavior eSteamTVRegionBehavior );
+S_API void SteamAPI_ISteamTV_RemoveRegion( ISteamTV* self, uint32 unRegionHandle );
+
+// ISteamParentalSettings
+S_API ISteamParentalSettings *SteamAPI_SteamParentalSettings_v001();
+S_API bool SteamAPI_ISteamParentalSettings_BIsParentalLockEnabled( ISteamParentalSettings* self );
+S_API bool SteamAPI_ISteamParentalSettings_BIsParentalLockLocked( ISteamParentalSettings* self );
+S_API bool SteamAPI_ISteamParentalSettings_BIsAppBlocked( ISteamParentalSettings* self, AppId_t nAppID );
+S_API bool SteamAPI_ISteamParentalSettings_BIsAppInBlockList( ISteamParentalSettings* self, AppId_t nAppID );
+S_API bool SteamAPI_ISteamParentalSettings_BIsFeatureBlocked( ISteamParentalSettings* self, EParentalFeature eFeature );
+S_API bool SteamAPI_ISteamParentalSettings_BIsFeatureInBlockList( ISteamParentalSettings* self, EParentalFeature eFeature );
+
+// ISteamRemotePlay
+S_API ISteamRemotePlay *SteamAPI_SteamRemotePlay_v001();
+S_API uint32 SteamAPI_ISteamRemotePlay_GetSessionCount( ISteamRemotePlay* self );
+S_API RemotePlaySessionID_t SteamAPI_ISteamRemotePlay_GetSessionID( ISteamRemotePlay* self, int iSessionIndex );
+S_API uint64_steamid SteamAPI_ISteamRemotePlay_GetSessionSteamID( ISteamRemotePlay* self, RemotePlaySessionID_t unSessionID );
+S_API const char * SteamAPI_ISteamRemotePlay_GetSessionClientName( ISteamRemotePlay* self, RemotePlaySessionID_t unSessionID );
+S_API ESteamDeviceFormFactor SteamAPI_ISteamRemotePlay_GetSessionClientFormFactor( ISteamRemotePlay* self, RemotePlaySessionID_t unSessionID );
+S_API bool SteamAPI_ISteamRemotePlay_BGetSessionClientResolution( ISteamRemotePlay* self, RemotePlaySessionID_t unSessionID, int * pnResolutionX, int * pnResolutionY );
+S_API bool SteamAPI_ISteamRemotePlay_BSendRemotePlayTogetherInvite( ISteamRemotePlay* self, uint64_steamid steamIDFriend );
+
+// ISteamNetworkingSockets
+S_API ISteamNetworkingSockets *SteamAPI_SteamNetworkingSockets_v008();
+S_API ISteamNetworkingSockets *SteamAPI_SteamGameServerNetworkingSockets_v008();
+S_API HSteamListenSocket SteamAPI_ISteamNetworkingSockets_CreateListenSocketIP( ISteamNetworkingSockets* self, const SteamNetworkingIPAddr & localAddress, int nOptions, const SteamNetworkingConfigValue_t * pOptions );
+S_API HSteamNetConnection SteamAPI_ISteamNetworkingSockets_ConnectByIPAddress( ISteamNetworkingSockets* self, const SteamNetworkingIPAddr & address, int nOptions, const SteamNetworkingConfigValue_t * pOptions );
+S_API HSteamListenSocket SteamAPI_ISteamNetworkingSockets_CreateListenSocketP2P( ISteamNetworkingSockets* self, int nVirtualPort, int nOptions, const SteamNetworkingConfigValue_t * pOptions );
+S_API HSteamNetConnection SteamAPI_ISteamNetworkingSockets_ConnectP2P( ISteamNetworkingSockets* self, const SteamNetworkingIdentity & identityRemote, int nVirtualPort, int nOptions, const SteamNetworkingConfigValue_t * pOptions );
+S_API EResult SteamAPI_ISteamNetworkingSockets_AcceptConnection( ISteamNetworkingSockets* self, HSteamNetConnection hConn );
+S_API bool SteamAPI_ISteamNetworkingSockets_CloseConnection( ISteamNetworkingSockets* self, HSteamNetConnection hPeer, int nReason, const char * pszDebug, bool bEnableLinger );
+S_API bool SteamAPI_ISteamNetworkingSockets_CloseListenSocket( ISteamNetworkingSockets* self, HSteamListenSocket hSocket );
+S_API bool SteamAPI_ISteamNetworkingSockets_SetConnectionUserData( ISteamNetworkingSockets* self, HSteamNetConnection hPeer, int64 nUserData );
+S_API int64 SteamAPI_ISteamNetworkingSockets_GetConnectionUserData( ISteamNetworkingSockets* self, HSteamNetConnection hPeer );
+S_API void SteamAPI_ISteamNetworkingSockets_SetConnectionName( ISteamNetworkingSockets* self, HSteamNetConnection hPeer, const char * pszName );
+S_API bool SteamAPI_ISteamNetworkingSockets_GetConnectionName( ISteamNetworkingSockets* self, HSteamNetConnection hPeer, char * pszName, int nMaxLen );
+S_API EResult SteamAPI_ISteamNetworkingSockets_SendMessageToConnection( ISteamNetworkingSockets* self, HSteamNetConnection hConn, const void * pData, uint32 cbData, int nSendFlags, int64 * pOutMessageNumber );
+S_API void SteamAPI_ISteamNetworkingSockets_SendMessages( ISteamNetworkingSockets* self, int nMessages, SteamNetworkingMessage_t *const * pMessages, int64 * pOutMessageNumberOrResult );
+S_API EResult SteamAPI_ISteamNetworkingSockets_FlushMessagesOnConnection( ISteamNetworkingSockets* self, HSteamNetConnection hConn );
+S_API int SteamAPI_ISteamNetworkingSockets_ReceiveMessagesOnConnection( ISteamNetworkingSockets* self, HSteamNetConnection hConn, SteamNetworkingMessage_t ** ppOutMessages, int nMaxMessages );
+S_API bool SteamAPI_ISteamNetworkingSockets_GetConnectionInfo( ISteamNetworkingSockets* self, HSteamNetConnection hConn, SteamNetConnectionInfo_t * pInfo );
+S_API bool SteamAPI_ISteamNetworkingSockets_GetQuickConnectionStatus( ISteamNetworkingSockets* self, HSteamNetConnection hConn, SteamNetworkingQuickConnectionStatus * pStats );
+S_API int SteamAPI_ISteamNetworkingSockets_GetDetailedConnectionStatus( ISteamNetworkingSockets* self, HSteamNetConnection hConn, char * pszBuf, int cbBuf );
+S_API bool SteamAPI_ISteamNetworkingSockets_GetListenSocketAddress( ISteamNetworkingSockets* self, HSteamListenSocket hSocket, SteamNetworkingIPAddr * address );
+S_API bool SteamAPI_ISteamNetworkingSockets_CreateSocketPair( ISteamNetworkingSockets* self, HSteamNetConnection * pOutConnection1, HSteamNetConnection * pOutConnection2, bool bUseNetworkLoopback, const SteamNetworkingIdentity * pIdentity1, const SteamNetworkingIdentity * pIdentity2 );
+S_API bool SteamAPI_ISteamNetworkingSockets_GetIdentity( ISteamNetworkingSockets* self, SteamNetworkingIdentity * pIdentity );
+S_API ESteamNetworkingAvailability SteamAPI_ISteamNetworkingSockets_InitAuthentication( ISteamNetworkingSockets* self );
+S_API ESteamNetworkingAvailability SteamAPI_ISteamNetworkingSockets_GetAuthenticationStatus( ISteamNetworkingSockets* self, SteamNetAuthenticationStatus_t * pDetails );
+S_API HSteamNetPollGroup SteamAPI_ISteamNetworkingSockets_CreatePollGroup( ISteamNetworkingSockets* self );
+S_API bool SteamAPI_ISteamNetworkingSockets_DestroyPollGroup( ISteamNetworkingSockets* self, HSteamNetPollGroup hPollGroup );
+S_API bool SteamAPI_ISteamNetworkingSockets_SetConnectionPollGroup( ISteamNetworkingSockets* self, HSteamNetConnection hConn, HSteamNetPollGroup hPollGroup );
+S_API int SteamAPI_ISteamNetworkingSockets_ReceiveMessagesOnPollGroup( ISteamNetworkingSockets* self, HSteamNetPollGroup hPollGroup, SteamNetworkingMessage_t ** ppOutMessages, int nMaxMessages );
+S_API bool SteamAPI_ISteamNetworkingSockets_ReceivedRelayAuthTicket( ISteamNetworkingSockets* self, const void * pvTicket, int cbTicket, SteamDatagramRelayAuthTicket * pOutParsedTicket );
+S_API int SteamAPI_ISteamNetworkingSockets_FindRelayAuthTicketForServer( ISteamNetworkingSockets* self, const SteamNetworkingIdentity & identityGameServer, int nVirtualPort, SteamDatagramRelayAuthTicket * pOutParsedTicket );
+S_API HSteamNetConnection SteamAPI_ISteamNetworkingSockets_ConnectToHostedDedicatedServer( ISteamNetworkingSockets* self, const SteamNetworkingIdentity & identityTarget, int nVirtualPort, int nOptions, const SteamNetworkingConfigValue_t * pOptions );
+S_API uint16 SteamAPI_ISteamNetworkingSockets_GetHostedDedicatedServerPort( ISteamNetworkingSockets* self );
+S_API SteamNetworkingPOPID SteamAPI_ISteamNetworkingSockets_GetHostedDedicatedServerPOPID( ISteamNetworkingSockets* self );
+S_API EResult SteamAPI_ISteamNetworkingSockets_GetHostedDedicatedServerAddress( ISteamNetworkingSockets* self, SteamDatagramHostedAddress * pRouting );
+S_API HSteamListenSocket SteamAPI_ISteamNetworkingSockets_CreateHostedDedicatedServerListenSocket( ISteamNetworkingSockets* self, int nVirtualPort, int nOptions, const SteamNetworkingConfigValue_t * pOptions );
+S_API EResult SteamAPI_ISteamNetworkingSockets_GetGameCoordinatorServerLogin( ISteamNetworkingSockets* self, SteamDatagramGameCoordinatorServerLogin * pLoginInfo, int * pcbSignedBlob, void * pBlob );
+S_API HSteamNetConnection SteamAPI_ISteamNetworkingSockets_ConnectP2PCustomSignaling( ISteamNetworkingSockets* self, ISteamNetworkingConnectionCustomSignaling * pSignaling, const SteamNetworkingIdentity * pPeerIdentity, int nOptions, const SteamNetworkingConfigValue_t * pOptions );
+S_API bool SteamAPI_ISteamNetworkingSockets_ReceivedP2PCustomSignal( ISteamNetworkingSockets* self, const void * pMsg, int cbMsg, ISteamNetworkingCustomSignalingRecvContext * pContext );
+S_API bool SteamAPI_ISteamNetworkingSockets_GetCertificateRequest( ISteamNetworkingSockets* self, int * pcbBlob, void * pBlob, SteamNetworkingErrMsg & errMsg );
+S_API bool SteamAPI_ISteamNetworkingSockets_SetCertificate( ISteamNetworkingSockets* self, const void * pCertificate, int cbCertificate, SteamNetworkingErrMsg & errMsg );
+
+// ISteamNetworkingConnectionCustomSignaling
+S_API bool SteamAPI_ISteamNetworkingConnectionCustomSignaling_SendSignal( ISteamNetworkingConnectionCustomSignaling* self, HSteamNetConnection hConn, const SteamNetConnectionInfo_t & info, const void * pMsg, int cbMsg );
+S_API void SteamAPI_ISteamNetworkingConnectionCustomSignaling_Release( ISteamNetworkingConnectionCustomSignaling* self );
+
+// ISteamNetworkingCustomSignalingRecvContext
+S_API ISteamNetworkingConnectionCustomSignaling * SteamAPI_ISteamNetworkingCustomSignalingRecvContext_OnConnectRequest( ISteamNetworkingCustomSignalingRecvContext* self, HSteamNetConnection hConn, const SteamNetworkingIdentity & identityPeer );
+S_API void SteamAPI_ISteamNetworkingCustomSignalingRecvContext_SendRejectionSignal( ISteamNetworkingCustomSignalingRecvContext* self, const SteamNetworkingIdentity & identityPeer, const void * pMsg, int cbMsg );
+
+// ISteamNetworkingUtils
+S_API ISteamNetworkingUtils *SteamAPI_SteamNetworkingUtils_v003();
+S_API SteamNetworkingMessage_t * SteamAPI_ISteamNetworkingUtils_AllocateMessage( ISteamNetworkingUtils* self, int cbAllocateBuffer );
+S_API void SteamAPI_ISteamNetworkingUtils_InitRelayNetworkAccess( ISteamNetworkingUtils* self );
+S_API ESteamNetworkingAvailability SteamAPI_ISteamNetworkingUtils_GetRelayNetworkStatus( ISteamNetworkingUtils* self, SteamRelayNetworkStatus_t * pDetails );
+S_API float SteamAPI_ISteamNetworkingUtils_GetLocalPingLocation( ISteamNetworkingUtils* self, SteamNetworkPingLocation_t & result );
+S_API int SteamAPI_ISteamNetworkingUtils_EstimatePingTimeBetweenTwoLocations( ISteamNetworkingUtils* self, const SteamNetworkPingLocation_t & location1, const SteamNetworkPingLocation_t & location2 );
+S_API int SteamAPI_ISteamNetworkingUtils_EstimatePingTimeFromLocalHost( ISteamNetworkingUtils* self, const SteamNetworkPingLocation_t & remoteLocation );
+S_API void SteamAPI_ISteamNetworkingUtils_ConvertPingLocationToString( ISteamNetworkingUtils* self, const SteamNetworkPingLocation_t & location, char * pszBuf, int cchBufSize );
+S_API bool SteamAPI_ISteamNetworkingUtils_ParsePingLocationString( ISteamNetworkingUtils* self, const char * pszString, SteamNetworkPingLocation_t & result );
+S_API bool SteamAPI_ISteamNetworkingUtils_CheckPingDataUpToDate( ISteamNetworkingUtils* self, float flMaxAgeSeconds );
+S_API int SteamAPI_ISteamNetworkingUtils_GetPingToDataCenter( ISteamNetworkingUtils* self, SteamNetworkingPOPID popID, SteamNetworkingPOPID * pViaRelayPoP );
+S_API int SteamAPI_ISteamNetworkingUtils_GetDirectPingToPOP( ISteamNetworkingUtils* self, SteamNetworkingPOPID popID );
+S_API int SteamAPI_ISteamNetworkingUtils_GetPOPCount( ISteamNetworkingUtils* self );
+S_API int SteamAPI_ISteamNetworkingUtils_GetPOPList( ISteamNetworkingUtils* self, SteamNetworkingPOPID * list, int nListSz );
+S_API SteamNetworkingMicroseconds SteamAPI_ISteamNetworkingUtils_GetLocalTimestamp( ISteamNetworkingUtils* self );
+S_API void SteamAPI_ISteamNetworkingUtils_SetDebugOutputFunction( ISteamNetworkingUtils* self, ESteamNetworkingSocketsDebugOutputType eDetailLevel, FSteamNetworkingSocketsDebugOutput pfnFunc );
+S_API bool SteamAPI_ISteamNetworkingUtils_SetGlobalConfigValueInt32( ISteamNetworkingUtils* self, ESteamNetworkingConfigValue eValue, int32 val );
+S_API bool SteamAPI_ISteamNetworkingUtils_SetGlobalConfigValueFloat( ISteamNetworkingUtils* self, ESteamNetworkingConfigValue eValue, float val );
+S_API bool SteamAPI_ISteamNetworkingUtils_SetGlobalConfigValueString( ISteamNetworkingUtils* self, ESteamNetworkingConfigValue eValue, const char * val );
+S_API bool SteamAPI_ISteamNetworkingUtils_SetConnectionConfigValueInt32( ISteamNetworkingUtils* self, HSteamNetConnection hConn, ESteamNetworkingConfigValue eValue, int32 val );
+S_API bool SteamAPI_ISteamNetworkingUtils_SetConnectionConfigValueFloat( ISteamNetworkingUtils* self, HSteamNetConnection hConn, ESteamNetworkingConfigValue eValue, float val );
+S_API bool SteamAPI_ISteamNetworkingUtils_SetConnectionConfigValueString( ISteamNetworkingUtils* self, HSteamNetConnection hConn, ESteamNetworkingConfigValue eValue, const char * val );
+S_API bool SteamAPI_ISteamNetworkingUtils_SetConfigValue( ISteamNetworkingUtils* self, ESteamNetworkingConfigValue eValue, ESteamNetworkingConfigScope eScopeType, intptr_t scopeObj, ESteamNetworkingConfigDataType eDataType, const void * pArg );
+S_API bool SteamAPI_ISteamNetworkingUtils_SetConfigValueStruct( ISteamNetworkingUtils* self, const SteamNetworkingConfigValue_t & opt, ESteamNetworkingConfigScope eScopeType, intptr_t scopeObj );
+S_API ESteamNetworkingGetConfigValueResult SteamAPI_ISteamNetworkingUtils_GetConfigValue( ISteamNetworkingUtils* self, ESteamNetworkingConfigValue eValue, ESteamNetworkingConfigScope eScopeType, intptr_t scopeObj, ESteamNetworkingConfigDataType * pOutDataType, void * pResult, size_t * cbResult );
+S_API bool SteamAPI_ISteamNetworkingUtils_GetConfigValueInfo( ISteamNetworkingUtils* self, ESteamNetworkingConfigValue eValue, const char ** pOutName, ESteamNetworkingConfigDataType * pOutDataType, ESteamNetworkingConfigScope * pOutScope, ESteamNetworkingConfigValue * pOutNextValue );
+S_API ESteamNetworkingConfigValue SteamAPI_ISteamNetworkingUtils_GetFirstConfigValue( ISteamNetworkingUtils* self );
+S_API void SteamAPI_ISteamNetworkingUtils_SteamNetworkingIPAddr_ToString( ISteamNetworkingUtils* self, const SteamNetworkingIPAddr & addr, char * buf, uint32 cbBuf, bool bWithPort );
+S_API bool SteamAPI_ISteamNetworkingUtils_SteamNetworkingIPAddr_ParseString( ISteamNetworkingUtils* self, SteamNetworkingIPAddr * pAddr, const char * pszStr );
+S_API void SteamAPI_ISteamNetworkingUtils_SteamNetworkingIdentity_ToString( ISteamNetworkingUtils* self, const SteamNetworkingIdentity & identity, char * buf, uint32 cbBuf );
+S_API bool SteamAPI_ISteamNetworkingUtils_SteamNetworkingIdentity_ParseString( ISteamNetworkingUtils* self, SteamNetworkingIdentity * pIdentity, const char * pszStr );
+
+// ISteamGameServer
+S_API ISteamGameServer *SteamAPI_SteamGameServer_v013();
+S_API void SteamAPI_ISteamGameServer_SetProduct( ISteamGameServer* self, const char * pszProduct );
+S_API void SteamAPI_ISteamGameServer_SetGameDescription( ISteamGameServer* self, const char * pszGameDescription );
+S_API void SteamAPI_ISteamGameServer_SetModDir( ISteamGameServer* self, const char * pszModDir );
+S_API void SteamAPI_ISteamGameServer_SetDedicatedServer( ISteamGameServer* self, bool bDedicated );
+S_API void SteamAPI_ISteamGameServer_LogOn( ISteamGameServer* self, const char * pszToken );
+S_API void SteamAPI_ISteamGameServer_LogOnAnonymous( ISteamGameServer* self );
+S_API void SteamAPI_ISteamGameServer_LogOff( ISteamGameServer* self );
+S_API bool SteamAPI_ISteamGameServer_BLoggedOn( ISteamGameServer* self );
+S_API bool SteamAPI_ISteamGameServer_BSecure( ISteamGameServer* self );
+S_API uint64_steamid SteamAPI_ISteamGameServer_GetSteamID( ISteamGameServer* self );
+S_API bool SteamAPI_ISteamGameServer_WasRestartRequested( ISteamGameServer* self );
+S_API void SteamAPI_ISteamGameServer_SetMaxPlayerCount( ISteamGameServer* self, int cPlayersMax );
+S_API void SteamAPI_ISteamGameServer_SetBotPlayerCount( ISteamGameServer* self, int cBotplayers );
+S_API void SteamAPI_ISteamGameServer_SetServerName( ISteamGameServer* self, const char * pszServerName );
+S_API void SteamAPI_ISteamGameServer_SetMapName( ISteamGameServer* self, const char * pszMapName );
+S_API void SteamAPI_ISteamGameServer_SetPasswordProtected( ISteamGameServer* self, bool bPasswordProtected );
+S_API void SteamAPI_ISteamGameServer_SetSpectatorPort( ISteamGameServer* self, uint16 unSpectatorPort );
+S_API void SteamAPI_ISteamGameServer_SetSpectatorServerName( ISteamGameServer* self, const char * pszSpectatorServerName );
+S_API void SteamAPI_ISteamGameServer_ClearAllKeyValues( ISteamGameServer* self );
+S_API void SteamAPI_ISteamGameServer_SetKeyValue( ISteamGameServer* self, const char * pKey, const char * pValue );
+S_API void SteamAPI_ISteamGameServer_SetGameTags( ISteamGameServer* self, const char * pchGameTags );
+S_API void SteamAPI_ISteamGameServer_SetGameData( ISteamGameServer* self, const char * pchGameData );
+S_API void SteamAPI_ISteamGameServer_SetRegion( ISteamGameServer* self, const char * pszRegion );
+S_API bool SteamAPI_ISteamGameServer_SendUserConnectAndAuthenticate( ISteamGameServer* self, uint32 unIPClient, const void * pvAuthBlob, uint32 cubAuthBlobSize, CSteamID * pSteamIDUser );
+S_API uint64_steamid SteamAPI_ISteamGameServer_CreateUnauthenticatedUserConnection( ISteamGameServer* self );
+S_API void SteamAPI_ISteamGameServer_SendUserDisconnect( ISteamGameServer* self, uint64_steamid steamIDUser );
+S_API bool SteamAPI_ISteamGameServer_BUpdateUserData( ISteamGameServer* self, uint64_steamid steamIDUser, const char * pchPlayerName, uint32 uScore );
+S_API HAuthTicket SteamAPI_ISteamGameServer_GetAuthSessionTicket( ISteamGameServer* self, void * pTicket, int cbMaxTicket, uint32 * pcbTicket );
+S_API EBeginAuthSessionResult SteamAPI_ISteamGameServer_BeginAuthSession( ISteamGameServer* self, const void * pAuthTicket, int cbAuthTicket, uint64_steamid steamID );
+S_API void SteamAPI_ISteamGameServer_EndAuthSession( ISteamGameServer* self, uint64_steamid steamID );
+S_API void SteamAPI_ISteamGameServer_CancelAuthTicket( ISteamGameServer* self, HAuthTicket hAuthTicket );
+S_API EUserHasLicenseForAppResult SteamAPI_ISteamGameServer_UserHasLicenseForApp( ISteamGameServer* self, uint64_steamid steamID, AppId_t appID );
+S_API bool SteamAPI_ISteamGameServer_RequestUserGroupStatus( ISteamGameServer* self, uint64_steamid steamIDUser, uint64_steamid steamIDGroup );
+S_API void SteamAPI_ISteamGameServer_GetGameplayStats( ISteamGameServer* self );
+S_API SteamAPICall_t SteamAPI_ISteamGameServer_GetServerReputation( ISteamGameServer* self );
+S_API SteamIPAddress_t SteamAPI_ISteamGameServer_GetPublicIP( ISteamGameServer* self );
+S_API bool SteamAPI_ISteamGameServer_HandleIncomingPacket( ISteamGameServer* self, const void * pData, int cbData, uint32 srcIP, uint16 srcPort );
+S_API int SteamAPI_ISteamGameServer_GetNextOutgoingPacket( ISteamGameServer* self, void * pOut, int cbMaxOut, uint32 * pNetAdr, uint16 * pPort );
+S_API void SteamAPI_ISteamGameServer_EnableHeartbeats( ISteamGameServer* self, bool bActive );
+S_API void SteamAPI_ISteamGameServer_SetHeartbeatInterval( ISteamGameServer* self, int iHeartbeatInterval );
+S_API void SteamAPI_ISteamGameServer_ForceHeartbeat( ISteamGameServer* self );
+S_API SteamAPICall_t SteamAPI_ISteamGameServer_AssociateWithClan( ISteamGameServer* self, uint64_steamid steamIDClan );
+S_API SteamAPICall_t SteamAPI_ISteamGameServer_ComputeNewPlayerCompatibility( ISteamGameServer* self, uint64_steamid steamIDNewPlayer );
+
+// ISteamGameServerStats
+S_API ISteamGameServerStats *SteamAPI_SteamGameServerStats_v001();
+S_API SteamAPICall_t SteamAPI_ISteamGameServerStats_RequestUserStats( ISteamGameServerStats* self, uint64_steamid steamIDUser );
+S_API bool SteamAPI_ISteamGameServerStats_GetUserStatInt32( ISteamGameServerStats* self, uint64_steamid steamIDUser, const char * pchName, int32 * pData );
+S_API bool SteamAPI_ISteamGameServerStats_GetUserStatFloat( ISteamGameServerStats* self, uint64_steamid steamIDUser, const char * pchName, float * pData );
+S_API bool SteamAPI_ISteamGameServerStats_GetUserAchievement( ISteamGameServerStats* self, uint64_steamid steamIDUser, const char * pchName, bool * pbAchieved );
+S_API bool SteamAPI_ISteamGameServerStats_SetUserStatInt32( ISteamGameServerStats* self, uint64_steamid steamIDUser, const char * pchName, int32 nData );
+S_API bool SteamAPI_ISteamGameServerStats_SetUserStatFloat( ISteamGameServerStats* self, uint64_steamid steamIDUser, const char * pchName, float fData );
+S_API bool SteamAPI_ISteamGameServerStats_UpdateUserAvgRateStat( ISteamGameServerStats* self, uint64_steamid steamIDUser, const char * pchName, float flCountThisSession, double dSessionLength );
+S_API bool SteamAPI_ISteamGameServerStats_SetUserAchievement( ISteamGameServerStats* self, uint64_steamid steamIDUser, const char * pchName );
+S_API bool SteamAPI_ISteamGameServerStats_ClearUserAchievement( ISteamGameServerStats* self, uint64_steamid steamIDUser, const char * pchName );
+S_API SteamAPICall_t SteamAPI_ISteamGameServerStats_StoreUserStats( ISteamGameServerStats* self, uint64_steamid steamIDUser );
+
+// SteamIPAddress_t
+S_API bool SteamAPI_SteamIPAddress_t_IsSet( SteamIPAddress_t* self );
+
+// MatchMakingKeyValuePair_t
+S_API void SteamAPI_MatchMakingKeyValuePair_t_Construct( MatchMakingKeyValuePair_t* self );
+
+// servernetadr_t
+S_API void SteamAPI_servernetadr_t_Construct( servernetadr_t* self );
+S_API void SteamAPI_servernetadr_t_Init( servernetadr_t* self, unsigned int ip, uint16 usQueryPort, uint16 usConnectionPort );
+S_API uint16 SteamAPI_servernetadr_t_GetQueryPort( servernetadr_t* self );
+S_API void SteamAPI_servernetadr_t_SetQueryPort( servernetadr_t* self, uint16 usPort );
+S_API uint16 SteamAPI_servernetadr_t_GetConnectionPort( servernetadr_t* self );
+S_API void SteamAPI_servernetadr_t_SetConnectionPort( servernetadr_t* self, uint16 usPort );
+S_API uint32 SteamAPI_servernetadr_t_GetIP( servernetadr_t* self );
+S_API void SteamAPI_servernetadr_t_SetIP( servernetadr_t* self, uint32 unIP );
+S_API const char * SteamAPI_servernetadr_t_GetConnectionAddressString( servernetadr_t* self );
+S_API const char * SteamAPI_servernetadr_t_GetQueryAddressString( servernetadr_t* self );
+S_API bool SteamAPI_servernetadr_t_IsLessThan( servernetadr_t* self, const servernetadr_t & netadr );
+S_API void SteamAPI_servernetadr_t_Assign( servernetadr_t* self, const servernetadr_t & that );
+
+// gameserveritem_t
+S_API void SteamAPI_gameserveritem_t_Construct( gameserveritem_t* self );
+S_API const char * SteamAPI_gameserveritem_t_GetName( gameserveritem_t* self );
+S_API void SteamAPI_gameserveritem_t_SetName( gameserveritem_t* self, const char * pName );
+
+// SteamNetworkingIPAddr
+S_API void SteamAPI_SteamNetworkingIPAddr_Clear( SteamNetworkingIPAddr* self );
+S_API bool SteamAPI_SteamNetworkingIPAddr_IsIPv6AllZeros( SteamNetworkingIPAddr* self );
+S_API void SteamAPI_SteamNetworkingIPAddr_SetIPv6( SteamNetworkingIPAddr* self, const uint8 * ipv6, uint16 nPort );
+S_API void SteamAPI_SteamNetworkingIPAddr_SetIPv4( SteamNetworkingIPAddr* self, uint32 nIP, uint16 nPort );
+S_API bool SteamAPI_SteamNetworkingIPAddr_IsIPv4( SteamNetworkingIPAddr* self );
+S_API uint32 SteamAPI_SteamNetworkingIPAddr_GetIPv4( SteamNetworkingIPAddr* self );
+S_API void SteamAPI_SteamNetworkingIPAddr_SetIPv6LocalHost( SteamNetworkingIPAddr* self, uint16 nPort );
+S_API bool SteamAPI_SteamNetworkingIPAddr_IsLocalHost( SteamNetworkingIPAddr* self );
+S_API void SteamAPI_SteamNetworkingIPAddr_ToString( SteamNetworkingIPAddr* self, char * buf, uint32 cbBuf, bool bWithPort );
+S_API bool SteamAPI_SteamNetworkingIPAddr_ParseString( SteamNetworkingIPAddr* self, const char * pszStr );
+S_API bool SteamAPI_SteamNetworkingIPAddr_IsEqualTo( SteamNetworkingIPAddr* self, const SteamNetworkingIPAddr & x );
+
+// SteamNetworkingIdentity
+S_API void SteamAPI_SteamNetworkingIdentity_Clear( SteamNetworkingIdentity* self );
+S_API bool SteamAPI_SteamNetworkingIdentity_IsInvalid( SteamNetworkingIdentity* self );
+S_API void SteamAPI_SteamNetworkingIdentity_SetSteamID( SteamNetworkingIdentity* self, uint64_steamid steamID );
+S_API uint64_steamid SteamAPI_SteamNetworkingIdentity_GetSteamID( SteamNetworkingIdentity* self );
+S_API void SteamAPI_SteamNetworkingIdentity_SetSteamID64( SteamNetworkingIdentity* self, uint64 steamID );
+S_API uint64 SteamAPI_SteamNetworkingIdentity_GetSteamID64( SteamNetworkingIdentity* self );
+S_API bool SteamAPI_SteamNetworkingIdentity_SetXboxPairwiseID( SteamNetworkingIdentity* self, const char * pszString );
+S_API const char * SteamAPI_SteamNetworkingIdentity_GetXboxPairwiseID( SteamNetworkingIdentity* self );
+S_API void SteamAPI_SteamNetworkingIdentity_SetIPAddr( SteamNetworkingIdentity* self, const SteamNetworkingIPAddr & addr );
+S_API const SteamNetworkingIPAddr * SteamAPI_SteamNetworkingIdentity_GetIPAddr( SteamNetworkingIdentity* self );
+S_API void SteamAPI_SteamNetworkingIdentity_SetLocalHost( SteamNetworkingIdentity* self );
+S_API bool SteamAPI_SteamNetworkingIdentity_IsLocalHost( SteamNetworkingIdentity* self );
+S_API bool SteamAPI_SteamNetworkingIdentity_SetGenericString( SteamNetworkingIdentity* self, const char * pszString );
+S_API const char * SteamAPI_SteamNetworkingIdentity_GetGenericString( SteamNetworkingIdentity* self );
+S_API bool SteamAPI_SteamNetworkingIdentity_SetGenericBytes( SteamNetworkingIdentity* self, const void * data, uint32 cbLen );
+S_API const uint8 * SteamAPI_SteamNetworkingIdentity_GetGenericBytes( SteamNetworkingIdentity* self, int & cbLen );
+S_API bool SteamAPI_SteamNetworkingIdentity_IsEqualTo( SteamNetworkingIdentity* self, const SteamNetworkingIdentity & x );
+S_API void SteamAPI_SteamNetworkingIdentity_ToString( SteamNetworkingIdentity* self, char * buf, uint32 cbBuf );
+S_API bool SteamAPI_SteamNetworkingIdentity_ParseString( SteamNetworkingIdentity* self, const char * pszStr );
+
+// SteamNetworkingMessage_t
+S_API void SteamAPI_SteamNetworkingMessage_t_Release( SteamNetworkingMessage_t* self );
+
+// SteamDatagramHostedAddress
+S_API void SteamAPI_SteamDatagramHostedAddress_Clear( SteamDatagramHostedAddress* self );
+S_API SteamNetworkingPOPID SteamAPI_SteamDatagramHostedAddress_GetPopID( SteamDatagramHostedAddress* self );
+S_API void SteamAPI_SteamDatagramHostedAddress_SetDevAddress( SteamDatagramHostedAddress* self, uint32 nIP, uint16 nPort, SteamNetworkingPOPID popid );
+#endif // STEAMAPIFLAT_H

--- a/lsteamclient/steamworks_sdk_148a/steam_api_internal.h
+++ b/lsteamclient/steamworks_sdk_148a/steam_api_internal.h
@@ -1,0 +1,410 @@
+//====== Copyright Valve Corporation, All rights reserved. ====================
+//
+// Internal implementation details of the steamworks SDK.
+//
+// You should be able to figure out how to use the SDK by reading
+// steam_api_common.h, and should not need to understand anything in here.
+// 
+//-----------------------------------------------------------------------------
+
+#ifdef STEAM_CALLBACK_BEGIN
+#error "This file should only be included from steam_api_common.h"
+#endif
+
+#include <string.h>
+
+// Internal functions used to locate/create interfaces
+S_API HSteamPipe S_CALLTYPE SteamAPI_GetHSteamPipe();
+S_API HSteamUser S_CALLTYPE SteamAPI_GetHSteamUser();
+S_API HSteamPipe S_CALLTYPE SteamGameServer_GetHSteamPipe();
+S_API HSteamUser S_CALLTYPE SteamGameServer_GetHSteamUser();
+S_API void *S_CALLTYPE SteamInternal_ContextInit( void *pContextInitData );
+S_API void *S_CALLTYPE SteamInternal_CreateInterface( const char *ver );
+S_API void *S_CALLTYPE SteamInternal_FindOrCreateUserInterface( HSteamUser hSteamUser, const char *pszVersion );
+S_API void *S_CALLTYPE SteamInternal_FindOrCreateGameServerInterface( HSteamUser hSteamUser, const char *pszVersion );
+
+// Macro used to define a type-safe accessor that will always return the version
+// of the interface of the *header file* you are compiling with!  We also bounce
+// through a safety function that checks for interfaces being created or destroyed.
+//
+// SteamInternal_ContextInit takes a base pointer for the equivalent of
+// struct { void (*pFn)(void* pCtx); uintptr_t counter; void *ptr; }
+// Do not change layout or add non-pointer aligned data!
+#define STEAM_DEFINE_INTERFACE_ACCESSOR( type, name, expr, kind, version ) \
+	inline void S_CALLTYPE SteamInternal_Init_ ## name( type *p ) { *p = (type)( expr ); } \
+	STEAM_CLANG_ATTR( "interface_accessor_kind:" kind ";interface_accessor_version:" version ";" ) \
+	inline type name() { \
+		static void* s_CallbackCounterAndContext[ 3 ] = { (void*)&SteamInternal_Init_ ## name, 0, 0 }; \
+		return *(type*)SteamInternal_ContextInit( s_CallbackCounterAndContext ); \
+	}
+
+#define STEAM_DEFINE_USER_INTERFACE_ACCESSOR( type, name, version ) \
+	STEAM_DEFINE_INTERFACE_ACCESSOR( type, name, SteamInternal_FindOrCreateUserInterface( SteamAPI_GetHSteamUser(), version ), "user", version )
+#define STEAM_DEFINE_GAMESERVER_INTERFACE_ACCESSOR( type, name, version ) \
+	STEAM_DEFINE_INTERFACE_ACCESSOR( type, name, SteamInternal_FindOrCreateGameServerInterface( SteamGameServer_GetHSteamUser(), version ), "gameserver", version )
+
+//
+// Internal stuff used for the standard, higher-level callback mechanism
+//
+
+// Internal functions used by the utility CCallback objects to receive callbacks
+S_API void S_CALLTYPE SteamAPI_RegisterCallback( class CCallbackBase *pCallback, int iCallback );
+S_API void S_CALLTYPE SteamAPI_UnregisterCallback( class CCallbackBase *pCallback );
+// Internal functions used by the utility CCallResult objects to receive async call results
+S_API void S_CALLTYPE SteamAPI_RegisterCallResult( class CCallbackBase *pCallback, SteamAPICall_t hAPICall );
+S_API void S_CALLTYPE SteamAPI_UnregisterCallResult( class CCallbackBase *pCallback, SteamAPICall_t hAPICall );
+
+// disable this warning; this pattern need for steam callback registration
+#ifdef _MSVC_VER
+#pragma warning( push )
+#pragma warning( disable: 4355 )	// 'this' : used in base member initializer list
+#endif
+
+#define _STEAM_CALLBACK_AUTO_HOOK( thisclass, func, param )
+#define _STEAM_CALLBACK_HELPER( _1, _2, SELECTED, ... )		_STEAM_CALLBACK_##SELECTED
+#define _STEAM_CALLBACK_SELECT( X, Y )						_STEAM_CALLBACK_HELPER X Y
+#define _STEAM_CALLBACK_3( extra_code, thisclass, func, param ) \
+	struct CCallbackInternal_ ## func : private CCallbackImpl< sizeof( param ) > { \
+		CCallbackInternal_ ## func () { extra_code SteamAPI_RegisterCallback( this, param::k_iCallback ); } \
+		CCallbackInternal_ ## func ( const CCallbackInternal_ ## func & ) { extra_code SteamAPI_RegisterCallback( this, param::k_iCallback ); } \
+		CCallbackInternal_ ## func & operator=( const CCallbackInternal_ ## func & ) { return *this; } \
+		private: virtual void Run( void *pvParam ) { _STEAM_CALLBACK_AUTO_HOOK( thisclass, func, param ) \
+			thisclass *pOuter = reinterpret_cast<thisclass*>( reinterpret_cast<char*>(this) - offsetof( thisclass, m_steamcallback_ ## func ) ); \
+			pOuter->func( reinterpret_cast<param*>( pvParam ) ); \
+		} \
+	} m_steamcallback_ ## func ; void func( param *pParam )
+#define _STEAM_CALLBACK_4( _, thisclass, func, param, var ) \
+	CCallback< thisclass, param > var; void func( param *pParam )
+#define _STEAM_CALLBACK_GS( _, thisclass, func, param, var ) \
+	CCallback< thisclass, param, true > var; void func( param *pParam )
+
+#ifndef API_GEN
+
+template< class T, class P >
+inline CCallResult<T, P>::CCallResult()
+{
+	m_hAPICall = k_uAPICallInvalid;
+	m_pObj = nullptr;
+	m_Func = nullptr;
+	m_iCallback = P::k_iCallback;
+}
+
+template< class T, class P >
+inline void CCallResult<T, P>::Set( SteamAPICall_t hAPICall, T *p, func_t func )
+{
+	if ( m_hAPICall )
+		SteamAPI_UnregisterCallResult( this, m_hAPICall );
+
+	m_hAPICall = hAPICall;
+	m_pObj = p;
+	m_Func = func;
+
+	if ( hAPICall )
+		SteamAPI_RegisterCallResult( this, hAPICall );
+}
+
+template< class T, class P >
+inline bool CCallResult<T, P>::IsActive() const
+{
+	return (m_hAPICall != k_uAPICallInvalid);
+}
+
+template< class T, class P >
+inline void CCallResult<T, P>::Cancel()
+{
+	if ( m_hAPICall != k_uAPICallInvalid )
+	{
+		SteamAPI_UnregisterCallResult( this, m_hAPICall );
+		m_hAPICall = k_uAPICallInvalid;
+	}
+}
+
+template< class T, class P >
+inline CCallResult<T, P>::~CCallResult()
+{
+	Cancel();
+}
+
+template< class T, class P >
+inline void CCallResult<T, P>::Run( void *pvParam )
+{
+	m_hAPICall = k_uAPICallInvalid; // caller unregisters for us
+	(m_pObj->*m_Func)((P *)pvParam, false);
+}
+
+template< class T, class P >
+inline void CCallResult<T, P>::Run( void *pvParam, bool bIOFailure, SteamAPICall_t hSteamAPICall )
+{
+	if ( hSteamAPICall == m_hAPICall )
+	{
+		m_hAPICall = k_uAPICallInvalid; // caller unregisters for us
+		(m_pObj->*m_Func)((P *)pvParam, bIOFailure);
+	}
+}
+
+template< class T, class P, bool bGameserver >
+inline CCallback< T, P, bGameserver >::CCallback( T *pObj, func_t func )
+	: m_pObj( nullptr ), m_Func( nullptr )
+{
+	if ( bGameserver )
+	{
+		this->SetGameserverFlag();
+	}
+	Register( pObj, func );
+}
+
+template< class T, class P, bool bGameserver >
+inline void CCallback< T, P, bGameserver >::Register( T *pObj, func_t func )
+{
+	if ( !pObj || !func )
+		return;
+
+	if ( this->m_nCallbackFlags & CCallbackBase::k_ECallbackFlagsRegistered )
+		Unregister();
+
+	m_pObj = pObj;
+	m_Func = func;
+	// SteamAPI_RegisterCallback sets k_ECallbackFlagsRegistered
+	SteamAPI_RegisterCallback( this, P::k_iCallback );
+}
+
+template< class T, class P, bool bGameserver >
+inline void CCallback< T, P, bGameserver >::Unregister()
+{
+	// SteamAPI_UnregisterCallback removes k_ECallbackFlagsRegistered
+	SteamAPI_UnregisterCallback( this );
+}
+
+template< class T, class P, bool bGameserver >
+inline void CCallback< T, P, bGameserver >::Run( void *pvParam )
+{
+	(m_pObj->*m_Func)((P *)pvParam);
+}
+
+#endif // #ifndef API_GEN
+
+// structure that contains client callback data
+// see callbacks documentation for more details
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error steam_api_common.h should define VALVE_CALLBACK_PACK_xxx
+#endif 
+
+/// Internal structure used in manual callback dispatch
+struct CallbackMsg_t
+{
+	HSteamUser m_hSteamUser; // Specific user to whom this callback applies.
+	int m_iCallback; // Callback identifier.  (Corresponds to the k_iCallback enum in the callback structure.)
+	uint8 *m_pubParam; // Points to the callback structure
+	int m_cubParam; // Size of the data pointed to by m_pubParam
+};
+#pragma pack( pop )
+
+// Macros to define steam callback structures.  Used internally for debugging
+#ifdef STEAM_CALLBACK_INSPECTION_ENABLED
+	#include "../../clientdll/steam_api_callback_inspection.h"
+#else
+	#define STEAM_CALLBACK_BEGIN( callbackname, callbackid )	struct callbackname { enum { k_iCallback = callbackid };
+	#define STEAM_CALLBACK_MEMBER( varidx, vartype, varname )	vartype varname ; 
+	#define STEAM_CALLBACK_MEMBER_ARRAY( varidx, vartype, varname, varcount ) vartype varname [ varcount ];
+	#define STEAM_CALLBACK_END(nArgs) };
+#endif
+
+// Forward declare all of the Steam interfaces.  (Do we really need to do this?)
+class ISteamClient;
+class ISteamUser;
+class ISteamGameServer;
+class ISteamFriends;
+class ISteamUtils;
+class ISteamMatchmaking;
+class ISteamContentServer;
+class ISteamMatchmakingServers;
+class ISteamUserStats;
+class ISteamApps;
+class ISteamNetworking;
+class ISteamRemoteStorage;
+class ISteamScreenshots;
+class ISteamMusic;
+class ISteamMusicRemote;
+class ISteamGameServerStats;
+class ISteamPS3OverlayRender;
+class ISteamHTTP;
+class ISteamController;
+class ISteamUGC;
+class ISteamAppList;
+class ISteamHTMLSurface;
+class ISteamInventory;
+class ISteamVideo;
+class ISteamParentalSettings;
+class ISteamGameSearch;
+class ISteamInput;
+class ISteamParties;
+class ISteamTV;
+class ISteamRemotePlay;
+
+//-----------------------------------------------------------------------------
+// Purpose: Base values for callback identifiers, each callback must
+//			have a unique ID.
+//-----------------------------------------------------------------------------
+enum { k_iSteamUserCallbacks = 100 };
+enum { k_iSteamGameServerCallbacks = 200 };
+enum { k_iSteamFriendsCallbacks = 300 };
+enum { k_iSteamBillingCallbacks = 400 };
+enum { k_iSteamMatchmakingCallbacks = 500 };
+enum { k_iSteamContentServerCallbacks = 600 };
+enum { k_iSteamUtilsCallbacks = 700 };
+enum { k_iClientFriendsCallbacks = 800 };
+enum { k_iClientUserCallbacks = 900 };
+enum { k_iSteamAppsCallbacks = 1000 };
+enum { k_iSteamUserStatsCallbacks = 1100 };
+enum { k_iSteamNetworkingCallbacks = 1200 };
+enum { k_iSteamNetworkingSocketsCallbacks = 1220 };
+enum { k_iSteamNetworkingMessagesCallbacks = 1250 };
+enum { k_iSteamNetworkingUtilsCallbacks = 1280 };
+enum { k_iClientRemoteStorageCallbacks = 1300 };
+enum { k_iClientDepotBuilderCallbacks = 1400 };
+enum { k_iSteamGameServerItemsCallbacks = 1500 };
+enum { k_iClientUtilsCallbacks = 1600 };
+enum { k_iSteamGameCoordinatorCallbacks = 1700 };
+enum { k_iSteamGameServerStatsCallbacks = 1800 };
+enum { k_iSteam2AsyncCallbacks = 1900 };
+enum { k_iSteamGameStatsCallbacks = 2000 };
+enum { k_iClientHTTPCallbacks = 2100 };
+enum { k_iClientScreenshotsCallbacks = 2200 };
+enum { k_iSteamScreenshotsCallbacks = 2300 };
+enum { k_iClientAudioCallbacks = 2400 };
+enum { k_iClientUnifiedMessagesCallbacks = 2500 };
+enum { k_iSteamStreamLauncherCallbacks = 2600 };
+enum { k_iClientControllerCallbacks = 2700 };
+enum { k_iSteamControllerCallbacks = 2800 };
+enum { k_iClientParentalSettingsCallbacks = 2900 };
+enum { k_iClientDeviceAuthCallbacks = 3000 };
+enum { k_iClientNetworkDeviceManagerCallbacks = 3100 };
+enum { k_iClientMusicCallbacks = 3200 };
+enum { k_iClientRemoteClientManagerCallbacks = 3300 };
+enum { k_iClientUGCCallbacks = 3400 };
+enum { k_iSteamStreamClientCallbacks = 3500 };
+enum { k_IClientProductBuilderCallbacks = 3600 };
+enum { k_iClientShortcutsCallbacks = 3700 };
+enum { k_iClientRemoteControlManagerCallbacks = 3800 };
+enum { k_iSteamAppListCallbacks = 3900 };
+enum { k_iSteamMusicCallbacks = 4000 };
+enum { k_iSteamMusicRemoteCallbacks = 4100 };
+enum { k_iClientVRCallbacks = 4200 };
+enum { k_iClientGameNotificationCallbacks = 4300 }; 
+enum { k_iSteamGameNotificationCallbacks = 4400 }; 
+enum { k_iSteamHTMLSurfaceCallbacks = 4500 };
+enum { k_iClientVideoCallbacks = 4600 };
+enum { k_iClientInventoryCallbacks = 4700 };
+enum { k_iClientBluetoothManagerCallbacks = 4800 };
+enum { k_iClientSharedConnectionCallbacks = 4900 };
+enum { k_ISteamParentalSettingsCallbacks = 5000 };
+enum { k_iClientShaderCallbacks = 5100 };
+enum { k_iSteamGameSearchCallbacks = 5200 };
+enum { k_iSteamPartiesCallbacks = 5300 };
+enum { k_iClientPartiesCallbacks = 5400 };
+enum { k_iSteamSTARCallbacks = 5500 };
+enum { k_iClientSTARCallbacks = 5600 };
+enum { k_iSteamRemotePlayCallbacks = 5700 };
+enum { k_iClientCompatCallbacks = 5800 };
+
+#ifdef _MSVC_VER
+#pragma warning( pop )
+#endif
+
+// CSteamAPIContext encapsulates the Steamworks API global accessors into
+// a single object.
+//
+// DEPRECATED: Used the global interface accessors instead!
+//
+// This will be removed in a future iteration of the SDK
+class CSteamAPIContext
+{
+public:
+	CSteamAPIContext() { Clear(); }
+	inline void Clear() { memset( this, 0, sizeof(*this) ); }
+	inline bool Init(); // NOTE: This is defined in steam_api.h, to avoid this file having to include everything
+	ISteamClient*		SteamClient() const					{ return m_pSteamClient; }
+	ISteamUser*			SteamUser() const					{ return m_pSteamUser; }
+	ISteamFriends*		SteamFriends() const				{ return m_pSteamFriends; }
+	ISteamUtils*		SteamUtils() const					{ return m_pSteamUtils; }
+	ISteamMatchmaking*	SteamMatchmaking() const			{ return m_pSteamMatchmaking; }
+	ISteamGameSearch*	SteamGameSearch() const				{ return m_pSteamGameSearch; }
+	ISteamUserStats*	SteamUserStats() const				{ return m_pSteamUserStats; }
+	ISteamApps*			SteamApps() const					{ return m_pSteamApps; }
+	ISteamMatchmakingServers* SteamMatchmakingServers() const { return m_pSteamMatchmakingServers; }
+	ISteamNetworking*	SteamNetworking() const				{ return m_pSteamNetworking; }
+	ISteamRemoteStorage* SteamRemoteStorage() const			{ return m_pSteamRemoteStorage; }
+	ISteamScreenshots*	SteamScreenshots() const			{ return m_pSteamScreenshots; }
+	ISteamHTTP*			SteamHTTP() const					{ return m_pSteamHTTP; }
+	ISteamController*	SteamController() const				{ return m_pController; }
+	ISteamUGC*			SteamUGC() const					{ return m_pSteamUGC; }
+	ISteamAppList*		SteamAppList() const				{ return m_pSteamAppList; }
+	ISteamMusic*		SteamMusic() const					{ return m_pSteamMusic; }
+	ISteamMusicRemote*	SteamMusicRemote() const			{ return m_pSteamMusicRemote; }
+	ISteamHTMLSurface*	SteamHTMLSurface() const			{ return m_pSteamHTMLSurface; }
+	ISteamInventory*	SteamInventory() const				{ return m_pSteamInventory; }
+	ISteamVideo*		SteamVideo() const					{ return m_pSteamVideo; }
+	ISteamTV*			SteamTV() const						{ return m_pSteamTV; }
+	ISteamParentalSettings* SteamParentalSettings() const	{ return m_pSteamParentalSettings; }
+	ISteamInput*		SteamInput() const					{ return m_pSteamInput; }
+private:
+	ISteamClient		*m_pSteamClient;
+	ISteamUser			*m_pSteamUser;
+	ISteamFriends		*m_pSteamFriends;
+	ISteamUtils			*m_pSteamUtils;
+	ISteamMatchmaking	*m_pSteamMatchmaking;
+	ISteamGameSearch	*m_pSteamGameSearch;
+	ISteamUserStats		*m_pSteamUserStats;
+	ISteamApps			*m_pSteamApps;
+	ISteamMatchmakingServers *m_pSteamMatchmakingServers;
+	ISteamNetworking	*m_pSteamNetworking;
+	ISteamRemoteStorage *m_pSteamRemoteStorage;
+	ISteamScreenshots	*m_pSteamScreenshots;
+	ISteamHTTP			*m_pSteamHTTP;
+	ISteamController	*m_pController;
+	ISteamUGC			*m_pSteamUGC;
+	ISteamAppList		*m_pSteamAppList;
+	ISteamMusic			*m_pSteamMusic;
+	ISteamMusicRemote	*m_pSteamMusicRemote;
+	ISteamHTMLSurface	*m_pSteamHTMLSurface;
+	ISteamInventory		*m_pSteamInventory;
+	ISteamVideo			*m_pSteamVideo;
+	ISteamTV			*m_pSteamTV;
+	ISteamParentalSettings *m_pSteamParentalSettings;
+	ISteamInput			*m_pSteamInput;
+};
+
+class CSteamGameServerAPIContext
+{
+public:
+	CSteamGameServerAPIContext() { Clear(); }
+	inline void Clear() { memset( this, 0, sizeof(*this) ); }
+	inline bool Init(); // NOTE: This is defined in steam_gameserver.h, to avoid this file having to include everything
+
+	ISteamClient *SteamClient() const					{ return m_pSteamClient; }
+	ISteamGameServer *SteamGameServer() const			{ return m_pSteamGameServer; }
+	ISteamUtils *SteamGameServerUtils() const			{ return m_pSteamGameServerUtils; }
+	ISteamNetworking *SteamGameServerNetworking() const	{ return m_pSteamGameServerNetworking; }
+	ISteamGameServerStats *SteamGameServerStats() const	{ return m_pSteamGameServerStats; }
+	ISteamHTTP *SteamHTTP() const						{ return m_pSteamHTTP; }
+	ISteamInventory *SteamInventory() const				{ return m_pSteamInventory; }
+	ISteamUGC *SteamUGC() const							{ return m_pSteamUGC; }
+	ISteamApps *SteamApps() const						{ return m_pSteamApps; }
+
+private:
+	ISteamClient				*m_pSteamClient;
+	ISteamGameServer			*m_pSteamGameServer;
+	ISteamUtils					*m_pSteamGameServerUtils;
+	ISteamNetworking			*m_pSteamGameServerNetworking;
+	ISteamGameServerStats		*m_pSteamGameServerStats;
+	ISteamHTTP					*m_pSteamHTTP;
+	ISteamInventory				*m_pSteamInventory;
+	ISteamUGC					*m_pSteamUGC;
+	ISteamApps					*m_pSteamApps;
+};
+
+

--- a/lsteamclient/steamworks_sdk_148a/steam_gameserver.h
+++ b/lsteamclient/steamworks_sdk_148a/steam_gameserver.h
@@ -1,0 +1,110 @@
+//====== Copyright © 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: 
+//
+//=============================================================================
+
+#ifndef STEAM_GAMESERVER_H
+#define STEAM_GAMESERVER_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api.h"
+#include "isteamgameserver.h"
+#include "isteamgameserverstats.h"
+
+enum EServerMode
+{
+	eServerModeInvalid = 0, // DO NOT USE		
+	eServerModeNoAuthentication = 1, // Don't authenticate user logins and don't list on the server list
+	eServerModeAuthentication = 2, // Authenticate users, list on the server list, don't run VAC on clients that connect
+	eServerModeAuthenticationAndSecure = 3, // Authenticate users, list on the server list and VAC protect clients
+};													
+
+// Initialize SteamGameServer client and interface objects, and set server properties which may not be changed.
+//
+// After calling this function, you should set any additional server parameters, and then
+// call ISteamGameServer::LogOnAnonymous() or ISteamGameServer::LogOn()
+//
+// - usSteamPort is the local port used to communicate with the steam servers.
+//   NOTE: unless you are using ver old Steam client binaries, this parameter is ignored, and
+//         you should pass 0.  Gameservers now always use WebSockets to talk to Steam.
+//         This protocol is TCP-based and thus always uses an ephemeral local port.
+//         Older steam client binaries used UDP to talk to Steam, and this argument was useful.
+//         A future version of the SDK will remove this argument.
+// - usGamePort is the port that clients will connect to for gameplay.
+// - usQueryPort is the port that will manage server browser related duties and info
+//		pings from clients.  If you pass MASTERSERVERUPDATERPORT_USEGAMESOCKETSHARE for usQueryPort, then it
+//		will use "GameSocketShare" mode, which means that the game is responsible for sending and receiving
+//		UDP packets for the master  server updater. See references to GameSocketShare in isteamgameserver.h.
+// - The version string is usually in the form x.x.x.x, and is used by the master server to detect when the
+//		server is out of date.  (Only servers with the latest version will be listed.)
+inline bool SteamGameServer_Init( uint32 unIP, uint16 usSteamPort, uint16 usGamePort, uint16 usQueryPort, EServerMode eServerMode, const char *pchVersionString );
+
+// Shutdown SteamGameSeverXxx interfaces, log out, and free resources.
+S_API void SteamGameServer_Shutdown();
+
+// Most Steam API functions allocate some amount of thread-local memory for
+// parameter storage. Calling SteamGameServer_ReleaseCurrentThreadMemory()
+// will free all API-related memory associated with the calling thread.
+// This memory is released automatically by SteamGameServer_RunCallbacks(),
+// so single-threaded servers do not need to explicitly call this function.
+inline void SteamGameServer_ReleaseCurrentThreadMemory();
+
+S_API bool SteamGameServer_BSecure();
+S_API uint64 SteamGameServer_GetSteamID();
+
+// Older SDKs exported this global pointer, but it is no longer supported.
+// You should use SteamGameServerClient() or CSteamGameServerAPIContext to
+// safely access the ISteamClient APIs from your game server application.
+//S_API ISteamClient *g_pSteamClientGameServer;
+
+// SteamGameServer_InitSafe has been replaced with SteamGameServer_Init and
+// is no longer supported. Use SteamGameServer_Init instead.
+//S_API void S_CALLTYPE SteamGameServer_InitSafe();
+
+//=============================================================================
+//
+// Internal implementation details below
+//
+//=============================================================================
+
+#ifndef STEAM_API_EXPORTS
+// This function must be declared inline in the header so the module using steam_api.dll gets the version names they want.
+inline bool CSteamGameServerAPIContext::Init()
+{
+	m_pSteamClient = ::SteamGameServerClient();
+	if ( !m_pSteamClient )
+		return false;
+
+	m_pSteamGameServer = ::SteamGameServer();
+	m_pSteamGameServerUtils = ::SteamGameServerUtils();
+	m_pSteamGameServerNetworking = ::SteamGameServerNetworking();
+	m_pSteamGameServerStats = ::SteamGameServerStats();
+	m_pSteamHTTP = ::SteamGameServerHTTP();
+	m_pSteamInventory = ::SteamGameServerInventory();
+	m_pSteamUGC = ::SteamGameServerUGC();
+	m_pSteamApps = ::SteamGameServerApps();
+	if ( !m_pSteamGameServer || !m_pSteamGameServerUtils || !m_pSteamGameServerNetworking || !m_pSteamGameServerStats
+		|| !m_pSteamHTTP || !m_pSteamInventory || !m_pSteamUGC || !m_pSteamApps )
+		return false;
+
+	return true;
+}
+#endif
+
+S_API bool S_CALLTYPE SteamInternal_GameServer_Init( uint32 unIP, uint16 usPort, uint16 usGamePort, uint16 usQueryPort, EServerMode eServerMode, const char *pchVersionString );
+inline bool SteamGameServer_Init( uint32 unIP, uint16 usSteamPort, uint16 usGamePort, uint16 usQueryPort, EServerMode eServerMode, const char *pchVersionString )
+{
+	if ( !SteamInternal_GameServer_Init( unIP, usSteamPort, usGamePort, usQueryPort, eServerMode, pchVersionString ) )
+		return false;
+
+	return true;
+}
+inline void SteamGameServer_ReleaseCurrentThreadMemory()
+{
+	SteamAPI_ReleaseCurrentThreadMemory();
+}
+
+#endif // STEAM_GAMESERVER_H

--- a/lsteamclient/steamworks_sdk_148a/steamclientpublic.h
+++ b/lsteamclient/steamworks_sdk_148a/steamclientpublic.h
@@ -1,0 +1,1489 @@
+//========= Copyright � 1996-2008, Valve LLC, All rights reserved. ============
+//
+// Purpose:
+//
+//=============================================================================
+
+#ifndef STEAMCLIENTPUBLIC_H
+#define STEAMCLIENTPUBLIC_H
+#ifdef _WIN32
+#pragma once
+#endif
+//lint -save -e1931 -e1927 -e1924 -e613 -e726
+
+// This header file defines the interface between the calling application and the code that
+// knows how to communicate with the connection manager (CM) from the Steam service 
+
+// This header file is intended to be portable; ideally this 1 header file plus a lib or dll
+// is all you need to integrate the client library into some other tree.  So please avoid
+// including or requiring other header files if possible.  This header should only describe the 
+// interface layer, no need to include anything about the implementation.
+
+#include "steamtypes.h"
+#include "steamuniverse.h"
+
+// General result codes
+enum EResult
+{
+	k_EResultNone = 0,							// no result
+	k_EResultOK	= 1,							// success
+	k_EResultFail = 2,							// generic failure 
+	k_EResultNoConnection = 3,					// no/failed network connection
+//	k_EResultNoConnectionRetry = 4,				// OBSOLETE - removed
+	k_EResultInvalidPassword = 5,				// password/ticket is invalid
+	k_EResultLoggedInElsewhere = 6,				// same user logged in elsewhere
+	k_EResultInvalidProtocolVer = 7,			// protocol version is incorrect
+	k_EResultInvalidParam = 8,					// a parameter is incorrect
+	k_EResultFileNotFound = 9,					// file was not found
+	k_EResultBusy = 10,							// called method busy - action not taken
+	k_EResultInvalidState = 11,					// called object was in an invalid state
+	k_EResultInvalidName = 12,					// name is invalid
+	k_EResultInvalidEmail = 13,					// email is invalid
+	k_EResultDuplicateName = 14,				// name is not unique
+	k_EResultAccessDenied = 15,					// access is denied
+	k_EResultTimeout = 16,						// operation timed out
+	k_EResultBanned = 17,						// VAC2 banned
+	k_EResultAccountNotFound = 18,				// account not found
+	k_EResultInvalidSteamID = 19,				// steamID is invalid
+	k_EResultServiceUnavailable = 20,			// The requested service is currently unavailable
+	k_EResultNotLoggedOn = 21,					// The user is not logged on
+	k_EResultPending = 22,						// Request is pending (may be in process, or waiting on third party)
+	k_EResultEncryptionFailure = 23,			// Encryption or Decryption failed
+	k_EResultInsufficientPrivilege = 24,		// Insufficient privilege
+	k_EResultLimitExceeded = 25,				// Too much of a good thing
+	k_EResultRevoked = 26,						// Access has been revoked (used for revoked guest passes)
+	k_EResultExpired = 27,						// License/Guest pass the user is trying to access is expired
+	k_EResultAlreadyRedeemed = 28,				// Guest pass has already been redeemed by account, cannot be acked again
+	k_EResultDuplicateRequest = 29,				// The request is a duplicate and the action has already occurred in the past, ignored this time
+	k_EResultAlreadyOwned = 30,					// All the games in this guest pass redemption request are already owned by the user
+	k_EResultIPNotFound = 31,					// IP address not found
+	k_EResultPersistFailed = 32,				// failed to write change to the data store
+	k_EResultLockingFailed = 33,				// failed to acquire access lock for this operation
+	k_EResultLogonSessionReplaced = 34,
+	k_EResultConnectFailed = 35,
+	k_EResultHandshakeFailed = 36,
+	k_EResultIOFailure = 37,
+	k_EResultRemoteDisconnect = 38,
+	k_EResultShoppingCartNotFound = 39,			// failed to find the shopping cart requested
+	k_EResultBlocked = 40,						// a user didn't allow it
+	k_EResultIgnored = 41,						// target is ignoring sender
+	k_EResultNoMatch = 42,						// nothing matching the request found
+	k_EResultAccountDisabled = 43,
+	k_EResultServiceReadOnly = 44,				// this service is not accepting content changes right now
+	k_EResultAccountNotFeatured = 45,			// account doesn't have value, so this feature isn't available
+	k_EResultAdministratorOK = 46,				// allowed to take this action, but only because requester is admin
+	k_EResultContentVersion = 47,				// A Version mismatch in content transmitted within the Steam protocol.
+	k_EResultTryAnotherCM = 48,					// The current CM can't service the user making a request, user should try another.
+	k_EResultPasswordRequiredToKickSession = 49,// You are already logged in elsewhere, this cached credential login has failed.
+	k_EResultAlreadyLoggedInElsewhere = 50,		// You are already logged in elsewhere, you must wait
+	k_EResultSuspended = 51,					// Long running operation (content download) suspended/paused
+	k_EResultCancelled = 52,					// Operation canceled (typically by user: content download)
+	k_EResultDataCorruption = 53,				// Operation canceled because data is ill formed or unrecoverable
+	k_EResultDiskFull = 54,						// Operation canceled - not enough disk space.
+	k_EResultRemoteCallFailed = 55,				// an remote call or IPC call failed
+	k_EResultPasswordUnset = 56,				// Password could not be verified as it's unset server side
+	k_EResultExternalAccountUnlinked = 57,		// External account (PSN, Facebook...) is not linked to a Steam account
+	k_EResultPSNTicketInvalid = 58,				// PSN ticket was invalid
+	k_EResultExternalAccountAlreadyLinked = 59,	// External account (PSN, Facebook...) is already linked to some other account, must explicitly request to replace/delete the link first
+	k_EResultRemoteFileConflict = 60,			// The sync cannot resume due to a conflict between the local and remote files
+	k_EResultIllegalPassword = 61,				// The requested new password is not legal
+	k_EResultSameAsPreviousValue = 62,			// new value is the same as the old one ( secret question and answer )
+	k_EResultAccountLogonDenied = 63,			// account login denied due to 2nd factor authentication failure
+	k_EResultCannotUseOldPassword = 64,			// The requested new password is not legal
+	k_EResultInvalidLoginAuthCode = 65,			// account login denied due to auth code invalid
+	k_EResultAccountLogonDeniedNoMail = 66,		// account login denied due to 2nd factor auth failure - and no mail has been sent
+	k_EResultHardwareNotCapableOfIPT = 67,		// 
+	k_EResultIPTInitError = 68,					// 
+	k_EResultParentalControlRestricted = 69,	// operation failed due to parental control restrictions for current user
+	k_EResultFacebookQueryError = 70,			// Facebook query returned an error
+	k_EResultExpiredLoginAuthCode = 71,			// account login denied due to auth code expired
+	k_EResultIPLoginRestrictionFailed = 72,
+	k_EResultAccountLockedDown = 73,
+	k_EResultAccountLogonDeniedVerifiedEmailRequired = 74,
+	k_EResultNoMatchingURL = 75,
+	k_EResultBadResponse = 76,					// parse failure, missing field, etc.
+	k_EResultRequirePasswordReEntry = 77,		// The user cannot complete the action until they re-enter their password
+	k_EResultValueOutOfRange = 78,				// the value entered is outside the acceptable range
+	k_EResultUnexpectedError = 79,				// something happened that we didn't expect to ever happen
+	k_EResultDisabled = 80,						// The requested service has been configured to be unavailable
+	k_EResultInvalidCEGSubmission = 81,			// The set of files submitted to the CEG server are not valid !
+	k_EResultRestrictedDevice = 82,				// The device being used is not allowed to perform this action
+	k_EResultRegionLocked = 83,					// The action could not be complete because it is region restricted
+	k_EResultRateLimitExceeded = 84,			// Temporary rate limit exceeded, try again later, different from k_EResultLimitExceeded which may be permanent
+	k_EResultAccountLoginDeniedNeedTwoFactor = 85,	// Need two-factor code to login
+	k_EResultItemDeleted = 86,					// The thing we're trying to access has been deleted
+	k_EResultAccountLoginDeniedThrottle = 87,	// login attempt failed, try to throttle response to possible attacker
+	k_EResultTwoFactorCodeMismatch = 88,		// two factor code mismatch
+	k_EResultTwoFactorActivationCodeMismatch = 89,	// activation code for two-factor didn't match
+	k_EResultAccountAssociatedToMultiplePartners = 90,	// account has been associated with multiple partners
+	k_EResultNotModified = 91,					// data not modified
+	k_EResultNoMobileDevice = 92,				// the account does not have a mobile device associated with it
+	k_EResultTimeNotSynced = 93,				// the time presented is out of range or tolerance
+	k_EResultSmsCodeFailed = 94,				// SMS code failure (no match, none pending, etc.)
+	k_EResultAccountLimitExceeded = 95,			// Too many accounts access this resource
+	k_EResultAccountActivityLimitExceeded = 96,	// Too many changes to this account
+	k_EResultPhoneActivityLimitExceeded = 97,	// Too many changes to this phone
+	k_EResultRefundToWallet = 98,				// Cannot refund to payment method, must use wallet
+	k_EResultEmailSendFailure = 99,				// Cannot send an email
+	k_EResultNotSettled = 100,					// Can't perform operation till payment has settled
+	k_EResultNeedCaptcha = 101,					// Needs to provide a valid captcha
+	k_EResultGSLTDenied = 102,					// a game server login token owned by this token's owner has been banned
+	k_EResultGSOwnerDenied = 103,				// game server owner is denied for other reason (account lock, community ban, vac ban, missing phone)
+	k_EResultInvalidItemType = 104,				// the type of thing we were requested to act on is invalid
+	k_EResultIPBanned = 105,					// the ip address has been banned from taking this action
+	k_EResultGSLTExpired = 106,					// this token has expired from disuse; can be reset for use
+	k_EResultInsufficientFunds = 107,			// user doesn't have enough wallet funds to complete the action
+	k_EResultTooManyPending = 108,				// There are too many of this thing pending already
+	k_EResultNoSiteLicensesFound = 109,			// No site licenses found
+	k_EResultWGNetworkSendExceeded = 110,		// the WG couldn't send a response because we exceeded max network send size
+	k_EResultAccountNotFriends = 111,			// the user is not mutually friends
+	k_EResultLimitedUserAccount = 112,			// the user is limited
+	k_EResultCantRemoveItem = 113,				// item can't be removed
+	k_EResultAccountDeleted = 114,				// account has been deleted
+	k_EResultExistingUserCancelledLicense = 115,	// A license for this already exists, but cancelled
+};
+
+// Error codes for use with the voice functions
+enum EVoiceResult
+{
+	k_EVoiceResultOK = 0,
+	k_EVoiceResultNotInitialized = 1,
+	k_EVoiceResultNotRecording = 2,
+	k_EVoiceResultNoData = 3,
+	k_EVoiceResultBufferTooSmall = 4,
+	k_EVoiceResultDataCorrupted = 5,
+	k_EVoiceResultRestricted = 6,
+	k_EVoiceResultUnsupportedCodec = 7,
+	k_EVoiceResultReceiverOutOfDate = 8,
+	k_EVoiceResultReceiverDidNotAnswer = 9,
+
+};
+
+// Result codes to GSHandleClientDeny/Kick
+enum EDenyReason
+{
+	k_EDenyInvalid = 0,
+	k_EDenyInvalidVersion = 1,
+	k_EDenyGeneric = 2,
+	k_EDenyNotLoggedOn = 3,
+	k_EDenyNoLicense = 4,
+	k_EDenyCheater = 5,
+	k_EDenyLoggedInElseWhere = 6,
+	k_EDenyUnknownText = 7,
+	k_EDenyIncompatibleAnticheat = 8,
+	k_EDenyMemoryCorruption = 9,
+	k_EDenyIncompatibleSoftware = 10,
+	k_EDenySteamConnectionLost = 11,
+	k_EDenySteamConnectionError = 12,
+	k_EDenySteamResponseTimedOut = 13,
+	k_EDenySteamValidationStalled = 14,
+	k_EDenySteamOwnerLeftGuestUser = 15,
+};
+
+// return type of GetAuthSessionTicket
+typedef uint32 HAuthTicket;
+const HAuthTicket k_HAuthTicketInvalid = 0;
+
+// results from BeginAuthSession
+enum EBeginAuthSessionResult
+{
+	k_EBeginAuthSessionResultOK = 0,						// Ticket is valid for this game and this steamID.
+	k_EBeginAuthSessionResultInvalidTicket = 1,				// Ticket is not valid.
+	k_EBeginAuthSessionResultDuplicateRequest = 2,			// A ticket has already been submitted for this steamID
+	k_EBeginAuthSessionResultInvalidVersion = 3,			// Ticket is from an incompatible interface version
+	k_EBeginAuthSessionResultGameMismatch = 4,				// Ticket is not for this game
+	k_EBeginAuthSessionResultExpiredTicket = 5,				// Ticket has expired
+};
+
+// Callback values for callback ValidateAuthTicketResponse_t which is a response to BeginAuthSession
+enum EAuthSessionResponse
+{
+	k_EAuthSessionResponseOK = 0,							// Steam has verified the user is online, the ticket is valid and ticket has not been reused.
+	k_EAuthSessionResponseUserNotConnectedToSteam = 1,		// The user in question is not connected to steam
+	k_EAuthSessionResponseNoLicenseOrExpired = 2,			// The license has expired.
+	k_EAuthSessionResponseVACBanned = 3,					// The user is VAC banned for this game.
+	k_EAuthSessionResponseLoggedInElseWhere = 4,			// The user account has logged in elsewhere and the session containing the game instance has been disconnected.
+	k_EAuthSessionResponseVACCheckTimedOut = 5,				// VAC has been unable to perform anti-cheat checks on this user
+	k_EAuthSessionResponseAuthTicketCanceled = 6,			// The ticket has been canceled by the issuer
+	k_EAuthSessionResponseAuthTicketInvalidAlreadyUsed = 7,	// This ticket has already been used, it is not valid.
+	k_EAuthSessionResponseAuthTicketInvalid = 8,			// This ticket is not from a user instance currently connected to steam.
+	k_EAuthSessionResponsePublisherIssuedBan = 9,			// The user is banned for this game. The ban came via the web api and not VAC
+};
+
+// results from UserHasLicenseForApp
+enum EUserHasLicenseForAppResult
+{
+	k_EUserHasLicenseResultHasLicense = 0,					// User has a license for specified app
+	k_EUserHasLicenseResultDoesNotHaveLicense = 1,			// User does not have a license for the specified app
+	k_EUserHasLicenseResultNoAuth = 2,						// User has not been authenticated
+};
+
+
+// Steam account types
+enum EAccountType
+{
+	k_EAccountTypeInvalid = 0,			
+	k_EAccountTypeIndividual = 1,		// single user account
+	k_EAccountTypeMultiseat = 2,		// multiseat (e.g. cybercafe) account
+	k_EAccountTypeGameServer = 3,		// game server account
+	k_EAccountTypeAnonGameServer = 4,	// anonymous game server account
+	k_EAccountTypePending = 5,			// pending
+	k_EAccountTypeContentServer = 6,	// content server
+	k_EAccountTypeClan = 7,
+	k_EAccountTypeChat = 8,
+	k_EAccountTypeConsoleUser = 9,		// Fake SteamID for local PSN account on PS3 or Live account on 360, etc.
+	k_EAccountTypeAnonUser = 10,
+
+	// Max of 16 items in this field
+	k_EAccountTypeMax
+};
+
+
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+enum EAppReleaseState
+{
+	k_EAppReleaseState_Unknown			= 0,	// unknown, required appinfo or license info is missing
+	k_EAppReleaseState_Unavailable		= 1,	// even if user 'just' owns it, can see game at all
+	k_EAppReleaseState_Prerelease		= 2,	// can be purchased and is visible in games list, nothing else. Common appInfo section released
+	k_EAppReleaseState_PreloadOnly		= 3,	// owners can preload app, not play it. AppInfo fully released.
+	k_EAppReleaseState_Released			= 4,	// owners can download and play app.
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+enum EAppOwnershipFlags
+{
+	k_EAppOwnershipFlags_None				= 0x0000,	// unknown
+	k_EAppOwnershipFlags_OwnsLicense		= 0x0001,	// owns license for this game
+	k_EAppOwnershipFlags_FreeLicense		= 0x0002,	// not paid for game
+	k_EAppOwnershipFlags_RegionRestricted	= 0x0004,	// owns app, but not allowed to play in current region
+	k_EAppOwnershipFlags_LowViolence		= 0x0008,	// only low violence version
+	k_EAppOwnershipFlags_InvalidPlatform	= 0x0010,	// app not supported on current platform
+	k_EAppOwnershipFlags_SharedLicense		= 0x0020,	// license was granted by authorized local device
+	k_EAppOwnershipFlags_FreeWeekend		= 0x0040,	// owned by a free weekend licenses
+	k_EAppOwnershipFlags_RetailLicense		= 0x0080,	// has a retail license for game, (CD-Key etc)
+	k_EAppOwnershipFlags_LicenseLocked		= 0x0100,	// shared license is locked (in use) by other user
+	k_EAppOwnershipFlags_LicensePending		= 0x0200,	// owns app, but transaction is still pending. Can't install or play
+	k_EAppOwnershipFlags_LicenseExpired		= 0x0400,	// doesn't own app anymore since license expired
+	k_EAppOwnershipFlags_LicensePermanent	= 0x0800,	// permanent license, not borrowed, or guest or freeweekend etc
+	k_EAppOwnershipFlags_LicenseRecurring	= 0x1000,	// Recurring license, user is charged periodically
+	k_EAppOwnershipFlags_LicenseCanceled	= 0x2000,	// Mark as canceled, but might be still active if recurring
+	k_EAppOwnershipFlags_AutoGrant			= 0x4000,	// Ownership is based on any kind of autogrant license
+	k_EAppOwnershipFlags_PendingGift		= 0x8000,	// user has pending gift to redeem
+	k_EAppOwnershipFlags_RentalNotActivated	= 0x10000,	// Rental hasn't been activated yet
+	k_EAppOwnershipFlags_Rental				= 0x20000,	// Is a rental
+	k_EAppOwnershipFlags_SiteLicense		= 0x40000,	// Is from a site license
+	k_EAppOwnershipFlags_LegacyFreeSub		= 0x80000,	// App only owned through Steam's legacy free sub
+	k_EAppOwnershipFlags_InvalidOSType		= 0x100000,	// app not supported on current OS version, used to indicate a game is 32-bit on post-catalina. Currently it's own flag so the library will display a notice.
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: designed as flags to allow filters masks
+// NOTE: If you add to this, please update PackageAppType (SteamConfig) as well as populatePackageAppType 
+//-----------------------------------------------------------------------------
+enum EAppType
+{
+	k_EAppType_Invalid				= 0x000,	// unknown / invalid
+	k_EAppType_Game					= 0x001,	// playable game, default type
+	k_EAppType_Application			= 0x002,	// software application
+	k_EAppType_Tool					= 0x004,	// SDKs, editors & dedicated servers
+	k_EAppType_Demo					= 0x008,	// game demo
+	k_EAppType_Media_DEPRECATED		= 0x010,	// legacy - was used for game trailers, which are now just videos on the web
+	k_EAppType_DLC					= 0x020,	// down loadable content
+	k_EAppType_Guide				= 0x040,	// game guide, PDF etc
+	k_EAppType_Driver				= 0x080,	// hardware driver updater (ATI, Razor etc)
+	k_EAppType_Config				= 0x100,	// hidden app used to config Steam features (backpack, sales, etc)
+	k_EAppType_Hardware				= 0x200,	// a hardware device (Steam Machine, Steam Controller, Steam Link, etc.)
+	k_EAppType_Franchise			= 0x400,	// A hub for collections of multiple apps, eg films, series, games
+	k_EAppType_Video				= 0x800,	// A video component of either a Film or TVSeries (may be the feature, an episode, preview, making-of, etc)
+	k_EAppType_Plugin				= 0x1000,	// Plug-in types for other Apps
+	k_EAppType_MusicAlbum			= 0x2000,	// "Video game soundtrack album"
+	k_EAppType_Series				= 0x4000,	// Container app for video series
+	k_EAppType_Comic_UNUSED			= 0x8000,	// Comic Book
+	k_EAppType_Beta					= 0x10000,	// this is a beta version of a game
+		
+	k_EAppType_Shortcut				= 0x40000000,	// just a shortcut, client side only
+	k_EAppType_DepotOnly			= 0x80000000,	// placeholder since depots and apps share the same namespace
+};
+
+
+
+//-----------------------------------------------------------------------------
+// types of user game stats fields
+// WARNING: DO NOT RENUMBER EXISTING VALUES - STORED IN DATABASE
+//-----------------------------------------------------------------------------
+enum ESteamUserStatType
+{
+	k_ESteamUserStatTypeINVALID = 0,
+	k_ESteamUserStatTypeINT = 1,
+	k_ESteamUserStatTypeFLOAT = 2,
+	// Read as FLOAT, set with count / session length
+	k_ESteamUserStatTypeAVGRATE = 3,
+	k_ESteamUserStatTypeACHIEVEMENTS = 4,
+	k_ESteamUserStatTypeGROUPACHIEVEMENTS = 5,
+
+	// max, for sanity checks
+	k_ESteamUserStatTypeMAX
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Chat Entry Types (previously was only friend-to-friend message types)
+//-----------------------------------------------------------------------------
+enum EChatEntryType
+{
+	k_EChatEntryTypeInvalid = 0, 
+	k_EChatEntryTypeChatMsg = 1,		// Normal text message from another user
+	k_EChatEntryTypeTyping = 2,			// Another user is typing (not used in multi-user chat)
+	k_EChatEntryTypeInviteGame = 3,		// Invite from other user into that users current game
+	k_EChatEntryTypeEmote = 4,			// text emote message (deprecated, should be treated as ChatMsg)
+	//k_EChatEntryTypeLobbyGameStart = 5,	// lobby game is starting (dead - listen for LobbyGameCreated_t callback instead)
+	k_EChatEntryTypeLeftConversation = 6, // user has left the conversation ( closed chat window )
+	// Above are previous FriendMsgType entries, now merged into more generic chat entry types
+	k_EChatEntryTypeEntered = 7,		// user has entered the conversation (used in multi-user chat and group chat)
+	k_EChatEntryTypeWasKicked = 8,		// user was kicked (data: 64-bit steamid of actor performing the kick)
+	k_EChatEntryTypeWasBanned = 9,		// user was banned (data: 64-bit steamid of actor performing the ban)
+	k_EChatEntryTypeDisconnected = 10,	// user disconnected
+	k_EChatEntryTypeHistoricalChat = 11,	// a chat message from user's chat history or offilne message
+	//k_EChatEntryTypeReserved1 = 12, // No longer used
+	//k_EChatEntryTypeReserved2 = 13, // No longer used
+	k_EChatEntryTypeLinkBlocked = 14, // a link was removed by the chat filter.
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Chat Room Enter Responses
+//-----------------------------------------------------------------------------
+enum EChatRoomEnterResponse
+{
+	k_EChatRoomEnterResponseSuccess = 1,		// Success
+	k_EChatRoomEnterResponseDoesntExist = 2,	// Chat doesn't exist (probably closed)
+	k_EChatRoomEnterResponseNotAllowed = 3,		// General Denied - You don't have the permissions needed to join the chat
+	k_EChatRoomEnterResponseFull = 4,			// Chat room has reached its maximum size
+	k_EChatRoomEnterResponseError = 5,			// Unexpected Error
+	k_EChatRoomEnterResponseBanned = 6,			// You are banned from this chat room and may not join
+	k_EChatRoomEnterResponseLimited = 7,		// Joining this chat is not allowed because you are a limited user (no value on account)
+	k_EChatRoomEnterResponseClanDisabled = 8,	// Attempt to join a clan chat when the clan is locked or disabled
+	k_EChatRoomEnterResponseCommunityBan = 9,	// Attempt to join a chat when the user has a community lock on their account
+	k_EChatRoomEnterResponseMemberBlockedYou = 10, // Join failed - some member in the chat has blocked you from joining
+	k_EChatRoomEnterResponseYouBlockedMember = 11, // Join failed - you have blocked some member already in the chat
+	// k_EChatRoomEnterResponseNoRankingDataLobby = 12,  // No longer used
+	// k_EChatRoomEnterResponseNoRankingDataUser = 13,  //  No longer used
+	// k_EChatRoomEnterResponseRankOutOfRange = 14, //  No longer used
+	k_EChatRoomEnterResponseRatelimitExceeded = 15, // Join failed - to many join attempts in a very short period of time
+};
+
+
+typedef void (*PFNLegacyKeyRegistration)( const char *pchCDKey, const char *pchInstallPath );
+typedef bool (*PFNLegacyKeyInstalled)();
+
+const unsigned int k_unSteamAccountIDMask = 0xFFFFFFFF;
+const unsigned int k_unSteamAccountInstanceMask = 0x000FFFFF;
+const unsigned int k_unSteamUserDefaultInstance	= 1; // fixed instance for all individual users
+
+// Special flags for Chat accounts - they go in the top 8 bits
+// of the steam ID's "instance", leaving 12 for the actual instances
+enum EChatSteamIDInstanceFlags
+{
+	k_EChatAccountInstanceMask = 0x00000FFF, // top 8 bits are flags
+
+	k_EChatInstanceFlagClan = ( k_unSteamAccountInstanceMask + 1 ) >> 1,	// top bit
+	k_EChatInstanceFlagLobby = ( k_unSteamAccountInstanceMask + 1 ) >> 2,	// next one down, etc
+	k_EChatInstanceFlagMMSLobby = ( k_unSteamAccountInstanceMask + 1 ) >> 3,	// next one down, etc
+
+	// Max of 8 flags
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Marketing message flags that change how a client should handle them
+//-----------------------------------------------------------------------------
+enum EMarketingMessageFlags
+{
+	k_EMarketingMessageFlagsNone = 0,
+	k_EMarketingMessageFlagsHighPriority = 1 << 0,
+	k_EMarketingMessageFlagsPlatformWindows = 1 << 1,
+	k_EMarketingMessageFlagsPlatformMac = 1 << 2,
+	k_EMarketingMessageFlagsPlatformLinux = 1 << 3,
+
+	//aggregate flags
+	k_EMarketingMessageFlagsPlatformRestrictions = 
+		k_EMarketingMessageFlagsPlatformWindows |
+		k_EMarketingMessageFlagsPlatformMac |
+		k_EMarketingMessageFlagsPlatformLinux,
+};
+
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Possible positions to tell the overlay to show notifications in
+//-----------------------------------------------------------------------------
+enum ENotificationPosition
+{
+	k_EPositionTopLeft = 0,
+	k_EPositionTopRight = 1,
+	k_EPositionBottomLeft = 2,
+	k_EPositionBottomRight = 3,
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Broadcast upload result details
+//-----------------------------------------------------------------------------
+enum EBroadcastUploadResult
+{
+	k_EBroadcastUploadResultNone = 0,	// broadcast state unknown
+	k_EBroadcastUploadResultOK = 1,		// broadcast was good, no problems
+	k_EBroadcastUploadResultInitFailed = 2,	// broadcast init failed
+	k_EBroadcastUploadResultFrameFailed = 3,	// broadcast frame upload failed
+	k_EBroadcastUploadResultTimeout = 4,	// broadcast upload timed out
+	k_EBroadcastUploadResultBandwidthExceeded = 5,	// broadcast send too much data
+	k_EBroadcastUploadResultLowFPS = 6,	// broadcast FPS too low
+	k_EBroadcastUploadResultMissingKeyFrames = 7,	// broadcast sending not enough key frames
+	k_EBroadcastUploadResultNoConnection = 8,	// broadcast client failed to connect to relay
+	k_EBroadcastUploadResultRelayFailed = 9,	// relay dropped the upload
+	k_EBroadcastUploadResultSettingsChanged = 10,	// the client changed broadcast settings 
+	k_EBroadcastUploadResultMissingAudio = 11,	// client failed to send audio data
+	k_EBroadcastUploadResultTooFarBehind = 12,	// clients was too slow uploading
+	k_EBroadcastUploadResultTranscodeBehind = 13,	// server failed to keep up with transcode
+	k_EBroadcastUploadResultNotAllowedToPlay = 14, // Broadcast does not have permissions to play game
+	k_EBroadcastUploadResultBusy = 15, // RTMP host to busy to take new broadcast stream, choose another
+	k_EBroadcastUploadResultBanned = 16, // Account banned from community broadcast
+	k_EBroadcastUploadResultAlreadyActive = 17, // We already already have an stream running.
+	k_EBroadcastUploadResultForcedOff = 18, // We explicitly shutting down a broadcast
+	k_EBroadcastUploadResultAudioBehind = 19, // Audio stream was too far behind video 
+	k_EBroadcastUploadResultShutdown = 20,	// Broadcast Server was shut down
+	k_EBroadcastUploadResultDisconnect = 21,	// broadcast uploader TCP disconnected 
+	k_EBroadcastUploadResultVideoInitFailed = 22,	// invalid video settings 
+	k_EBroadcastUploadResultAudioInitFailed = 23,	// invalid audio settings 
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: codes for well defined launch options
+//-----------------------------------------------------------------------------
+enum ELaunchOptionType
+{
+	k_ELaunchOptionType_None		= 0,	// unknown what launch option does
+	k_ELaunchOptionType_Default		= 1,	// runs the game, app, whatever in default mode
+	k_ELaunchOptionType_SafeMode	= 2,	// runs the game in safe mode
+	k_ELaunchOptionType_Multiplayer = 3,	// runs the game in multiplayer mode
+	k_ELaunchOptionType_Config		= 4,	// runs config tool for this game
+	k_ELaunchOptionType_OpenVR		= 5,	// runs game in VR mode using OpenVR
+	k_ELaunchOptionType_Server		= 6,	// runs dedicated server for this game
+	k_ELaunchOptionType_Editor		= 7,	// runs game editor
+	k_ELaunchOptionType_Manual		= 8,	// shows game manual
+	k_ELaunchOptionType_Benchmark	= 9,	// runs game benchmark
+	k_ELaunchOptionType_Option1		= 10,	// generic run option, uses description field for game name
+	k_ELaunchOptionType_Option2		= 11,	// generic run option, uses description field for game name
+	k_ELaunchOptionType_Option3     = 12,	// generic run option, uses description field for game name
+	k_ELaunchOptionType_OculusVR	= 13,	// runs game in VR mode using the Oculus SDK 
+	k_ELaunchOptionType_OpenVROverlay = 14,	// runs an OpenVR dashboard overlay
+	k_ELaunchOptionType_OSVR		= 15,	// runs game in VR mode using the OSVR SDK
+
+	
+	k_ELaunchOptionType_Dialog 		= 1000, // show launch options dialog
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: true if this launch option is any of the vr launching types
+//-----------------------------------------------------------------------------
+static inline bool BIsVRLaunchOptionType( const ELaunchOptionType  eType )
+{
+	return eType == k_ELaunchOptionType_OpenVR 
+		|| eType == k_ELaunchOptionType_OpenVROverlay 
+		|| eType == k_ELaunchOptionType_OculusVR
+		|| eType == k_ELaunchOptionType_OSVR;
+}
+
+
+//-----------------------------------------------------------------------------
+// Purpose: code points for VR HMD vendors and models 
+// WARNING: DO NOT RENUMBER EXISTING VALUES - STORED IN A DATABASE
+//-----------------------------------------------------------------------------
+enum EVRHMDType
+{
+	k_eEVRHMDType_None = -1, // unknown vendor and model
+
+	k_eEVRHMDType_Unknown = 0, // unknown vendor and model
+
+	k_eEVRHMDType_HTC_Dev = 1,	// original HTC dev kits
+	k_eEVRHMDType_HTC_VivePre = 2,	// htc vive pre
+	k_eEVRHMDType_HTC_Vive = 3,	// htc vive consumer release
+	k_eEVRHMDType_HTC_VivePro = 4,	// htc vive pro release
+	k_eEVRHMDType_HTC_ViveCosmos = 5,	// HTC Vive Cosmos
+
+	k_eEVRHMDType_HTC_Unknown = 20, // unknown htc hmd
+
+	k_eEVRHMDType_Oculus_DK1 = 21, // Oculus DK1 
+	k_eEVRHMDType_Oculus_DK2 = 22, // Oculus DK2
+	k_eEVRHMDType_Oculus_Rift = 23, // Oculus Rift
+	k_eEVRHMDType_Oculus_RiftS = 24, // Oculus Rift S
+	k_eEVRHMDType_Oculus_Quest = 25, // Oculus Quest
+
+	k_eEVRHMDType_Oculus_Unknown = 40, // // Oculus unknown HMD
+
+	k_eEVRHMDType_Acer_Unknown = 50, // Acer unknown HMD
+	k_eEVRHMDType_Acer_WindowsMR = 51, // Acer QHMD Windows MR headset
+
+	k_eEVRHMDType_Dell_Unknown = 60, // Dell unknown HMD
+	k_eEVRHMDType_Dell_Visor = 61, // Dell Visor Windows MR headset
+
+	k_eEVRHMDType_Lenovo_Unknown = 70, // Lenovo unknown HMD
+	k_eEVRHMDType_Lenovo_Explorer = 71, // Lenovo Explorer Windows MR headset
+
+	k_eEVRHMDType_HP_Unknown = 80, // HP unknown HMD
+	k_eEVRHMDType_HP_WindowsMR = 81, // HP Windows MR headset
+	k_eEVRHMDType_HP_Reverb = 82, // HP Reverb Windows MR headset
+
+	k_eEVRHMDType_Samsung_Unknown = 90, // Samsung unknown HMD
+	k_eEVRHMDType_Samsung_Odyssey = 91, // Samsung Odyssey Windows MR headset
+
+	k_eEVRHMDType_Unannounced_Unknown = 100, // Unannounced unknown HMD
+	k_eEVRHMDType_Unannounced_WindowsMR = 101, // Unannounced Windows MR headset
+
+	k_eEVRHMDType_vridge = 110, // VRIDGE tool
+	
+	k_eEVRHMDType_Huawei_Unknown = 120, // Huawei unknown HMD
+	k_eEVRHMDType_Huawei_VR2 = 121, // Huawei VR2 3DOF headset
+	k_eEVRHMDType_Huawei_EndOfRange = 129, // end of Huawei HMD range
+
+	k_eEVRHmdType_Valve_Unknown = 130, // Valve Unknown HMD
+	k_eEVRHmdType_Valve_Index = 131, // Valve Index HMD
+
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: true if this is from an Oculus HMD
+//-----------------------------------------------------------------------------
+static inline bool BIsOculusHMD( EVRHMDType eType )
+{
+	return eType == k_eEVRHMDType_Oculus_DK1 || eType == k_eEVRHMDType_Oculus_DK2 || eType == k_eEVRHMDType_Oculus_Rift || eType == k_eEVRHMDType_Oculus_RiftS || eType == k_eEVRHMDType_Oculus_Quest || eType == k_eEVRHMDType_Oculus_Unknown;
+}
+
+
+//-----------------------------------------------------------------------------
+// Purpose: true if this is from a Windows MR HMD
+//-----------------------------------------------------------------------------
+static inline bool BIsWindowsMRHeadset( EVRHMDType eType )
+{
+	return eType >= k_eEVRHMDType_Acer_WindowsMR && eType <= k_eEVRHMDType_Unannounced_WindowsMR;
+}
+
+
+//-----------------------------------------------------------------------------
+// Purpose: true if this is from a Hauwei HMD
+//-----------------------------------------------------------------------------
+static inline bool BIsHuaweiHeadset( EVRHMDType eType )
+{
+	return eType >= k_eEVRHMDType_Huawei_Unknown && eType <= k_eEVRHMDType_Huawei_EndOfRange;
+}
+
+
+//-----------------------------------------------------------------------------
+// Purpose: true if this is from an Vive HMD
+//-----------------------------------------------------------------------------
+static inline bool BIsViveHMD( EVRHMDType eType )
+{
+	return eType == k_eEVRHMDType_HTC_Dev || eType == k_eEVRHMDType_HTC_VivePre || eType == k_eEVRHMDType_HTC_Vive || eType == k_eEVRHMDType_HTC_Unknown || eType == k_eEVRHMDType_HTC_VivePro;
+}
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Reasons a user may not use the Community Market.
+//          Used in MarketEligibilityResponse_t.
+//-----------------------------------------------------------------------------
+enum EMarketNotAllowedReasonFlags
+{
+	k_EMarketNotAllowedReason_None = 0,
+
+	// A back-end call failed or something that might work again on retry
+	k_EMarketNotAllowedReason_TemporaryFailure = (1 << 0),
+
+	// Disabled account
+	k_EMarketNotAllowedReason_AccountDisabled = (1 << 1),
+
+	// Locked account
+	k_EMarketNotAllowedReason_AccountLockedDown = (1 << 2),
+
+	// Limited account (no purchases)
+	k_EMarketNotAllowedReason_AccountLimited = (1 << 3),
+
+	// The account is banned from trading items
+	k_EMarketNotAllowedReason_TradeBanned = (1 << 4),
+
+	// Wallet funds aren't tradable because the user has had no purchase
+	// activity in the last year or has had no purchases prior to last month
+	k_EMarketNotAllowedReason_AccountNotTrusted = (1 << 5),
+
+	// The user doesn't have Steam Guard enabled
+	k_EMarketNotAllowedReason_SteamGuardNotEnabled = (1 << 6),
+
+	// The user has Steam Guard, but it hasn't been enabled for the required
+	// number of days
+	k_EMarketNotAllowedReason_SteamGuardOnlyRecentlyEnabled = (1 << 7),
+
+	// The user has recently forgotten their password and reset it
+	k_EMarketNotAllowedReason_RecentPasswordReset = (1 << 8),
+
+	// The user has recently funded his or her wallet with a new payment method
+	k_EMarketNotAllowedReason_NewPaymentMethod = (1 << 9),
+
+	// An invalid cookie was sent by the user
+	k_EMarketNotAllowedReason_InvalidCookie = (1 << 10),
+
+	// The user has Steam Guard, but is using a new computer or web browser
+	k_EMarketNotAllowedReason_UsingNewDevice = (1 << 11),
+
+	// The user has recently refunded a store purchase by his or herself
+	k_EMarketNotAllowedReason_RecentSelfRefund = (1 << 12),
+
+	// The user has recently funded his or her wallet with a new payment method that cannot be verified
+	k_EMarketNotAllowedReason_NewPaymentMethodCannotBeVerified = (1 << 13),
+
+	// Not only is the account not trusted, but they have no recent purchases at all
+	k_EMarketNotAllowedReason_NoRecentPurchases = (1 << 14),
+
+	// User accepted a wallet gift that was recently purchased
+	k_EMarketNotAllowedReason_AcceptedWalletGift = (1 << 15),
+};
+
+
+//
+// describes XP / progress restrictions to apply for games with duration control /
+// anti-indulgence enabled for minor Steam China users.
+//
+// WARNING: DO NOT RENUMBER
+enum EDurationControlProgress
+{
+	k_EDurationControlProgress_Full = 0,	// Full progress
+	k_EDurationControlProgress_Half = 1,	// deprecated - XP or persistent rewards should be halved
+	k_EDurationControlProgress_None = 2,	// deprecated - XP or persistent rewards should be stopped
+
+	k_EDurationControl_ExitSoon_3h = 3,		// allowed 3h time since 5h gap/break has elapsed, game should exit - steam will terminate the game soon
+	k_EDurationControl_ExitSoon_5h = 4,		// allowed 5h time in calendar day has elapsed, game should exit - steam will terminate the game soon
+	k_EDurationControl_ExitSoon_Night = 5,	// game running after day period, game should exit - steam will terminate the game soon
+};
+
+
+//
+// describes which notification timer has expired, for steam china duration control feature
+//
+// WARNING: DO NOT RENUMBER
+enum EDurationControlNotification
+{
+	k_EDurationControlNotification_None = 0,		// just informing you about progress, no notification to show
+	k_EDurationControlNotification_1Hour = 1,		// "you've been playing for N hours"
+	
+	k_EDurationControlNotification_3Hours = 2,		// deprecated - "you've been playing for 3 hours; take a break"
+	k_EDurationControlNotification_HalfProgress = 3,// deprecated - "your XP / progress is half normal"
+	k_EDurationControlNotification_NoProgress = 4,	// deprecated - "your XP / progress is zero"
+	
+	k_EDurationControlNotification_ExitSoon_3h = 5,	// allowed 3h time since 5h gap/break has elapsed, game should exit - steam will terminate the game soon
+	k_EDurationControlNotification_ExitSoon_5h = 6,	// allowed 5h time in calendar day has elapsed, game should exit - steam will terminate the game soon
+	k_EDurationControlNotification_ExitSoon_Night = 7,// game running after day period, game should exit - steam will terminate the game soon
+};
+
+
+#pragma pack( push, 1 )
+
+#define CSTEAMID_DEFINED
+
+// Steam ID structure (64 bits total)
+class CSteamID
+{
+public:
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Constructor
+	//-----------------------------------------------------------------------------
+	CSteamID()
+	{
+		m_steamid.m_comp.m_unAccountID = 0;
+		m_steamid.m_comp.m_EAccountType = k_EAccountTypeInvalid;
+		m_steamid.m_comp.m_EUniverse = k_EUniverseInvalid;
+		m_steamid.m_comp.m_unAccountInstance = 0;
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Constructor
+	// Input  : unAccountID -	32-bit account ID
+	//			eUniverse -		Universe this account belongs to
+	//			eAccountType -	Type of account
+	//-----------------------------------------------------------------------------
+	CSteamID( uint32 unAccountID, EUniverse eUniverse, EAccountType eAccountType )
+	{
+		Set( unAccountID, eUniverse, eAccountType );
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Constructor
+	// Input  : unAccountID -	32-bit account ID
+	//			unAccountInstance - instance 
+	//			eUniverse -		Universe this account belongs to
+	//			eAccountType -	Type of account
+	//-----------------------------------------------------------------------------
+	CSteamID( uint32 unAccountID, unsigned int unAccountInstance, EUniverse eUniverse, EAccountType eAccountType )
+	{
+#if defined(_SERVER) && defined(Assert)
+		Assert( ( k_EAccountTypeIndividual != eAccountType ) || ( unAccountInstance == k_unSteamUserDefaultInstance ) );	// enforce that for individual accounts, instance is always 1
+#endif // _SERVER
+		InstancedSet( unAccountID, unAccountInstance, eUniverse, eAccountType );
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Constructor
+	// Input  : ulSteamID -		64-bit representation of a Steam ID
+	// Note:	Will not accept a uint32 or int32 as input, as that is a probable mistake.
+	//			See the stubbed out overloads in the private: section for more info.
+	//-----------------------------------------------------------------------------
+	CSteamID( uint64 ulSteamID )
+	{
+		SetFromUint64( ulSteamID );
+	}
+#ifdef INT64_DIFFERENT_FROM_INT64_T
+	CSteamID( uint64_t ulSteamID )
+	{
+		SetFromUint64( (uint64)ulSteamID );
+	}
+#endif
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Sets parameters for steam ID
+	// Input  : unAccountID -	32-bit account ID
+	//			eUniverse -		Universe this account belongs to
+	//			eAccountType -	Type of account
+	//-----------------------------------------------------------------------------
+	void Set( uint32 unAccountID, EUniverse eUniverse, EAccountType eAccountType )
+	{
+		m_steamid.m_comp.m_unAccountID = unAccountID;
+		m_steamid.m_comp.m_EUniverse = eUniverse;
+		m_steamid.m_comp.m_EAccountType = eAccountType;
+
+		if ( eAccountType == k_EAccountTypeClan || eAccountType == k_EAccountTypeGameServer )
+		{
+			m_steamid.m_comp.m_unAccountInstance = 0;
+		}
+		else
+		{
+			m_steamid.m_comp.m_unAccountInstance = k_unSteamUserDefaultInstance;
+		}
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Sets parameters for steam ID
+	// Input  : unAccountID -	32-bit account ID
+	//			eUniverse -		Universe this account belongs to
+	//			eAccountType -	Type of account
+	//-----------------------------------------------------------------------------
+	void InstancedSet( uint32 unAccountID, uint32 unInstance, EUniverse eUniverse, EAccountType eAccountType )
+	{
+		m_steamid.m_comp.m_unAccountID = unAccountID;
+		m_steamid.m_comp.m_EUniverse = eUniverse;
+		m_steamid.m_comp.m_EAccountType = eAccountType;
+		m_steamid.m_comp.m_unAccountInstance = unInstance;
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Initializes a steam ID from its 52 bit parts and universe/type
+	// Input  : ulIdentifier - 52 bits of goodness
+	//-----------------------------------------------------------------------------
+	void FullSet( uint64 ulIdentifier, EUniverse eUniverse, EAccountType eAccountType )
+	{
+		m_steamid.m_comp.m_unAccountID = ( ulIdentifier & k_unSteamAccountIDMask );						// account ID is low 32 bits
+		m_steamid.m_comp.m_unAccountInstance = ( ( ulIdentifier >> 32 ) & k_unSteamAccountInstanceMask );			// account instance is next 20 bits
+		m_steamid.m_comp.m_EUniverse = eUniverse;
+		m_steamid.m_comp.m_EAccountType = eAccountType;
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Initializes a steam ID from its 64-bit representation
+	// Input  : ulSteamID -		64-bit representation of a Steam ID
+	//-----------------------------------------------------------------------------
+	void SetFromUint64( uint64 ulSteamID )
+	{
+		m_steamid.m_unAll64Bits = ulSteamID;
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Clear all fields, leaving an invalid ID.
+	//-----------------------------------------------------------------------------
+    void Clear()
+	{
+		m_steamid.m_comp.m_unAccountID = 0;
+		m_steamid.m_comp.m_EAccountType = k_EAccountTypeInvalid;
+		m_steamid.m_comp.m_EUniverse = k_EUniverseInvalid;
+		m_steamid.m_comp.m_unAccountInstance = 0;
+	}
+
+
+#if defined( INCLUDED_STEAM2_USERID_STRUCTS ) 
+	//-----------------------------------------------------------------------------
+	// Purpose: Initializes a steam ID from a Steam2 ID structure
+	// Input:	pTSteamGlobalUserID -	Steam2 ID to convert
+	//			eUniverse -				universe this ID belongs to
+	//-----------------------------------------------------------------------------
+	void SetFromSteam2( TSteamGlobalUserID *pTSteamGlobalUserID, EUniverse eUniverse )
+	{
+		m_steamid.m_comp.m_unAccountID = pTSteamGlobalUserID->m_SteamLocalUserID.Split.Low32bits * 2 + 
+			pTSteamGlobalUserID->m_SteamLocalUserID.Split.High32bits;
+		m_steamid.m_comp.m_EUniverse = eUniverse;		// set the universe
+		m_steamid.m_comp.m_EAccountType = k_EAccountTypeIndividual; // Steam 2 accounts always map to account type of individual
+		m_steamid.m_comp.m_unAccountInstance = k_unSteamUserDefaultInstance; // Steam2 only knew one instance
+	}
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Fills out a Steam2 ID structure
+	// Input:	pTSteamGlobalUserID -	Steam2 ID to write to
+	//-----------------------------------------------------------------------------
+	void ConvertToSteam2( TSteamGlobalUserID *pTSteamGlobalUserID ) const
+	{
+		// only individual accounts have any meaning in Steam 2, only they can be mapped
+		// Assert( m_steamid.m_comp.m_EAccountType == k_EAccountTypeIndividual );
+
+		pTSteamGlobalUserID->m_SteamInstanceID = 0;
+		pTSteamGlobalUserID->m_SteamLocalUserID.Split.High32bits = m_steamid.m_comp.m_unAccountID % 2;
+		pTSteamGlobalUserID->m_SteamLocalUserID.Split.Low32bits = m_steamid.m_comp.m_unAccountID / 2;
+	}
+#endif // defined( INCLUDED_STEAM_COMMON_STEAMCOMMON_H )
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Converts steam ID to its 64-bit representation
+	// Output : 64-bit representation of a Steam ID
+	//-----------------------------------------------------------------------------
+	uint64 ConvertToUint64() const
+	{
+		return m_steamid.m_unAll64Bits;
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Converts the static parts of a steam ID to a 64-bit representation.
+	//			For multiseat accounts, all instances of that account will have the
+	//			same static account key, so they can be grouped together by the static
+	//			account key.
+	// Output : 64-bit static account key
+	//-----------------------------------------------------------------------------
+	uint64 GetStaticAccountKey() const
+	{
+		// note we do NOT include the account instance (which is a dynamic property) in the static account key
+		return (uint64) ( ( ( (uint64) m_steamid.m_comp.m_EUniverse ) << 56 ) + ((uint64) m_steamid.m_comp.m_EAccountType << 52 ) + m_steamid.m_comp.m_unAccountID );
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: create an anonymous game server login to be filled in by the AM
+	//-----------------------------------------------------------------------------
+	void CreateBlankAnonLogon( EUniverse eUniverse )
+	{
+		m_steamid.m_comp.m_unAccountID = 0;
+		m_steamid.m_comp.m_EAccountType = k_EAccountTypeAnonGameServer;
+		m_steamid.m_comp.m_EUniverse = eUniverse;
+		m_steamid.m_comp.m_unAccountInstance = 0;
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: create an anonymous game server login to be filled in by the AM
+	//-----------------------------------------------------------------------------
+	void CreateBlankAnonUserLogon( EUniverse eUniverse )
+	{
+		m_steamid.m_comp.m_unAccountID = 0;
+		m_steamid.m_comp.m_EAccountType = k_EAccountTypeAnonUser;
+		m_steamid.m_comp.m_EUniverse = eUniverse;
+		m_steamid.m_comp.m_unAccountInstance = 0;
+	}
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this an anonymous game server login that will be filled in?
+	//-----------------------------------------------------------------------------
+	bool BBlankAnonAccount() const
+	{
+		return m_steamid.m_comp.m_unAccountID == 0 && BAnonAccount() && m_steamid.m_comp.m_unAccountInstance == 0;
+	}
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this a game server account id?  (Either persistent or anonymous)
+	//-----------------------------------------------------------------------------
+	bool BGameServerAccount() const
+	{
+		return m_steamid.m_comp.m_EAccountType == k_EAccountTypeGameServer || m_steamid.m_comp.m_EAccountType == k_EAccountTypeAnonGameServer;
+	}
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this a persistent (not anonymous) game server account id?
+	//-----------------------------------------------------------------------------
+	bool BPersistentGameServerAccount() const
+	{
+		return m_steamid.m_comp.m_EAccountType == k_EAccountTypeGameServer;
+	}
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this an anonymous game server account id?
+	//-----------------------------------------------------------------------------
+	bool BAnonGameServerAccount() const
+	{
+		return m_steamid.m_comp.m_EAccountType == k_EAccountTypeAnonGameServer;
+	}
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this a content server account id?
+	//-----------------------------------------------------------------------------
+	bool BContentServerAccount() const
+	{
+		return m_steamid.m_comp.m_EAccountType == k_EAccountTypeContentServer;
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this a clan account id?
+	//-----------------------------------------------------------------------------
+	bool BClanAccount() const
+	{
+		return m_steamid.m_comp.m_EAccountType == k_EAccountTypeClan;
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this a chat account id?
+	//-----------------------------------------------------------------------------
+	bool BChatAccount() const
+	{
+		return m_steamid.m_comp.m_EAccountType == k_EAccountTypeChat;
+	}
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this a chat account id?
+	//-----------------------------------------------------------------------------
+	bool IsLobby() const
+	{
+		return ( m_steamid.m_comp.m_EAccountType == k_EAccountTypeChat )
+			&& ( m_steamid.m_comp.m_unAccountInstance & k_EChatInstanceFlagLobby );
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this an individual user account id?
+	//-----------------------------------------------------------------------------
+	bool BIndividualAccount() const
+	{
+		return m_steamid.m_comp.m_EAccountType == k_EAccountTypeIndividual || m_steamid.m_comp.m_EAccountType == k_EAccountTypeConsoleUser;
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this an anonymous account?
+	//-----------------------------------------------------------------------------
+	bool BAnonAccount() const
+	{
+		return m_steamid.m_comp.m_EAccountType == k_EAccountTypeAnonUser || m_steamid.m_comp.m_EAccountType == k_EAccountTypeAnonGameServer;
+	}
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this an anonymous user account? ( used to create an account or reset a password )
+	//-----------------------------------------------------------------------------
+	bool BAnonUserAccount() const
+	{
+		return m_steamid.m_comp.m_EAccountType == k_EAccountTypeAnonUser;
+	}
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this a faked up Steam ID for a PSN friend account?
+	//-----------------------------------------------------------------------------
+	bool BConsoleUserAccount() const
+	{
+		return m_steamid.m_comp.m_EAccountType == k_EAccountTypeConsoleUser;
+	}
+
+	// simple accessors
+	void SetAccountID( uint32 unAccountID )		{ m_steamid.m_comp.m_unAccountID = unAccountID; }
+	void SetAccountInstance( uint32 unInstance ){ m_steamid.m_comp.m_unAccountInstance = unInstance; }
+		
+	AccountID_t GetAccountID() const			{ return m_steamid.m_comp.m_unAccountID; }
+	uint32 GetUnAccountInstance() const			{ return m_steamid.m_comp.m_unAccountInstance; }
+	EAccountType GetEAccountType() const		{ return ( EAccountType ) m_steamid.m_comp.m_EAccountType; }
+	EUniverse GetEUniverse() const				{ return m_steamid.m_comp.m_EUniverse; }
+	void SetEUniverse( EUniverse eUniverse )	{ m_steamid.m_comp.m_EUniverse = eUniverse; }
+	bool IsValid() const;
+
+	// this set of functions is hidden, will be moved out of class
+	explicit CSteamID( const char *pchSteamID, EUniverse eDefaultUniverse = k_EUniverseInvalid );
+	const char * Render() const;				// renders this steam ID to string
+	static const char * Render( uint64 ulSteamID );	// static method to render a uint64 representation of a steam ID to a string
+
+	void SetFromString( const char *pchSteamID, EUniverse eDefaultUniverse );
+    // SetFromString allows many partially-correct strings, constraining how
+    // we might be able to change things in the future.
+    // SetFromStringStrict requires the exact string forms that we support
+    // and is preferred when the caller knows it's safe to be strict.
+    // Returns whether the string parsed correctly.
+	bool SetFromStringStrict( const char *pchSteamID, EUniverse eDefaultUniverse );
+	bool SetFromSteam2String( const char *pchSteam2ID, EUniverse eUniverse );
+
+	inline bool operator==( const CSteamID &val ) const { return m_steamid.m_unAll64Bits == val.m_steamid.m_unAll64Bits; } 
+	inline bool operator!=( const CSteamID &val ) const { return !operator==( val ); }
+	inline bool operator<( const CSteamID &val ) const { return m_steamid.m_unAll64Bits < val.m_steamid.m_unAll64Bits; }
+	inline bool operator>( const CSteamID &val ) const { return m_steamid.m_unAll64Bits > val.m_steamid.m_unAll64Bits; }
+
+	// DEBUG function
+	bool BValidExternalSteamID() const;
+
+private:
+	// These are defined here to prevent accidental implicit conversion of a u32AccountID to a CSteamID.
+	// If you get a compiler error about an ambiguous constructor/function then it may be because you're
+	// passing a 32-bit int to a function that takes a CSteamID. You should explicitly create the SteamID
+	// using the correct Universe and account Type/Instance values.
+	CSteamID( uint32 );
+	CSteamID( int32 );
+
+	// 64 bits total
+	union SteamID_t
+	{
+		struct SteamIDComponent_t
+		{
+#ifdef VALVE_BIG_ENDIAN
+			EUniverse			m_EUniverse : 8;	// universe this account belongs to
+			unsigned int		m_EAccountType : 4;			// type of account - can't show as EAccountType, due to signed / unsigned difference
+			unsigned int		m_unAccountInstance : 20;	// dynamic instance ID
+			uint32				m_unAccountID : 32;			// unique account identifier
+#else
+			uint32				m_unAccountID : 32;			// unique account identifier
+			unsigned int		m_unAccountInstance : 20;	// dynamic instance ID
+			unsigned int		m_EAccountType : 4;			// type of account - can't show as EAccountType, due to signed / unsigned difference
+			EUniverse			m_EUniverse : 8;	// universe this account belongs to
+#endif
+		} m_comp;
+
+		uint64 m_unAll64Bits;
+	} m_steamid;
+};
+
+inline bool CSteamID::IsValid() const
+{
+	if ( m_steamid.m_comp.m_EAccountType <= k_EAccountTypeInvalid || m_steamid.m_comp.m_EAccountType >= k_EAccountTypeMax )
+		return false;
+	
+	if ( m_steamid.m_comp.m_EUniverse <= k_EUniverseInvalid || m_steamid.m_comp.m_EUniverse >= k_EUniverseMax )
+		return false;
+
+	if ( m_steamid.m_comp.m_EAccountType == k_EAccountTypeIndividual )
+	{
+		if ( m_steamid.m_comp.m_unAccountID == 0 || m_steamid.m_comp.m_unAccountInstance != k_unSteamUserDefaultInstance )
+			return false;
+	}
+
+	if ( m_steamid.m_comp.m_EAccountType == k_EAccountTypeClan )
+	{
+		if ( m_steamid.m_comp.m_unAccountID == 0 || m_steamid.m_comp.m_unAccountInstance != 0 )
+			return false;
+	}
+
+	if ( m_steamid.m_comp.m_EAccountType == k_EAccountTypeGameServer )
+	{
+		if ( m_steamid.m_comp.m_unAccountID == 0 )
+			return false;
+		// Any limit on instances?  We use them for local users and bots
+	}
+	return true;
+}
+
+// generic invalid CSteamID
+#define k_steamIDNil CSteamID()
+
+// This steamID comes from a user game connection to an out of date GS that hasnt implemented the protocol
+// to provide its steamID
+#define k_steamIDOutofDateGS CSteamID( 0, 0, k_EUniverseInvalid, k_EAccountTypeInvalid )
+// This steamID comes from a user game connection to an sv_lan GS
+#define k_steamIDLanModeGS CSteamID( 0, 0, k_EUniversePublic, k_EAccountTypeInvalid )
+// This steamID can come from a user game connection to a GS that has just booted but hasnt yet even initialized
+// its steam3 component and started logging on.
+#define k_steamIDNotInitYetGS CSteamID( 1, 0, k_EUniverseInvalid, k_EAccountTypeInvalid )
+// This steamID can come from a user game connection to a GS that isn't using the steam authentication system but still
+// wants to support the "Join Game" option in the friends list
+#define k_steamIDNonSteamGS CSteamID( 2, 0, k_EUniverseInvalid, k_EAccountTypeInvalid )
+
+
+#ifdef STEAM
+// Returns the matching chat steamID, with the default instance of 0
+// If the steamID passed in is already of type k_EAccountTypeChat it will be returned with the same instance
+CSteamID ChatIDFromSteamID( const CSteamID &steamID );
+// Returns the matching clan steamID, with the default instance of 0
+// If the steamID passed in is already of type k_EAccountTypeClan it will be returned with the same instance
+CSteamID ClanIDFromSteamID( const CSteamID &steamID );
+// Asserts steamID type before conversion
+CSteamID ChatIDFromClanID( const CSteamID &steamIDClan );
+// Asserts steamID type before conversion
+CSteamID ClanIDFromChatID( const CSteamID &steamIDChat );
+
+#endif // _STEAM
+
+
+//-----------------------------------------------------------------------------
+// Purpose: encapsulates an appID/modID pair
+//-----------------------------------------------------------------------------
+class CGameID
+{
+public:
+
+	CGameID()
+	{
+		m_gameID.m_nType = k_EGameIDTypeApp;
+		m_gameID.m_nAppID = k_uAppIdInvalid;
+		m_gameID.m_nModID = 0;
+	}
+
+	explicit CGameID( uint64 ulGameID )
+	{
+		m_ulGameID = ulGameID;
+	}
+#ifdef INT64_DIFFERENT_FROM_INT64_T
+	CGameID( uint64_t ulGameID )
+	{
+		m_ulGameID = (uint64)ulGameID;
+	}
+#endif
+
+	explicit CGameID( int32 nAppID )
+	{
+		m_ulGameID = 0;
+		m_gameID.m_nAppID = nAppID;
+	}
+
+	explicit CGameID( uint32 nAppID )
+	{
+		m_ulGameID = 0;
+		m_gameID.m_nAppID = nAppID;
+	}
+
+	CGameID( uint32 nAppID, uint32 nModID )
+	{
+		m_ulGameID = 0;
+		m_gameID.m_nAppID = nAppID;
+		m_gameID.m_nModID = nModID;
+		m_gameID.m_nType = k_EGameIDTypeGameMod;
+	}
+
+	CGameID( const CGameID &that )
+	{
+		m_ulGameID = that.m_ulGameID;
+	}
+
+	CGameID& operator=( const CGameID & that )
+	{
+		m_ulGameID = that.m_ulGameID;
+		return *this;
+	}
+
+	// Hidden functions used only by Steam
+	explicit CGameID( const char *pchGameID );
+	const char *Render() const;					// render this Game ID to string
+	static const char *Render( uint64 ulGameID );		// static method to render a uint64 representation of a Game ID to a string
+
+	// must include checksum_crc.h first to get this functionality
+#if defined( CHECKSUM_CRC_H )
+	CGameID( uint32 nAppID, const char *pchModPath )
+	{
+		m_ulGameID = 0;
+		m_gameID.m_nAppID = nAppID;
+		m_gameID.m_nType = k_EGameIDTypeGameMod;
+
+		char rgchModDir[MAX_PATH];
+		V_FileBase( pchModPath, rgchModDir, sizeof( rgchModDir ) );
+		CRC32_t crc32;
+		CRC32_Init( &crc32 );
+		CRC32_ProcessBuffer( &crc32, rgchModDir, V_strlen( rgchModDir ) );
+		CRC32_Final( &crc32 );
+
+		// set the high-bit on the mod-id 
+		// reduces crc32 to 31bits, but lets us use the modID as a guaranteed unique
+		// replacement for appID's
+		m_gameID.m_nModID = crc32 | (0x80000000);
+	}
+
+	CGameID( const char *pchExePath, const char *pchAppName )
+	{
+		m_ulGameID = 0;
+		m_gameID.m_nAppID = k_uAppIdInvalid;
+		m_gameID.m_nType = k_EGameIDTypeShortcut;
+
+		CRC32_t crc32;
+		CRC32_Init( &crc32 );
+		if ( pchExePath )
+			CRC32_ProcessBuffer( &crc32, pchExePath, V_strlen( pchExePath ) );
+		if ( pchAppName )
+			CRC32_ProcessBuffer( &crc32, pchAppName, V_strlen( pchAppName ) );
+		CRC32_Final( &crc32 );
+
+		// set the high-bit on the mod-id 
+		// reduces crc32 to 31bits, but lets us use the modID as a guaranteed unique
+		// replacement for appID's
+		m_gameID.m_nModID = crc32 | (0x80000000);
+	}
+
+#if defined( VSTFILEID_H )
+
+	CGameID( VstFileID vstFileID )
+	{
+		m_ulGameID = 0;
+		m_gameID.m_nAppID = k_uAppIdInvalid;
+		m_gameID.m_nType = k_EGameIDTypeP2P;
+
+		CRC32_t crc32;
+		CRC32_Init( &crc32 );
+		const char *pchFileId = vstFileID.Render();
+		CRC32_ProcessBuffer( &crc32, pchFileId, V_strlen( pchFileId ) );
+		CRC32_Final( &crc32 );
+
+		// set the high-bit on the mod-id 
+		// reduces crc32 to 31bits, but lets us use the modID as a guaranteed unique
+		// replacement for appID's
+		m_gameID.m_nModID = crc32 | (0x80000000);		
+	}
+
+#endif /* VSTFILEID_H */
+
+#endif /* CHECKSUM_CRC_H */
+
+
+	uint64 ToUint64() const
+	{
+		return m_ulGameID;
+	}
+
+	uint64 *GetUint64Ptr()
+	{
+		return &m_ulGameID;
+	}
+
+	void Set( uint64 ulGameID )
+	{
+		m_ulGameID = ulGameID;
+	}
+
+	bool IsMod() const
+	{
+		return ( m_gameID.m_nType == k_EGameIDTypeGameMod );
+	}
+
+	bool IsShortcut() const
+	{
+		return ( m_gameID.m_nType == k_EGameIDTypeShortcut );
+	}
+
+	bool IsP2PFile() const
+	{
+		return ( m_gameID.m_nType == k_EGameIDTypeP2P );
+	}
+
+	bool IsSteamApp() const
+	{
+		return ( m_gameID.m_nType == k_EGameIDTypeApp );
+	}
+		
+	uint32 ModID() const
+	{
+		return m_gameID.m_nModID;
+	}
+
+	uint32 AppID() const
+	{
+		return m_gameID.m_nAppID;
+	}
+
+	bool operator == ( const CGameID &rhs ) const
+	{
+		return m_ulGameID == rhs.m_ulGameID;
+	}
+
+	bool operator != ( const CGameID &rhs ) const
+	{
+		return !(*this == rhs);
+	}
+
+	bool operator < ( const CGameID &rhs ) const
+	{
+		return ( m_ulGameID < rhs.m_ulGameID );
+	}
+
+	bool IsValid() const
+	{
+		// each type has it's own invalid fixed point:
+		switch( m_gameID.m_nType )
+		{
+		case k_EGameIDTypeApp:
+			return m_gameID.m_nAppID != k_uAppIdInvalid;
+
+		case k_EGameIDTypeGameMod:
+			return m_gameID.m_nAppID != k_uAppIdInvalid && m_gameID.m_nModID & 0x80000000;
+
+		case k_EGameIDTypeShortcut:
+			return (m_gameID.m_nModID & 0x80000000) != 0;
+
+		case k_EGameIDTypeP2P:
+			return m_gameID.m_nAppID == k_uAppIdInvalid && m_gameID.m_nModID & 0x80000000;
+
+		default:
+			return false;
+		}
+
+	}
+
+	void Reset() 
+	{
+		m_ulGameID = 0;
+	}
+
+
+
+private:
+
+	enum EGameIDType
+	{
+		k_EGameIDTypeApp		= 0,
+		k_EGameIDTypeGameMod	= 1,
+		k_EGameIDTypeShortcut	= 2,
+		k_EGameIDTypeP2P		= 3,
+	};
+
+	struct GameID_t
+	{
+#ifdef VALVE_BIG_ENDIAN
+		unsigned int m_nModID : 32;
+		unsigned int m_nType : 8;
+		unsigned int m_nAppID : 24;
+#else
+		unsigned int m_nAppID : 24;
+		unsigned int m_nType : 8;
+		unsigned int m_nModID : 32;
+#endif
+	};
+
+	union
+	{
+		uint64 m_ulGameID;
+		GameID_t m_gameID;
+	};
+};
+
+#pragma pack( pop )
+
+const int k_cchGameExtraInfoMax = 64;
+
+
+//-----------------------------------------------------------------------------
+// Constants used for query ports.
+//-----------------------------------------------------------------------------
+
+#define QUERY_PORT_NOT_INITIALIZED		0xFFFF	// We haven't asked the GS for this query port's actual value yet.
+#define QUERY_PORT_ERROR				0xFFFE	// We were unable to get the query port for this server.
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Passed as argument to SteamAPI_UseBreakpadCrashHandler to enable optional callback
+//  just before minidump file is captured after a crash has occurred.  (Allows app to append additional comment data to the dump, etc.)
+//-----------------------------------------------------------------------------
+typedef void (*PFNPreMinidumpCallback)(void *context);
+
+//-----------------------------------------------------------------------------
+// Purpose: Used by ICrashHandler interfaces to reference particular installed crash handlers
+//-----------------------------------------------------------------------------
+typedef void *BREAKPAD_HANDLE;
+#define BREAKPAD_INVALID_HANDLE (BREAKPAD_HANDLE)0 
+
+enum EGameSearchErrorCode_t
+{
+	k_EGameSearchErrorCode_OK = 1,
+	k_EGameSearchErrorCode_Failed_Search_Already_In_Progress = 2,
+	k_EGameSearchErrorCode_Failed_No_Search_In_Progress = 3,
+	k_EGameSearchErrorCode_Failed_Not_Lobby_Leader = 4, // if not the lobby leader can not call SearchForGameWithLobby
+	k_EGameSearchErrorCode_Failed_No_Host_Available = 5, // no host is available that matches those search params
+	k_EGameSearchErrorCode_Failed_Search_Params_Invalid = 6, // search params are invalid
+	k_EGameSearchErrorCode_Failed_Offline = 7, // offline, could not communicate with server
+	k_EGameSearchErrorCode_Failed_NotAuthorized = 8, // either the user or the application does not have priveledges to do this
+	k_EGameSearchErrorCode_Failed_Unknown_Error = 9, // unknown error
+};
+
+enum EPlayerResult_t
+{
+	k_EPlayerResultFailedToConnect = 1, // failed to connect after confirming
+	k_EPlayerResultAbandoned = 2,		// quit game without completing it
+	k_EPlayerResultKicked = 3,			// kicked by other players/moderator/server rules
+	k_EPlayerResultIncomplete = 4,		// player stayed to end but game did not conclude successfully ( nofault to player )
+	k_EPlayerResultCompleted = 5,		// player completed game
+};
+
+
+enum ESteamIPv6ConnectivityProtocol
+{
+	k_ESteamIPv6ConnectivityProtocol_Invalid = 0,
+	k_ESteamIPv6ConnectivityProtocol_HTTP = 1,		// because a proxy may make this different than other protocols
+	k_ESteamIPv6ConnectivityProtocol_UDP = 2,		// test UDP connectivity. Uses a port that is commonly needed for other Steam stuff. If UDP works, TCP probably works. 
+};
+
+// For the above transport protocol, what do we think the local machine's connectivity to the internet over ipv6 is like
+enum ESteamIPv6ConnectivityState
+{
+	k_ESteamIPv6ConnectivityState_Unknown = 0,	// We haven't run a test yet
+	k_ESteamIPv6ConnectivityState_Good = 1,		// We have recently been able to make a request on ipv6 for the given protocol
+	k_ESteamIPv6ConnectivityState_Bad = 2,		// We failed to make a request, either because this machine has no ipv6 address assigned, or it has no upstream connectivity
+};
+
+
+// Define compile time assert macros to let us validate the structure sizes.
+#define VALVE_COMPILE_TIME_ASSERT( pred ) typedef char compile_time_assert_type[(pred) ? 1 : -1];
+
+#if defined(__linux__) || defined(__APPLE__) 
+// The 32-bit version of gcc has the alignment requirement for uint64 and double set to
+// 4 meaning that even with #pragma pack(8) these types will only be four-byte aligned.
+// The 64-bit version of gcc has the alignment requirement for these types set to
+// 8 meaning that unless we use #pragma pack(4) our structures will get bigger.
+// The 64-bit structure packing has to match the 32-bit structure packing for each platform.
+#define VALVE_CALLBACK_PACK_SMALL
+#else
+#define VALVE_CALLBACK_PACK_LARGE
+#endif
+
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error ???
+#endif 
+
+typedef struct ValvePackingSentinel_t
+{
+    uint32 m_u32;
+    uint64 m_u64;
+    uint16 m_u16;
+    double m_d;
+} ValvePackingSentinel_t;
+
+#pragma pack( pop )
+
+
+#if defined(VALVE_CALLBACK_PACK_SMALL)
+VALVE_COMPILE_TIME_ASSERT( sizeof(ValvePackingSentinel_t) == 24 )
+#elif defined(VALVE_CALLBACK_PACK_LARGE)
+VALVE_COMPILE_TIME_ASSERT( sizeof(ValvePackingSentinel_t) == 32 )
+#else
+#error ???
+#endif
+
+#endif // STEAMCLIENTPUBLIC_H

--- a/lsteamclient/steamworks_sdk_148a/steamdatagram_tickets.h
+++ b/lsteamclient/steamworks_sdk_148a/steamdatagram_tickets.h
@@ -1,0 +1,286 @@
+//====== Copyright Valve Corporation, All rights reserved. ====================
+//
+// Types and utilities for handling steam datagram tickets.  These are
+// useful for both the client and the backend ticket generating authority.
+//
+//=============================================================================
+
+#ifndef STEAMDATAGRAM_TICKETS_H
+#define STEAMDATAGRAM_TICKETS_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#ifndef assert
+	#include <assert.h>
+#endif
+
+#include <string.h>
+#include "steamnetworkingtypes.h"
+
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error "Must define VALVE_CALLBACK_PACK_SMALL or VALVE_CALLBACK_PACK_LARGE"
+#endif
+
+/// Max length of serialized auth ticket.  This is important so that we
+/// can ensure that we always fit into a single UDP datagram (along with
+/// other certs and signatures) and keep the implementation simple.
+const size_t k_cbSteamDatagramMaxSerializedTicket = 512;
+
+/// Network-routable identifier for a service.  This is an intentionally
+/// opaque byte blob.  The relays know how to use this to forward it on
+/// to the intended destination, but otherwise clients really should not
+/// need to know what's inside.  (Indeed, we don't really want them to
+/// know, as it could reveal information useful to an attacker.)
+struct SteamDatagramHostedAddress
+{
+
+	// Size of data blob.
+	int m_cbSize;
+
+	// Opaque data
+	char m_data[ 128 ];
+
+	// Reset to empty state
+	void Clear() { memset( this, 0, sizeof(*this) ); }
+
+	// Parse the data center out of the blob.
+	SteamNetworkingPOPID GetPopID() const { return CalculateSteamNetworkingPOPIDFromString( m_data ); }
+
+	/// Set a dummy routing blob with a hardcoded IP:port.  You should only use
+	/// this in a dev environment, since the address is in plaintext!
+	/// In production this information should come from the server,
+	/// using ISteamNetworkingSockets::GetHostedDedicatedServerAddress
+	void SetDevAddress( uint32 nIP, uint16 nPort, SteamNetworkingPOPID popid = 0 )
+	{
+		GetSteamNetworkingLocationPOPStringFromID( popid, m_data );
+		m_cbSize = 4;
+		m_data[m_cbSize++] = 1;
+		m_data[m_cbSize++] = 1;
+		m_data[m_cbSize++] = char(nPort);
+		m_data[m_cbSize++] = char(nPort>>8);
+		m_data[m_cbSize++] = char(nIP);
+		m_data[m_cbSize++] = char(nIP>>8);
+		m_data[m_cbSize++] = char(nIP>>16);
+		m_data[m_cbSize++] = char(nIP>>24);
+	}
+
+	/// Convert to/from std::string (or anything that acts like it).
+	/// Useful for interfacing with google protobuf.  It's a template
+	/// mainly so that we don't have to include <string> in the header.
+	/// Note: by "string", we don't mean that it's text.  It's a binary
+	/// blob, and it might have zeros in it.  (std::string can handle that.)
+	template <typename T> bool SetFromStdString( const T &str )
+	{
+		if ( str.length() >= sizeof(m_data) )
+		{
+			m_cbSize = 0;
+			return false;
+		}
+		m_cbSize = (int)str.length();
+		memcpy( m_data, str.c_str(), m_cbSize );
+		return true;
+	}
+	template <typename T> void GetAsStdString( T *str ) const
+	{
+		str->assign( m_data, m_cbSize );
+	}
+};
+
+/// Ticket used to gain access to the relay network.
+struct SteamDatagramRelayAuthTicket
+{
+	SteamDatagramRelayAuthTicket() { Clear(); }
+
+	/// Reset all fields
+	void Clear() { memset( this, 0, sizeof(*this) ); m_nRestrictToVirtualPort = -1; }
+
+	/// Identity of the gameserver we want to talk to.  This is required.
+	SteamNetworkingIdentity m_identityGameserver;
+
+	/// Identity of the person who was authorized.  This is required.
+	SteamNetworkingIdentity m_identityAuthorizedClient;
+
+	/// SteamID is authorized to send from a particular public IP.  If this
+	/// is 0, then the sender is not restricted to a particular IP.
+	///
+	/// Recommend to leave this set to zero.
+	uint32 m_unPublicIP;
+
+	/// Time when the ticket expires.  Recommended: take the current
+	/// time and add 6 hours, or maybe a bit longer if your gameplay
+	/// sessions are longer.
+	///
+	/// NOTE: relays may reject tickets with expiry times excessively
+	/// far in the future, so contact us if you wish to use an expiry
+	/// longer than, say, 24 hours.
+	RTime32 m_rtimeTicketExpiry;
+
+	/// Routing information where the gameserver is listening for
+	/// relayed traffic.  You should fill this in when generating
+	/// a ticket.
+	///
+	/// When generating tickets on your backend:
+	/// - In production: The gameserver knows the proper routing
+	///   information, so you need to call
+	///   ISteamNetworkingSockets::GetHostedDedicatedServerAddress
+	///   and send the info to your backend.
+	/// - In development, you will need to provide public IP
+	///   of the server using SteamDatagramServiceNetID::SetDevAddress.
+	///   Relays need to be able to send UDP
+	///   packets to this server.  Since it's very likely that
+	///   your server is behind a firewall/NAT, make sure that
+	///   the address is the one that the outside world can use.
+	///   The traffic from the relays will be "unsolicited", so
+	///   stateful firewalls won't work -- you will probably have
+	///   to set up an explicit port forward.
+	/// On the client:
+	/// - this field will always be blank.
+	SteamDatagramHostedAddress m_routing;
+
+	/// App ID this is for.  This is required, and should be the
+	/// App ID the client is running.  (Even if your gameserver
+	/// uses a different App ID.)
+	uint32 m_nAppID;
+
+	/// Restrict this ticket to be used for a particular virtual port?
+	/// Set to -1 to allow any virtual port.
+	///
+	/// This is useful as a security measure, and also so the client will
+	/// use the right ticket (which might have extra fields that are useful
+	/// for proper analytics), if the client happens to have more than one
+	/// appropriate ticket.
+	///
+	/// Note: if a client has more that one acceptable ticket, they will
+	/// always use the one expiring the latest.
+	int m_nRestrictToVirtualPort;
+
+	//
+	// Extra fields.
+	//
+	// These are collected for backend analytics.  For example, you might
+	// send a MatchID so that all of the records for a particular match can
+	// be located.  Or send a game mode field so that you can compare
+	// the network characteristics of different game modes.
+	//
+	// (At the time of this writing we don't have a way to expose the data
+	// we collect to partners, but we hope to in the future so that you can
+	// get visibility into network conditions.)
+	//
+
+	struct ExtraField
+	{
+		enum EType
+		{
+			k_EType_String,
+			k_EType_Int, // For most small integral values.  Uses google protobuf sint64, so it's small on the wire.  WARNING: In some places this value may be transmitted in JSON, in which case precision may be lost in backend analytics.  Don't use this for an "identifier", use it for a scalar quantity.
+			k_EType_Fixed64, // 64 arbitrary bits.  This value is treated as an "identifier".  In places where JSON format is used, it will be serialized as a string.  No aggregation / analytics can be performed on this value.
+		};
+		int /* EType */ m_eType;
+		char m_szName[28];
+
+		union {
+			char m_szStringValue[128];
+			int64 m_nIntValue;
+			uint64 m_nFixed64Value;
+		};
+	};
+	enum { k_nMaxExtraFields = 16 };
+	int m_nExtraFields;
+	ExtraField m_vecExtraFields[ k_nMaxExtraFields ];
+
+	/// Helper to add an extra field in a single call
+	void AddExtraField_Int( const char *pszName, int64 val )
+	{
+		ExtraField *p = AddExtraField( pszName, ExtraField::k_EType_Int );
+		if ( p )
+			p->m_nIntValue = val;
+	}
+	void AddExtraField_Fixed64( const char *pszName, uint64 val )
+	{
+		ExtraField *p = AddExtraField( pszName, ExtraField::k_EType_Fixed64 );
+		if ( p )
+			p->m_nFixed64Value = val;
+	}
+	void AddExtraField_String( const char *pszName, const char *val )
+	{
+		ExtraField *p = AddExtraField( pszName, ExtraField::k_EType_String );
+		if ( p )
+		{
+			size_t l = strlen( val );
+			if ( l > sizeof(p->m_szStringValue)-1 )
+				l = sizeof(p->m_szStringValue)-1;
+			memcpy( p->m_szStringValue, val, l );
+			p->m_szStringValue[l] = '\0';
+		}
+	}
+
+private:
+	ExtraField *AddExtraField( const char *pszName, ExtraField::EType eType )
+	{
+		if ( m_nExtraFields >= k_nMaxExtraFields )
+		{
+			assert( false );
+			return NULL;
+		}
+		ExtraField *p = &m_vecExtraFields[ m_nExtraFields++ ];
+		p->m_eType = eType;
+
+		size_t l = strlen( pszName );
+		if ( l > sizeof(p->m_szName)-1 )
+			l = sizeof(p->m_szName)-1;
+		memcpy( p->m_szName, pszName, l );
+		p->m_szName[l] = '\0';
+		return p;
+	}
+};
+
+#pragma pack(pop)
+
+/// Max size of user data blob
+const size_t k_cbMaxSteamDatagramGameCoordinatorServerLoginAppData = 2048;
+
+/// Max size of serialized data blob
+const size_t k_cbMaxSteamDatagramGameCoordinatorServerLoginSerialized = 4096;
+
+/// Structure that describes a gameserver attempting to authenticate
+/// with your central server allocator / matchmaking service ("game coordinator").
+/// This is useful because the game coordinator needs to know:
+///
+/// - What data center is the gameserver running in?
+/// - The routing blob of the gameserver
+/// - Is the gameserver actually trusted?
+///
+/// Using this structure, you can securely communicate this information
+/// to your server, and you can do this WITHOUT maintaining any
+/// whitelists or tables of IP addresses.
+///
+/// See ISteamNetworkingSockets::GetGameCoordinatorServerLogin
+struct SteamDatagramGameCoordinatorServerLogin
+{
+	/// Server's identity
+	SteamNetworkingIdentity m_identity;
+
+	/// Routing info.  Note that this includes the POPID
+	SteamDatagramHostedAddress m_routing;
+
+	/// AppID that the server thinks it is running
+	AppId_t m_nAppID;
+
+	/// Unix timestamp when this was generated
+	RTime32 m_rtime;
+
+	/// Size of application data
+	int m_cbAppData;
+
+	/// Application data.  This is any additional information
+	/// that you need to identify the server not contained above.
+	/// (E.g. perhaps a public IP as seen by the coordinator service.)
+	char m_appData[ k_cbMaxSteamDatagramGameCoordinatorServerLoginAppData ];
+};
+
+#endif // STEAMDATAGRAM_TICKETS_H

--- a/lsteamclient/steamworks_sdk_148a/steamencryptedappticket.h
+++ b/lsteamclient/steamworks_sdk_148a/steamencryptedappticket.h
@@ -1,0 +1,36 @@
+//========= Copyright © 1996-2010, Valve LLC, All rights reserved. ============
+//
+// Purpose: utilities to decode/decrypt a ticket from the
+// ISteamUser::RequestEncryptedAppTicket, ISteamUser::GetEncryptedAppTicket API
+// 
+// To use: declare CSteamEncryptedAppTicket, then call BDecryptTicket
+// if BDecryptTicket returns true, other accessors are valid
+// 
+//=============================================================================
+
+#include "steam_api.h"
+
+static const int k_nSteamEncryptedAppTicketSymmetricKeyLen = 32;				
+
+
+S_API bool SteamEncryptedAppTicket_BDecryptTicket( const uint8 *rgubTicketEncrypted, uint32 cubTicketEncrypted,
+						  uint8 *rgubTicketDecrypted, uint32 *pcubTicketDecrypted,
+						  const uint8 rgubKey[k_nSteamEncryptedAppTicketSymmetricKeyLen], int cubKey );
+
+S_API bool SteamEncryptedAppTicket_BIsTicketForApp( uint8 *rgubTicketDecrypted, uint32 cubTicketDecrypted, AppId_t nAppID );
+
+S_API RTime32 SteamEncryptedAppTicket_GetTicketIssueTime( uint8 *rgubTicketDecrypted, uint32 cubTicketDecrypted );
+
+S_API void SteamEncryptedAppTicket_GetTicketSteamID( uint8 *rgubTicketDecrypted, uint32 cubTicketDecrypted, CSteamID *psteamID );
+
+S_API AppId_t SteamEncryptedAppTicket_GetTicketAppID( uint8 *rgubTicketDecrypted, uint32 cubTicketDecrypted );
+
+S_API bool SteamEncryptedAppTicket_BUserOwnsAppInTicket( uint8 *rgubTicketDecrypted, uint32 cubTicketDecrypted, AppId_t nAppID );
+
+S_API bool SteamEncryptedAppTicket_BUserIsVacBanned( uint8 *rgubTicketDecrypted, uint32 cubTicketDecrypted );
+
+S_API bool SteamEncryptedAppTicket_BGetAppDefinedValue( uint8 *rgubTicketDecrypted, uint32 cubTicketDecrypted, uint32 *pValue );
+
+S_API const uint8 *SteamEncryptedAppTicket_GetUserVariableData( uint8 *rgubTicketDecrypted, uint32 cubTicketDecrypted, uint32 *pcubUserData );
+
+S_API bool SteamEncryptedAppTicket_BIsTicketSigned( uint8 *rgubTicketDecrypted, uint32 cubTicketDecrypted, const uint8 *pubRSAKey, uint32 cubRSAKey );

--- a/lsteamclient/steamworks_sdk_148a/steamhttpenums.h
+++ b/lsteamclient/steamworks_sdk_148a/steamhttpenums.h
@@ -1,0 +1,98 @@
+//====== Copyright © 1996-2010, Valve Corporation, All rights reserved. =======
+//
+// Purpose: HTTP related enums, stuff that is shared by both clients and servers, and our
+// UI projects goes here.
+//
+//=============================================================================
+
+#ifndef STEAMHTTPENUMS_H
+#define STEAMHTTPENUMS_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+// HTTP related types
+
+// This enum is used in client API methods, do not re-number existing values.
+enum EHTTPMethod
+{
+	k_EHTTPMethodInvalid = 0,
+	k_EHTTPMethodGET,
+	k_EHTTPMethodHEAD,
+	k_EHTTPMethodPOST,
+	k_EHTTPMethodPUT,
+	k_EHTTPMethodDELETE,
+	k_EHTTPMethodOPTIONS,
+	k_EHTTPMethodPATCH,
+
+	// The remaining HTTP methods are not yet supported, per rfc2616 section 5.1.1 only GET and HEAD are required for 
+	// a compliant general purpose server.  We'll likely add more as we find uses for them.
+
+	// k_EHTTPMethodTRACE,
+	// k_EHTTPMethodCONNECT
+};
+
+
+// HTTP Status codes that the server can send in response to a request, see rfc2616 section 10.3 for descriptions
+// of each of these.
+enum EHTTPStatusCode
+{
+	// Invalid status code (this isn't defined in HTTP, used to indicate unset in our code)
+	k_EHTTPStatusCodeInvalid =					0,
+
+	// Informational codes
+	k_EHTTPStatusCode100Continue =				100,
+	k_EHTTPStatusCode101SwitchingProtocols =	101,
+
+	// Success codes
+	k_EHTTPStatusCode200OK =					200,
+	k_EHTTPStatusCode201Created =				201,
+	k_EHTTPStatusCode202Accepted =				202,
+	k_EHTTPStatusCode203NonAuthoritative =		203,
+	k_EHTTPStatusCode204NoContent =				204,
+	k_EHTTPStatusCode205ResetContent =			205,
+	k_EHTTPStatusCode206PartialContent =		206,
+
+	// Redirection codes
+	k_EHTTPStatusCode300MultipleChoices =		300,
+	k_EHTTPStatusCode301MovedPermanently =		301,
+	k_EHTTPStatusCode302Found =					302,
+	k_EHTTPStatusCode303SeeOther =				303,
+	k_EHTTPStatusCode304NotModified =			304,
+	k_EHTTPStatusCode305UseProxy =				305,
+	//k_EHTTPStatusCode306Unused =				306, (used in old HTTP spec, now unused in 1.1)
+	k_EHTTPStatusCode307TemporaryRedirect =		307,
+
+	// Error codes
+	k_EHTTPStatusCode400BadRequest =			400,
+	k_EHTTPStatusCode401Unauthorized =			401, // You probably want 403 or something else. 401 implies you're sending a WWW-Authenticate header and the client can sent an Authorization header in response.
+	k_EHTTPStatusCode402PaymentRequired =		402, // This is reserved for future HTTP specs, not really supported by clients
+	k_EHTTPStatusCode403Forbidden =				403,
+	k_EHTTPStatusCode404NotFound =				404,
+	k_EHTTPStatusCode405MethodNotAllowed =		405,
+	k_EHTTPStatusCode406NotAcceptable =			406,
+	k_EHTTPStatusCode407ProxyAuthRequired =		407,
+	k_EHTTPStatusCode408RequestTimeout =		408,
+	k_EHTTPStatusCode409Conflict =				409,
+	k_EHTTPStatusCode410Gone =					410,
+	k_EHTTPStatusCode411LengthRequired =		411,
+	k_EHTTPStatusCode412PreconditionFailed =	412,
+	k_EHTTPStatusCode413RequestEntityTooLarge =	413,
+	k_EHTTPStatusCode414RequestURITooLong =		414,
+	k_EHTTPStatusCode415UnsupportedMediaType =	415,
+	k_EHTTPStatusCode416RequestedRangeNotSatisfiable = 416,
+	k_EHTTPStatusCode417ExpectationFailed =		417,
+	k_EHTTPStatusCode4xxUnknown = 				418, // 418 is reserved, so we'll use it to mean unknown
+	k_EHTTPStatusCode429TooManyRequests	=		429,
+
+	// Server error codes
+	k_EHTTPStatusCode500InternalServerError =	500,
+	k_EHTTPStatusCode501NotImplemented =		501,
+	k_EHTTPStatusCode502BadGateway =			502,
+	k_EHTTPStatusCode503ServiceUnavailable =	503,
+	k_EHTTPStatusCode504GatewayTimeout =		504,
+	k_EHTTPStatusCode505HTTPVersionNotSupported = 505,
+	k_EHTTPStatusCode5xxUnknown =				599,
+};
+
+#endif // STEAMHTTPENUMS_H

--- a/lsteamclient/steamworks_sdk_148a/steamnetworkingtypes.h
+++ b/lsteamclient/steamworks_sdk_148a/steamnetworkingtypes.h
@@ -1,0 +1,1283 @@
+//====== Copyright Valve Corporation, All rights reserved. ====================
+//
+// Purpose: misc networking utilities
+//
+//=============================================================================
+
+#ifndef STEAMNETWORKINGTYPES
+#define STEAMNETWORKINGTYPES
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include <string.h>
+#include <stdint.h>
+
+//----------------------------------------
+// SteamNetworkingSockets library config
+// Compiling in Steam public branch.
+#define STEAMNETWORKINGSOCKETS_STEAM
+#ifdef STEAMNETWORKINGSOCKETS_STATIC_LINK
+	#define STEAMNETWORKINGSOCKETS_INTERFACE extern
+#endif
+#define STEAMNETWORKINGSOCKETS_STEAMCLIENT
+#define STEAMNETWORKINGSOCKETS_ENABLE_SDR
+#define STEAMNETWORKINGSOCKETS_ENABLE_P2P
+#include "steam_api_common.h"
+// 
+//----------------------------------------
+
+
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error "Must define VALVE_CALLBACK_PACK_SMALL or VALVE_CALLBACK_PACK_LARGE"
+#endif
+
+struct SteamDatagramRelayAuthTicket;
+struct SteamDatagramHostedAddress;
+struct SteamDatagramGameCoordinatorServerLogin;
+struct SteamNetConnectionStatusChangedCallback_t;
+struct SteamNetAuthenticationStatus_t;
+struct SteamRelayNetworkStatus_t;
+
+/// Handle used to identify a connection to a remote host.
+typedef uint32 HSteamNetConnection;
+const HSteamNetConnection k_HSteamNetConnection_Invalid = 0;
+
+/// Handle used to identify a "listen socket".  Unlike traditional
+/// Berkeley sockets, a listen socket and a connection are two
+/// different abstractions.
+typedef uint32 HSteamListenSocket;
+const HSteamListenSocket k_HSteamListenSocket_Invalid = 0;
+
+/// Handle used to identify a poll group, used to query many
+/// connections at once efficiently.
+typedef uint32 HSteamNetPollGroup;
+const HSteamNetPollGroup k_HSteamNetPollGroup_Invalid = 0;
+
+/// Max length of diagnostic error message
+const int k_cchMaxSteamNetworkingErrMsg = 1024;
+
+/// Used to return English-language diagnostic error messages to caller.
+/// (For debugging or spewing to a console, etc.  Not intended for UI.)
+typedef char SteamNetworkingErrMsg[ k_cchMaxSteamNetworkingErrMsg ];
+
+/// Identifier used for a network location point of presence.  (E.g. a Valve data center.)
+/// Typically you won't need to directly manipulate these.
+typedef uint32 SteamNetworkingPOPID;
+
+/// A local timestamp.  You can subtract two timestamps to get the number of elapsed
+/// microseconds.  This is guaranteed to increase over time during the lifetime
+/// of a process, but not globally across runs.  You don't need to worry about
+/// the value wrapping around.  Note that the underlying clock might not actually have
+/// microsecond resolution.
+typedef int64 SteamNetworkingMicroseconds;
+
+/// Describe the status of a particular network resource
+enum ESteamNetworkingAvailability
+{
+	// Negative values indicate a problem.
+	//
+	// In general, we will not automatically retry unless you take some action that
+	// depends on of requests this resource, such as querying the status, attempting
+	// to initiate a connection, receive a connection, etc.  If you do not take any
+	// action at all, we do not automatically retry in the background.
+	k_ESteamNetworkingAvailability_CannotTry = -102,		// A dependent resource is missing, so this service is unavailable.  (E.g. we cannot talk to routers because Internet is down or we don't have the network config.)
+	k_ESteamNetworkingAvailability_Failed = -101,			// We have tried for enough time that we would expect to have been successful by now.  We have never been successful
+	k_ESteamNetworkingAvailability_Previously = -100,		// We tried and were successful at one time, but now it looks like we have a problem
+
+	k_ESteamNetworkingAvailability_Retrying = -10,		// We previously failed and are currently retrying
+
+	// Not a problem, but not ready either
+	k_ESteamNetworkingAvailability_NeverTried = 1,		// We don't know because we haven't ever checked/tried
+	k_ESteamNetworkingAvailability_Waiting = 2,			// We're waiting on a dependent resource to be acquired.  (E.g. we cannot obtain a cert until we are logged into Steam.  We cannot measure latency to relays until we have the network config.)
+	k_ESteamNetworkingAvailability_Attempting = 3,		// We're actively trying now, but are not yet successful.
+
+	k_ESteamNetworkingAvailability_Current = 100,			// Resource is online/available
+
+
+	k_ESteamNetworkingAvailability_Unknown = 0,			// Internal dummy/sentinel, or value is not applicable in this context
+	k_ESteamNetworkingAvailability__Force32bit = 0x7fffffff,
+};
+
+//
+// Describing network hosts
+//
+
+/// Different methods of describing the identity of a network host
+enum ESteamNetworkingIdentityType
+{
+	// Dummy/empty/invalid.
+	// Plese note that if we parse a string that we don't recognize
+	// but that appears reasonable, we will NOT use this type.  Instead
+	// we'll use k_ESteamNetworkingIdentityType_UnknownType.
+	k_ESteamNetworkingIdentityType_Invalid = 0,
+
+	//
+	// Basic platform-specific identifiers.
+	//
+	k_ESteamNetworkingIdentityType_SteamID = 16, // 64-bit CSteamID
+
+	//
+	// Special identifiers.
+	//
+
+	// Use their IP address (and port) as their "identity".
+	// These types of identities are always unauthenticated.
+	// They are useful for porting plain sockets code, and other
+	// situations where you don't care about authentication.  In this
+	// case, the local identity will be "localhost",
+	// and the remote address will be their network address.
+	//
+	// We use the same type for either IPv4 or IPv6, and
+	// the address is always store as IPv6.  We use IPv4
+	// mapped addresses to handle IPv4.
+	k_ESteamNetworkingIdentityType_IPAddress = 1,
+
+	// Generic string/binary blobs.  It's up to your app to interpret this.
+	// This library can tell you if the remote host presented a certificate
+	// signed by somebody you have chosen to trust, with this identity on it.
+	// It's up to you to ultimately decide what this identity means.
+	k_ESteamNetworkingIdentityType_GenericString = 2,
+	k_ESteamNetworkingIdentityType_GenericBytes = 3,
+
+	// This identity type is used when we parse a string that looks like is a
+	// valid identity, just of a kind that we don't recognize.  In this case, we
+	// can often still communicate with the peer!  Allowing such identities
+	// for types we do not recognize useful is very useful for forward
+	// compatibility.
+	k_ESteamNetworkingIdentityType_UnknownType = 4,
+
+	// Make sure this enum is stored in an int.
+	k_ESteamNetworkingIdentityType__Force32bit = 0x7fffffff,
+};
+
+#pragma pack(push,1)
+
+/// Store an IP and port.  IPv6 is always used; IPv4 is represented using
+/// "IPv4-mapped" addresses: IPv4 aa.bb.cc.dd => IPv6 ::ffff:aabb:ccdd
+/// (RFC 4291 section 2.5.5.2.)
+struct SteamNetworkingIPAddr
+{
+	void Clear(); // Set everything to zero.  E.g. [::]:0
+	bool IsIPv6AllZeros() const;  // Return true if the IP is ::0.  (Doesn't check port.)
+	void SetIPv6( const uint8 *ipv6, uint16 nPort ); // Set IPv6 address.  IP is interpreted as bytes, so there are no endian issues.  (Same as inaddr_in6.)  The IP can be a mapped IPv4 address
+	void SetIPv4( uint32 nIP, uint16 nPort ); // Sets to IPv4 mapped address.  IP and port are in host byte order.
+	bool IsIPv4() const; // Return true if IP is mapped IPv4
+	uint32 GetIPv4() const; // Returns IP in host byte order (e.g. aa.bb.cc.dd as 0xaabbccdd).  Returns 0 if IP is not mapped IPv4.
+	void SetIPv6LocalHost( uint16 nPort = 0); // Set to the IPv6 localhost address ::1, and the specified port.
+	bool IsLocalHost() const; // Return true if this identity is localhost.  (Either IPv6 ::1, or IPv4 127.0.0.1)
+
+	// Max length of the buffer needed to hold IP formatted using ToString, including '\0'
+	// ([0123:4567:89ab:cdef:0123:4567:89ab:cdef]:12345)
+	enum { k_cchMaxString = 48 };
+
+	/// Print to a string, with or without the port.  Mapped IPv4 addresses are printed
+	/// as dotted decimal (12.34.56.78), otherwise this will print the canonical
+	/// form according to RFC5952.  If you include the port, IPv6 will be surrounded by
+	/// brackets, e.g. [::1:2]:80.  Your buffer should be at least k_cchMaxString bytes
+	/// to avoid truncation
+	inline void ToString( char *buf, size_t cbBuf, bool bWithPort ) const;
+
+	/// Parse an IP address and optional port.  If a port is not present, it is set to 0.
+	/// (This means that you cannot tell if a zero port was explicitly specified.)
+	inline bool ParseString( const char *pszStr );
+
+	union
+	{
+		uint8 m_ipv6[ 16 ];
+		#ifndef API_GEN // API generator doesn't understand this.  The bindings will just use the accessors
+		struct // IPv4 "mapped address" (rfc4038 section 4.2)
+		{
+			uint64 m_8zeros;
+			uint16 m_0000;
+			uint16 m_ffff;
+			uint8 m_ip[ 4 ]; // NOTE: As bytes, i.e. network byte order
+		} m_ipv4;
+		#endif
+	};
+	uint16 m_port; // Host byte order
+
+	/// See if two addresses are identical
+	bool operator==(const SteamNetworkingIPAddr &x ) const;
+};
+
+/// An abstract way to represent the identity of a network host.  All identities can
+/// be represented as simple string.  Furthermore, this string representation is actually
+/// used on the wire in several places, even though it is less efficient, in order to
+/// facilitate forward compatibility.  (Old client code can handle an identity type that
+/// it doesn't understand.)
+struct SteamNetworkingIdentity
+{
+	/// Type of identity.
+	ESteamNetworkingIdentityType m_eType;
+
+	//
+	// Get/Set in various formats.
+	//
+
+	void Clear();
+	bool IsInvalid() const; // Return true if we are the invalid type.  Does not make any other validity checks (e.g. is SteamID actually valid)
+
+	void SetSteamID( CSteamID steamID );
+	CSteamID GetSteamID() const; // Return black CSteamID (!IsValid()) if identity is not a SteamID
+	void SetSteamID64( uint64 steamID ); // Takes SteamID as raw 64-bit number
+	uint64 GetSteamID64() const; // Returns 0 if identity is not SteamID
+
+	void SetIPAddr( const SteamNetworkingIPAddr &addr ); // Set to specified IP:port
+	const SteamNetworkingIPAddr *GetIPAddr() const; // returns null if we are not an IP address.
+
+	// "localhost" is equivalent for many purposes to "anonymous."  Our remote
+	// will identify us by the network address we use.
+	void SetLocalHost(); // Set to localhost.  (We always use IPv6 ::1 for this, not 127.0.0.1)
+	bool IsLocalHost() const; // Return true if this identity is localhost.
+
+	bool SetGenericString( const char *pszString ); // Returns false if invalid length
+	const char *GetGenericString() const; // Returns nullptr if not generic string type
+
+	bool SetGenericBytes( const void *data, size_t cbLen ); // Returns false if invalid size.
+	const uint8 *GetGenericBytes( int &cbLen ) const; // Returns null if not generic bytes type
+
+	/// See if two identities are identical
+	bool operator==(const SteamNetworkingIdentity &x ) const;
+
+	/// Print to a human-readable string.  This is suitable for debug messages
+	/// or any other time you need to encode the identity as a string.  It has a
+	/// URL-like format (type:<type-data>).  Your buffer should be at least
+	/// k_cchMaxString bytes big to avoid truncation.
+	void ToString( char *buf, size_t cbBuf ) const;
+
+	/// Parse back a string that was generated using ToString.  If we don't understand the
+	/// string, but it looks "reasonable" (it matches the pattern type:<type-data> and doesn't
+	/// have any funcky characters, etc), then we will return true, and the type is set to
+	/// k_ESteamNetworkingIdentityType_UnknownType.  false will only be returned if the string
+	/// looks invalid.
+	bool ParseString( const char *pszStr );
+
+	// Max sizes
+	enum {
+		k_cchMaxString = 128, // Max length of the buffer needed to hold any identity, formatted in string format by ToString
+		k_cchMaxGenericString = 32, // Max length of the string for generic string identities.  Including terminating '\0'
+		k_cbMaxGenericBytes = 32,
+	};
+
+	//
+	// Internal representation.  Don't access this directly, use the accessors!
+	//
+	// Number of bytes that are relevant below.  This MUST ALWAYS be
+	// set.  (Use the accessors!)  This is important to enable old code to work
+	// with new identity types.
+	int m_cbSize;
+	union {
+		uint64 m_steamID64;
+		char m_szGenericString[ k_cchMaxGenericString ];
+		uint8 m_genericBytes[ k_cbMaxGenericBytes ];
+		char m_szUnknownRawString[ k_cchMaxString ];
+		SteamNetworkingIPAddr m_ip;
+		uint32 m_reserved[ 32 ]; // Pad structure to leave easy room for future expansion
+	};
+};
+#pragma pack(pop)
+
+//
+// Connection status
+//
+
+/// High level connection status
+enum ESteamNetworkingConnectionState
+{
+
+	/// Dummy value used to indicate an error condition in the API.
+	/// Specified connection doesn't exist or has already been closed.
+	k_ESteamNetworkingConnectionState_None = 0,
+
+	/// We are trying to establish whether peers can talk to each other,
+	/// whether they WANT to talk to each other, perform basic auth,
+	/// and exchange crypt keys.
+	///
+	/// - For connections on the "client" side (initiated locally):
+	///   We're in the process of trying to establish a connection.
+	///   Depending on the connection type, we might not know who they are.
+	///   Note that it is not possible to tell if we are waiting on the
+	///   network to complete handshake packets, or for the application layer
+	///   to accept the connection.
+	///
+	/// - For connections on the "server" side (accepted through listen socket):
+	///   We have completed some basic handshake and the client has presented
+	///   some proof of identity.  The connection is ready to be accepted
+	///   using AcceptConnection().
+	///
+	/// In either case, any unreliable packets sent now are almost certain
+	/// to be dropped.  Attempts to receive packets are guaranteed to fail.
+	/// You may send messages if the send mode allows for them to be queued.
+	/// but if you close the connection before the connection is actually
+	/// established, any queued messages will be discarded immediately.
+	/// (We will not attempt to flush the queue and confirm delivery to the
+	/// remote host, which ordinarily happens when a connection is closed.)
+	k_ESteamNetworkingConnectionState_Connecting = 1,
+
+	/// Some connection types use a back channel or trusted 3rd party
+	/// for earliest communication.  If the server accepts the connection,
+	/// then these connections switch into the rendezvous state.  During this
+	/// state, we still have not yet established an end-to-end route (through
+	/// the relay network), and so if you send any messages unreliable, they
+	/// are going to be discarded.
+	k_ESteamNetworkingConnectionState_FindingRoute = 2,
+
+	/// We've received communications from our peer (and we know
+	/// who they are) and are all good.  If you close the connection now,
+	/// we will make our best effort to flush out any reliable sent data that
+	/// has not been acknowledged by the peer.  (But note that this happens
+	/// from within the application process, so unlike a TCP connection, you are
+	/// not totally handing it off to the operating system to deal with it.)
+	k_ESteamNetworkingConnectionState_Connected = 3,
+
+	/// Connection has been closed by our peer, but not closed locally.
+	/// The connection still exists from an API perspective.  You must close the
+	/// handle to free up resources.  If there are any messages in the inbound queue,
+	/// you may retrieve them.  Otherwise, nothing may be done with the connection
+	/// except to close it.
+	///
+	/// This stats is similar to CLOSE_WAIT in the TCP state machine.
+	k_ESteamNetworkingConnectionState_ClosedByPeer = 4,
+
+	/// A disruption in the connection has been detected locally.  (E.g. timeout,
+	/// local internet connection disrupted, etc.)
+	///
+	/// The connection still exists from an API perspective.  You must close the
+	/// handle to free up resources.
+	///
+	/// Attempts to send further messages will fail.  Any remaining received messages
+	/// in the queue are available.
+	k_ESteamNetworkingConnectionState_ProblemDetectedLocally = 5,
+
+//
+// The following values are used internally and will not be returned by any API.
+// We document them here to provide a little insight into the state machine that is used
+// under the hood.
+//
+
+	/// We've disconnected on our side, and from an API perspective the connection is closed.
+	/// No more data may be sent or received.  All reliable data has been flushed, or else
+	/// we've given up and discarded it.  We do not yet know for sure that the peer knows
+	/// the connection has been closed, however, so we're just hanging around so that if we do
+	/// get a packet from them, we can send them the appropriate packets so that they can
+	/// know why the connection was closed (and not have to rely on a timeout, which makes
+	/// it appear as if something is wrong).
+	k_ESteamNetworkingConnectionState_FinWait = -1,
+
+	/// We've disconnected on our side, and from an API perspective the connection is closed.
+	/// No more data may be sent or received.  From a network perspective, however, on the wire,
+	/// we have not yet given any indication to the peer that the connection is closed.
+	/// We are in the process of flushing out the last bit of reliable data.  Once that is done,
+	/// we will inform the peer that the connection has been closed, and transition to the
+	/// FinWait state.
+	///
+	/// Note that no indication is given to the remote host that we have closed the connection,
+	/// until the data has been flushed.  If the remote host attempts to send us data, we will
+	/// do whatever is necessary to keep the connection alive until it can be closed properly.
+	/// But in fact the data will be discarded, since there is no way for the application to
+	/// read it back.  Typically this is not a problem, as application protocols that utilize
+	/// the lingering functionality are designed for the remote host to wait for the response
+	/// before sending any more data.
+	k_ESteamNetworkingConnectionState_Linger = -2, 
+
+	/// Connection is completely inactive and ready to be destroyed
+	k_ESteamNetworkingConnectionState_Dead = -3,
+
+	k_ESteamNetworkingConnectionState__Force32Bit = 0x7fffffff
+};
+
+/// Enumerate various causes of connection termination.  These are designed to work similar
+/// to HTTP error codes: the numeric range gives you a rough classification as to the source
+/// of the problem.
+enum ESteamNetConnectionEnd
+{
+	// Invalid/sentinel value
+	k_ESteamNetConnectionEnd_Invalid = 0,
+
+	//
+	// Application codes.  These are the values you will pass to
+	// ISteamNetworkingSockets::CloseConnection.  You can use these codes if
+	// you want to plumb through application-specific reason codes.  If you don't
+	// need this facility, feel free to always pass
+	// k_ESteamNetConnectionEnd_App_Generic.
+	//
+	// The distinction between "normal" and "exceptional" termination is
+	// one you may use if you find useful, but it's not necessary for you
+	// to do so.  The only place where we distinguish between normal and
+	// exceptional is in connection analytics.  If a significant
+	// proportion of connections terminates in an exceptional manner,
+	// this can trigger an alert.
+	//
+
+	// 1xxx: Application ended the connection in a "usual" manner.
+	//       E.g.: user intentionally disconnected from the server,
+	//             gameplay ended normally, etc
+	k_ESteamNetConnectionEnd_App_Min = 1000,
+		k_ESteamNetConnectionEnd_App_Generic = k_ESteamNetConnectionEnd_App_Min,
+		// Use codes in this range for "normal" disconnection
+	k_ESteamNetConnectionEnd_App_Max = 1999,
+
+	// 2xxx: Application ended the connection in some sort of exceptional
+	//       or unusual manner that might indicate a bug or configuration
+	//       issue.
+	// 
+	k_ESteamNetConnectionEnd_AppException_Min = 2000,
+		k_ESteamNetConnectionEnd_AppException_Generic = k_ESteamNetConnectionEnd_AppException_Min,
+		// Use codes in this range for "unusual" disconnection
+	k_ESteamNetConnectionEnd_AppException_Max = 2999,
+
+	//
+	// System codes.  These will be returned by the system when
+	// the connection state is k_ESteamNetworkingConnectionState_ClosedByPeer
+	// or k_ESteamNetworkingConnectionState_ProblemDetectedLocally.  It is
+	// illegal to pass a code in this range to ISteamNetworkingSockets::CloseConnection
+	//
+
+	// 3xxx: Connection failed or ended because of problem with the
+	//       local host or their connection to the Internet.
+	k_ESteamNetConnectionEnd_Local_Min = 3000,
+
+		// You cannot do what you want to do because you're running in offline mode.
+		k_ESteamNetConnectionEnd_Local_OfflineMode = 3001,
+
+		// We're having trouble contacting many (perhaps all) relays.
+		// Since it's unlikely that they all went offline at once, the best
+		// explanation is that we have a problem on our end.  Note that we don't
+		// bother distinguishing between "many" and "all", because in practice,
+		// it takes time to detect a connection problem, and by the time
+		// the connection has timed out, we might not have been able to
+		// actively probe all of the relay clusters, even if we were able to
+		// contact them at one time.  So this code just means that:
+		//
+		// * We don't have any recent successful communication with any relay.
+		// * We have evidence of recent failures to communicate with multiple relays.
+		k_ESteamNetConnectionEnd_Local_ManyRelayConnectivity = 3002,
+
+		// A hosted server is having trouble talking to the relay
+		// that the client was using, so the problem is most likely
+		// on our end
+		k_ESteamNetConnectionEnd_Local_HostedServerPrimaryRelay = 3003,
+
+		// We're not able to get the network config.  This is
+		// *almost* always a local issue, since the network config
+		// comes from the CDN, which is pretty darn reliable.
+		k_ESteamNetConnectionEnd_Local_NetworkConfig = 3004,
+
+		// Steam rejected our request because we don't have rights
+		// to do this.
+		k_ESteamNetConnectionEnd_Local_Rights = 3005,
+
+	k_ESteamNetConnectionEnd_Local_Max = 3999,
+
+	// 4xxx: Connection failed or ended, and it appears that the
+	//       cause does NOT have to do with the local host or their
+	//       connection to the Internet.  It could be caused by the
+	//       remote host, or it could be somewhere in between.
+	k_ESteamNetConnectionEnd_Remote_Min = 4000,
+
+		// The connection was lost, and as far as we can tell our connection
+		// to relevant services (relays) has not been disrupted.  This doesn't
+		// mean that the problem is "their fault", it just means that it doesn't
+		// appear that we are having network issues on our end.
+		k_ESteamNetConnectionEnd_Remote_Timeout = 4001,
+
+		// Something was invalid with the cert or crypt handshake
+		// info you gave me, I don't understand or like your key types,
+		// etc.
+		k_ESteamNetConnectionEnd_Remote_BadCrypt = 4002,
+
+		// You presented me with a cert that was I was able to parse
+		// and *technically* we could use encrypted communication.
+		// But there was a problem that prevents me from checking your identity
+		// or ensuring that somebody int he middle can't observe our communication.
+		// E.g.: - the CA key was missing (and I don't accept unsigned certs)
+		// - The CA key isn't one that I trust,
+		// - The cert doesn't was appropriately restricted by app, user, time, data center, etc.
+		// - The cert wasn't issued to you.
+		// - etc
+		k_ESteamNetConnectionEnd_Remote_BadCert = 4003,
+
+		// We couldn't rendezvous with the remote host because
+		// they aren't logged into Steam
+		k_ESteamNetConnectionEnd_Remote_NotLoggedIn = 4004,
+
+		// We couldn't rendezvous with the remote host because
+		// they aren't running the right application.
+		k_ESteamNetConnectionEnd_Remote_NotRunningApp = 4005,
+
+		// Something wrong with the protocol version you are using.
+		// (Probably the code you are running is too old.)
+		k_ESteamNetConnectionEnd_Remote_BadProtocolVersion = 4006,
+
+	k_ESteamNetConnectionEnd_Remote_Max = 4999,
+
+	// 5xxx: Connection failed for some other reason.
+	k_ESteamNetConnectionEnd_Misc_Min = 5000,
+
+		// A failure that isn't necessarily the result of a software bug,
+		// but that should happen rarely enough that it isn't worth specifically
+		// writing UI or making a localized message for.
+		// The debug string should contain further details.
+		k_ESteamNetConnectionEnd_Misc_Generic = 5001,
+
+		// Generic failure that is most likely a software bug.
+		k_ESteamNetConnectionEnd_Misc_InternalError = 5002,
+
+		// The connection to the remote host timed out, but we
+		// don't know if the problem is on our end, in the middle,
+		// or on their end.
+		k_ESteamNetConnectionEnd_Misc_Timeout = 5003,
+
+		// We're having trouble talking to the relevant relay.
+		// We don't have enough information to say whether the
+		// problem is on our end or not.
+		k_ESteamNetConnectionEnd_Misc_RelayConnectivity = 5004,
+
+		// There's some trouble talking to Steam.
+		k_ESteamNetConnectionEnd_Misc_SteamConnectivity = 5005,
+
+		// A server in a dedicated hosting situation has no relay sessions
+		// active with which to talk back to a client.  (It's the client's
+		// job to open and maintain those sessions.)
+		k_ESteamNetConnectionEnd_Misc_NoRelaySessionsToClient = 5006,
+
+	k_ESteamNetConnectionEnd_Misc_Max = 5999,
+
+	k_ESteamNetConnectionEnd__Force32Bit = 0x7fffffff
+};
+
+/// Max length, in bytes (including null terminator) of the reason string
+/// when a connection is closed.
+const int k_cchSteamNetworkingMaxConnectionCloseReason = 128;
+
+/// Max length, in bytes (include null terminator) of debug description
+/// of a connection.
+const int k_cchSteamNetworkingMaxConnectionDescription = 128;
+
+/// Describe the state of a connection.
+struct SteamNetConnectionInfo_t
+{
+
+	/// Who is on the other end?  Depending on the connection type and phase of the connection, we might not know
+	SteamNetworkingIdentity m_identityRemote;
+
+	/// Arbitrary user data set by the local application code
+	int64 m_nUserData;
+
+	/// Handle to listen socket this was connected on, or k_HSteamListenSocket_Invalid if we initiated the connection
+	HSteamListenSocket m_hListenSocket;
+
+	/// Remote address.  Might be all 0's if we don't know it, or if this is N/A.
+	/// (E.g. Basically everything except direct UDP connection.)
+	SteamNetworkingIPAddr m_addrRemote;
+	uint16 m__pad1;
+
+	/// What data center is the remote host in?  (0 if we don't know.)
+	SteamNetworkingPOPID m_idPOPRemote;
+
+	/// What relay are we using to communicate with the remote host?
+	/// (0 if not applicable.)
+	SteamNetworkingPOPID m_idPOPRelay;
+
+	/// High level state of the connection
+	ESteamNetworkingConnectionState m_eState;
+
+	/// Basic cause of the connection termination or problem.
+	/// See ESteamNetConnectionEnd for the values used
+	int m_eEndReason;
+
+	/// Human-readable, but non-localized explanation for connection
+	/// termination or problem.  This is intended for debugging /
+	/// diagnostic purposes only, not to display to users.  It might
+	/// have some details specific to the issue.
+	char m_szEndDebug[ k_cchSteamNetworkingMaxConnectionCloseReason ];
+
+	/// Debug description.  This includes the connection handle,
+	/// connection type (and peer information), and the app name.
+	/// This string is used in various internal logging messages
+	char m_szConnectionDescription[ k_cchSteamNetworkingMaxConnectionDescription ];
+
+	/// Internal stuff, room to change API easily
+	uint32 reserved[64];
+};
+
+/// Quick connection state, pared down to something you could call
+/// more frequently without it being too big of a perf hit.
+struct SteamNetworkingQuickConnectionStatus
+{
+
+	/// High level state of the connection
+	ESteamNetworkingConnectionState m_eState;
+
+	/// Current ping (ms)
+	int m_nPing;
+
+	/// Connection quality measured locally, 0...1.  (Percentage of packets delivered
+	/// end-to-end in order).
+	float m_flConnectionQualityLocal;
+
+	/// Packet delivery success rate as observed from remote host
+	float m_flConnectionQualityRemote;
+
+	/// Current data rates from recent history.
+	float m_flOutPacketsPerSec;
+	float m_flOutBytesPerSec;
+	float m_flInPacketsPerSec;
+	float m_flInBytesPerSec;
+
+	/// Estimate rate that we believe that we can send data to our peer.
+	/// Note that this could be significantly higher than m_flOutBytesPerSec,
+	/// meaning the capacity of the channel is higher than you are sending data.
+	/// (That's OK!)
+	int m_nSendRateBytesPerSecond;
+
+	/// Number of bytes pending to be sent.  This is data that you have recently
+	/// requested to be sent but has not yet actually been put on the wire.  The
+	/// reliable number ALSO includes data that was previously placed on the wire,
+	/// but has now been scheduled for re-transmission.  Thus, it's possible to
+	/// observe m_cbPendingReliable increasing between two checks, even if no
+	/// calls were made to send reliable data between the checks.  Data that is
+	/// awaiting the Nagle delay will appear in these numbers.
+	int m_cbPendingUnreliable;
+	int m_cbPendingReliable;
+
+	/// Number of bytes of reliable data that has been placed the wire, but
+	/// for which we have not yet received an acknowledgment, and thus we may
+	/// have to re-transmit.
+	int m_cbSentUnackedReliable;
+
+	/// If you asked us to send a message right now, how long would that message
+	/// sit in the queue before we actually started putting packets on the wire?
+	/// (And assuming Nagle does not cause any packets to be delayed.)
+	///
+	/// In general, data that is sent by the application is limited by the
+	/// bandwidth of the channel.  If you send data faster than this, it must
+	/// be queued and put on the wire at a metered rate.  Even sending a small amount
+	/// of data (e.g. a few MTU, say ~3k) will require some of the data to be delayed
+	/// a bit.
+	///
+	/// In general, the estimated delay will be approximately equal to
+	///
+	///		( m_cbPendingUnreliable+m_cbPendingReliable ) / m_nSendRateBytesPerSecond
+	///
+	/// plus or minus one MTU.  It depends on how much time has elapsed since the last
+	/// packet was put on the wire.  For example, the queue might have *just* been emptied,
+	/// and the last packet placed on the wire, and we are exactly up against the send
+	/// rate limit.  In that case we might need to wait for one packet's worth of time to
+	/// elapse before we can send again.  On the other extreme, the queue might have data
+	/// in it waiting for Nagle.  (This will always be less than one packet, because as soon
+	/// as we have a complete packet we would send it.)  In that case, we might be ready
+	/// to send data now, and this value will be 0.
+	SteamNetworkingMicroseconds m_usecQueueTime;
+
+	/// Internal stuff, room to change API easily
+	uint32 reserved[16];
+};
+
+#pragma pack( pop )
+
+//
+// Network messages
+//
+
+/// Max size of a single message that we can SEND.
+/// Note: We might be wiling to receive larger messages,
+/// and our peer might, too.
+const int k_cbMaxSteamNetworkingSocketsMessageSizeSend = 512 * 1024;
+
+/// A message that has been received.
+struct SteamNetworkingMessage_t
+{
+
+	/// Message payload
+	void *m_pData;
+
+	/// Size of the payload.
+	int m_cbSize;
+
+	/// For messages received on connections: what connection did this come from?
+	/// For outgoing messages: what connection to send it to?
+	/// Not used when using the ISteamNetworkingMessages interface
+	HSteamNetConnection m_conn;
+
+	/// For inbound messages: Who sent this to us?
+	/// For outbound messages on connections: not used.
+	/// For outbound messages on the ad-hoc ISteamNetworkingMessages interface: who should we send this to?
+	SteamNetworkingIdentity m_identityPeer;
+
+	/// For messages received on connections, this is the user data
+	/// associated with the connection.
+	///
+	/// This is *usually* the same as calling GetConnection() and then
+	/// fetching the user data associated with that connection, but for
+	/// the following subtle differences:
+	///
+	/// - This user data will match the connection's user data at the time
+	///   is captured at the time the message is returned by the API.
+	///   If you subsequently change the userdata on the connection,
+	///   this won't be updated.
+	/// - This is an inline call, so it's *much* faster.
+	/// - You might have closed the connection, so fetching the user data
+	///   would not be possible.
+	///
+	/// Not used when sending messages, 
+	int64 m_nConnUserData;
+
+	/// Local timestamp when the message was received
+	/// Not used for outbound messages.
+	SteamNetworkingMicroseconds m_usecTimeReceived;
+
+	/// Message number assigned by the sender.
+	/// This is not used for outbound messages
+	int64 m_nMessageNumber;
+
+	/// Function used to free up m_pData.  This mechanism exists so that
+	/// apps can create messages with buffers allocated from their own
+	/// heap, and pass them into the library.  This function will
+	/// usually be something like:
+	///
+	/// free( pMsg->m_pData );
+	void (*m_pfnFreeData)( SteamNetworkingMessage_t *pMsg );
+
+	/// Function to used to decrement the internal reference count and, if
+	/// it's zero, release the message.  You should not set this function pointer,
+	/// or need to access this directly!  Use the Release() function instead!
+	void (*m_pfnRelease)( SteamNetworkingMessage_t *pMsg );
+
+	/// When using ISteamNetworkingMessages, the channel number the message was received on
+	/// (Not used for messages sent or received on "connections")
+	int m_nChannel;
+
+	/// Bitmask of k_nSteamNetworkingSend_xxx flags.
+	/// For received messages, only the k_nSteamNetworkingSend_Reliable bit is valid.
+	/// For outbound messages, all bits are relevant
+	int m_nFlags;
+
+	/// Arbitrary user data that you can use when sending messages using
+	/// ISteamNetworkingUtils::AllocateMessage and ISteamNetworkingSockets::SendMessage.
+	/// (The callback you set in m_pfnFreeData might use this field.)
+	///
+	/// Not used for received messages.
+	int64 m_nUserData;
+
+	/// You MUST call this when you're done with the object,
+	/// to free up memory, etc.
+	inline void Release();
+
+	// For code compatibility, some accessors
+#ifndef API_GEN
+	inline uint32 GetSize() const { return m_cbSize; }
+	inline const void *GetData() const { return m_pData; }
+	inline int GetChannel() const { return m_nChannel; }
+	inline HSteamNetConnection GetConnection() const { return m_conn; }
+	inline int64 GetConnectionUserData() const { return m_nConnUserData; }
+	inline SteamNetworkingMicroseconds GetTimeReceived() const { return m_usecTimeReceived; }
+	inline int64 GetMessageNumber() const { return m_nMessageNumber; }
+#endif
+protected:
+	// Declare destructor protected.  You should never need to declare a message
+	// object on the stack or create one yourself.
+	// - You will receive a pointer to a message object when you receive messages (e.g. ISteamNetworkingSockets::ReceiveMessagesOnConnection)
+	// - You can allocate a message object for efficient sending using ISteamNetworkingUtils::AllocateMessage
+	// - Call Release() to free the object
+	inline ~SteamNetworkingMessage_t() {}
+};
+
+//
+// Flags used to set options for message sending
+//
+
+// Send the message unreliably. Can be lost.  Messages *can* be larger than a
+// single MTU (UDP packet), but there is no retransmission, so if any piece
+// of the message is lost, the entire message will be dropped.
+//
+// The sending API does have some knowledge of the underlying connection, so
+// if there is no NAT-traversal accomplished or there is a recognized adjustment
+// happening on the connection, the packet will be batched until the connection
+// is open again.
+//
+// Migration note: This is not exactly the same as k_EP2PSendUnreliable!  You
+// probably want k_ESteamNetworkingSendType_UnreliableNoNagle
+const int k_nSteamNetworkingSend_Unreliable = 0;
+
+// Disable Nagle's algorithm.
+// By default, Nagle's algorithm is applied to all outbound messages.  This means
+// that the message will NOT be sent immediately, in case further messages are
+// sent soon after you send this, which can be grouped together.  Any time there
+// is enough buffered data to fill a packet, the packets will be pushed out immediately,
+// but partially-full packets not be sent until the Nagle timer expires.  See
+// ISteamNetworkingSockets::FlushMessagesOnConnection, ISteamNetworkingMessages::FlushMessagesToUser
+//
+// NOTE: Don't just send every message without Nagle because you want packets to get there
+// quicker.  Make sure you understand the problem that Nagle is solving before disabling it.
+// If you are sending small messages, often many at the same time, then it is very likely that
+// it will be more efficient to leave Nagle enabled.  A typical proper use of this flag is
+// when you are sending what you know will be the last message sent for a while (e.g. the last
+// in the server simulation tick to a particular client), and you use this flag to flush all
+// messages.
+const int k_nSteamNetworkingSend_NoNagle = 1;
+
+// Send a message unreliably, bypassing Nagle's algorithm for this message and any messages
+// currently pending on the Nagle timer.  This is equivalent to using k_ESteamNetworkingSend_Unreliable
+// and then immediately flushing the messages using ISteamNetworkingSockets::FlushMessagesOnConnection
+// or ISteamNetworkingMessages::FlushMessagesToUser.  (But using this flag is more efficient since you
+// only make one API call.)
+const int k_nSteamNetworkingSend_UnreliableNoNagle = k_nSteamNetworkingSend_Unreliable|k_nSteamNetworkingSend_NoNagle;
+
+// If the message cannot be sent very soon (because the connection is still doing some initial
+// handshaking, route negotiations, etc), then just drop it.  This is only applicable for unreliable
+// messages.  Using this flag on reliable messages is invalid.
+const int k_nSteamNetworkingSend_NoDelay = 4;
+
+// Send an unreliable message, but if it cannot be sent relatively quickly, just drop it instead of queuing it.
+// This is useful for messages that are not useful if they are excessively delayed, such as voice data.
+// NOTE: The Nagle algorithm is not used, and if the message is not dropped, any messages waiting on the
+// Nagle timer are immediately flushed.
+//
+// A message will be dropped under the following circumstances:
+// - the connection is not fully connected.  (E.g. the "Connecting" or "FindingRoute" states)
+// - there is a sufficiently large number of messages queued up already such that the current message
+//   will not be placed on the wire in the next ~200ms or so.
+//
+// If a message is dropped for these reasons, k_EResultIgnored will be returned.
+const int k_nSteamNetworkingSend_UnreliableNoDelay = k_nSteamNetworkingSend_Unreliable|k_nSteamNetworkingSend_NoDelay|k_nSteamNetworkingSend_NoNagle;
+
+// Reliable message send. Can send up to k_cbMaxSteamNetworkingSocketsMessageSizeSend bytes in a single message. 
+// Does fragmentation/re-assembly of messages under the hood, as well as a sliding window for
+// efficient sends of large chunks of data.
+//
+// The Nagle algorithm is used.  See notes on k_ESteamNetworkingSendType_Unreliable for more details.
+// See k_ESteamNetworkingSendType_ReliableNoNagle, ISteamNetworkingSockets::FlushMessagesOnConnection,
+// ISteamNetworkingMessages::FlushMessagesToUser
+//
+// Migration note: This is NOT the same as k_EP2PSendReliable, it's more like k_EP2PSendReliableWithBuffering
+const int k_nSteamNetworkingSend_Reliable = 8;
+
+// Send a message reliably, but bypass Nagle's algorithm.
+//
+// Migration note: This is equivalent to k_EP2PSendReliable
+const int k_nSteamNetworkingSend_ReliableNoNagle = k_nSteamNetworkingSend_Reliable|k_nSteamNetworkingSend_NoNagle;
+
+// By default, message sending is queued, and the work of encryption and talking to
+// the operating system sockets, etc is done on a service thread.  This is usually a
+// a performance win when messages are sent from the "main thread".  However, if this
+// flag is set, and data is ready to be sent immediately (either from this message
+// or earlier queued data), then that work will be done in the current thread, before
+// the current call returns.  If data is not ready to be sent (due to rate limiting
+// or Nagle), then this flag has no effect.
+//
+// This is an advanced flag used to control performance at a very low level.  For
+// most applications running on modern hardware with more than one CPU core, doing
+// the work of sending on a service thread will yield the best performance.  Only
+// use this flag if you have a really good reason and understand what you are doing.
+// Otherwise you will probably just make performance worse.
+const int k_nSteamNetworkingSend_UseCurrentThread = 16;
+
+//
+// Ping location / measurement
+//
+
+/// Object that describes a "location" on the Internet with sufficient
+/// detail that we can reasonably estimate an upper bound on the ping between
+/// the two hosts, even if a direct route between the hosts is not possible,
+/// and the connection must be routed through the Steam Datagram Relay network.
+/// This does not contain any information that identifies the host.  Indeed,
+/// if two hosts are in the same building or otherwise have nearly identical
+/// networking characteristics, then it's valid to use the same location
+/// object for both of them.
+///
+/// NOTE: This object should only be used in the same process!  Do not serialize it,
+/// send it over the wire, or persist it in a file or database!  If you need
+/// to do that, convert it to a string representation using the methods in
+/// ISteamNetworkingUtils().
+struct SteamNetworkPingLocation_t
+{
+	uint8 m_data[ 512 ];
+};
+
+/// Max possible length of a ping location, in string format.  This is
+/// an extremely conservative worst case value which leaves room for future
+/// syntax enhancements.  Most strings in practice are a lot shorter.
+/// If you are storing many of these, you will very likely benefit from
+/// using dynamic memory.
+const int k_cchMaxSteamNetworkingPingLocationString = 1024;
+
+/// Special values that are returned by some functions that return a ping.
+const int k_nSteamNetworkingPing_Failed = -1;
+const int k_nSteamNetworkingPing_Unknown = -2;
+
+//
+// Configuration values
+//
+
+/// Configuration values can be applied to different types of objects.
+enum ESteamNetworkingConfigScope
+{
+
+	/// Get/set global option, or defaults.  Even options that apply to more specific scopes
+	/// have global scope, and you may be able to just change the global defaults.  If you
+	/// need different settings per connection (for example), then you will need to set those
+	/// options at the more specific scope.
+	k_ESteamNetworkingConfig_Global = 1,
+
+	/// Some options are specific to a particular interface.  Note that all connection
+	/// and listen socket settings can also be set at the interface level, and they will
+	/// apply to objects created through those interfaces.
+	k_ESteamNetworkingConfig_SocketsInterface = 2,
+
+	/// Options for a listen socket.  Listen socket options can be set at the interface layer,
+	/// if  you have multiple listen sockets and they all use the same options.
+	/// You can also set connection options on a listen socket, and they set the defaults
+	/// for all connections accepted through this listen socket.  (They will be used if you don't
+	/// set a connection option.)
+	k_ESteamNetworkingConfig_ListenSocket = 3,
+
+	/// Options for a specific connection.
+	k_ESteamNetworkingConfig_Connection = 4,
+
+	k_ESteamNetworkingConfigScope__Force32Bit = 0x7fffffff
+};
+
+// Different configuration values have different data types
+enum ESteamNetworkingConfigDataType
+{
+	k_ESteamNetworkingConfig_Int32 = 1,
+	k_ESteamNetworkingConfig_Int64 = 2,
+	k_ESteamNetworkingConfig_Float = 3,
+	k_ESteamNetworkingConfig_String = 4,
+	k_ESteamNetworkingConfig_FunctionPtr = 5, // NOTE: When setting	callbacks, you should put the pointer into a variable and pass a pointer to that variable.
+
+	k_ESteamNetworkingConfigDataType__Force32Bit = 0x7fffffff
+};
+
+/// Configuration options
+enum ESteamNetworkingConfigValue
+{
+	k_ESteamNetworkingConfig_Invalid = 0,
+
+	/// [global float, 0--100] Randomly discard N pct of packets instead of sending/recv
+	/// This is a global option only, since it is applied at a low level
+	/// where we don't have much context
+	k_ESteamNetworkingConfig_FakePacketLoss_Send = 2,
+	k_ESteamNetworkingConfig_FakePacketLoss_Recv = 3,
+
+	/// [global int32].  Delay all outbound/inbound packets by N ms
+	k_ESteamNetworkingConfig_FakePacketLag_Send = 4,
+	k_ESteamNetworkingConfig_FakePacketLag_Recv = 5,
+
+	/// [global float] 0-100 Percentage of packets we will add additional delay
+	/// to (causing them to be reordered)
+	k_ESteamNetworkingConfig_FakePacketReorder_Send = 6,
+	k_ESteamNetworkingConfig_FakePacketReorder_Recv = 7,
+
+	/// [global int32] Extra delay, in ms, to apply to reordered packets.
+	k_ESteamNetworkingConfig_FakePacketReorder_Time = 8,
+
+	/// [global float 0--100] Globally duplicate some percentage of packets we send
+	k_ESteamNetworkingConfig_FakePacketDup_Send = 26,
+	k_ESteamNetworkingConfig_FakePacketDup_Recv = 27,
+
+	/// [global int32] Amount of delay, in ms, to delay duplicated packets.
+	/// (We chose a random delay between 0 and this value)
+	k_ESteamNetworkingConfig_FakePacketDup_TimeMax = 28,
+
+	/// [connection int32] Timeout value (in ms) to use when first connecting
+	k_ESteamNetworkingConfig_TimeoutInitial = 24,
+
+	/// [connection int32] Timeout value (in ms) to use after connection is established
+	k_ESteamNetworkingConfig_TimeoutConnected = 25,
+
+	/// [connection int32] Upper limit of buffered pending bytes to be sent,
+	/// if this is reached SendMessage will return k_EResultLimitExceeded
+	/// Default is 512k (524288 bytes)
+	k_ESteamNetworkingConfig_SendBufferSize = 9,
+
+	/// [connection int32] Minimum/maximum send rate clamp, 0 is no limit.
+	/// This value will control the min/max allowed sending rate that 
+	/// bandwidth estimation is allowed to reach.  Default is 0 (no-limit)
+	k_ESteamNetworkingConfig_SendRateMin = 10,
+	k_ESteamNetworkingConfig_SendRateMax = 11,
+
+	/// [connection int32] Nagle time, in microseconds.  When SendMessage is called, if
+	/// the outgoing message is less than the size of the MTU, it will be
+	/// queued for a delay equal to the Nagle timer value.  This is to ensure
+	/// that if the application sends several small messages rapidly, they are
+	/// coalesced into a single packet.
+	/// See historical RFC 896.  Value is in microseconds. 
+	/// Default is 5000us (5ms).
+	k_ESteamNetworkingConfig_NagleTime = 12,
+
+	/// [connection int32] Don't automatically fail IP connections that don't have
+	/// strong auth.  On clients, this means we will attempt the connection even if
+	/// we don't know our identity or can't get a cert.  On the server, it means that
+	/// we won't automatically reject a connection due to a failure to authenticate.
+	/// (You can examine the incoming connection and decide whether to accept it.)
+	///
+	/// This is a dev configuration value, and you should not let users modify it in
+	/// production.
+	k_ESteamNetworkingConfig_IP_AllowWithoutAuth = 23,
+
+	/// [connection int32] Do not send UDP packets with a payload of
+	/// larger than N bytes.  If you set this, k_ESteamNetworkingConfig_MTU_DataSize
+	/// is automatically adjusted
+	k_ESteamNetworkingConfig_MTU_PacketSize = 32,
+
+	/// [connection int32] (read only) Maximum message size you can send that
+	/// will not fragment, based on k_ESteamNetworkingConfig_MTU_PacketSize
+	k_ESteamNetworkingConfig_MTU_DataSize = 33,
+
+	/// [connection int32] Allow unencrypted (and unauthenticated) communication.
+	/// 0: Not allowed (the default)
+	/// 1: Allowed, but prefer encrypted
+	/// 2: Allowed, and preferred
+	/// 3: Required.  (Fail the connection if the peer requires encryption.)
+	///
+	/// This is a dev configuration value, since its purpose is to disable encryption.
+	/// You should not let users modify it in production.  (But note that it requires
+	/// the peer to also modify their value in order for encryption to be disabled.)
+	k_ESteamNetworkingConfig_Unencrypted = 34,
+
+	/// [global int32] 0 or 1.  Some variables are "dev" variables.  They are useful
+	/// for debugging, but should not be adjusted in production.  When this flag is false (the default),
+	/// such variables will not be enumerated by the ISteamnetworkingUtils::GetFirstConfigValue
+	/// ISteamNetworkingUtils::GetConfigValueInfo functions.  The idea here is that you
+	/// can use those functions to provide a generic mechanism to set any configuration
+	/// value from a console or configuration file, looking up the variable by name.  Depending
+	/// on your game, modifying other configuration values may also have negative effects, and
+	/// you may wish to further lock down which variables are allowed to be modified by the user.
+	/// (Maybe no variables!)  Or maybe you use a whitelist or blacklist approach.
+	///
+	/// (This flag is itself a dev variable.)
+	k_ESteamNetworkingConfig_EnumerateDevVars = 35,
+
+	//
+	// Settings for SDR relayed connections
+	//
+
+	/// [int32 global] If the first N pings to a port all fail, mark that port as unavailable for
+	/// a while, and try a different one.  Some ISPs and routers may drop the first
+	/// packet, so setting this to 1 may greatly disrupt communications.
+	k_ESteamNetworkingConfig_SDRClient_ConsecutitivePingTimeoutsFailInitial = 19,
+
+	/// [int32 global] If N consecutive pings to a port fail, after having received successful 
+	/// communication, mark that port as unavailable for a while, and try a 
+	/// different one.
+	k_ESteamNetworkingConfig_SDRClient_ConsecutitivePingTimeoutsFail = 20,
+
+	/// [int32 global] Minimum number of lifetime pings we need to send, before we think our estimate
+	/// is solid.  The first ping to each cluster is very often delayed because of NAT,
+	/// routers not having the best route, etc.  Until we've sent a sufficient number
+	/// of pings, our estimate is often inaccurate.  Keep pinging until we get this
+	/// many pings.
+	k_ESteamNetworkingConfig_SDRClient_MinPingsBeforePingAccurate = 21,
+
+	/// [int32 global] Set all steam datagram traffic to originate from the same
+	/// local port. By default, we open up a new UDP socket (on a different local
+	/// port) for each relay.  This is slightly less optimal, but it works around
+	/// some routers that don't implement NAT properly.  If you have intermittent
+	/// problems talking to relays that might be NAT related, try toggling
+	/// this flag
+	k_ESteamNetworkingConfig_SDRClient_SingleSocket = 22,
+
+	/// [global string] Code of relay cluster to force use.  If not empty, we will
+	/// only use relays in that cluster.  E.g. 'iad'
+	k_ESteamNetworkingConfig_SDRClient_ForceRelayCluster = 29,
+
+	/// [connection string] For debugging, generate our own (unsigned) ticket, using
+	/// the specified  gameserver address.  Router must be configured to accept unsigned
+	/// tickets.
+	k_ESteamNetworkingConfig_SDRClient_DebugTicketAddress = 30,
+
+	/// [global string] For debugging.  Override list of relays from the config with
+	/// this set (maybe just one).  Comma-separated list.
+	k_ESteamNetworkingConfig_SDRClient_ForceProxyAddr = 31,
+
+	/// [global string] For debugging.  Force ping times to clusters to be the specified
+	/// values.  A comma separated list of <cluster>=<ms> values.  E.g. "sto=32,iad=100"
+	///
+	/// This is a dev configuration value, you probably should not let users modify it
+	/// in production.
+	k_ESteamNetworkingConfig_SDRClient_FakeClusterPing = 36,
+
+	//
+	// Log levels for debuging information.  A higher priority
+	// (lower numeric value) will cause more stuff to be printed.  
+	//
+	k_ESteamNetworkingConfig_LogLevel_AckRTT = 13, // [connection int32] RTT calculations for inline pings and replies
+	k_ESteamNetworkingConfig_LogLevel_PacketDecode = 14, // [connection int32] log SNP packets send
+	k_ESteamNetworkingConfig_LogLevel_Message = 15, // [connection int32] log each message send/recv
+	k_ESteamNetworkingConfig_LogLevel_PacketGaps = 16, // [connection int32] dropped packets
+	k_ESteamNetworkingConfig_LogLevel_P2PRendezvous = 17, // [connection int32] P2P rendezvous messages
+	k_ESteamNetworkingConfig_LogLevel_SDRRelayPings = 18, // [global int32] Ping relays
+
+	k_ESteamNetworkingConfigValue__Force32Bit = 0x7fffffff
+};
+
+/// In a few places we need to set configuration options on listen sockets and connections, and
+/// have them take effect *before* the listen socket or connection really starts doing anything.
+/// Creating the object and then setting the options "immediately" after creation doesn't work
+/// completely, because network packets could be received between the time the object is created and
+/// when the options are applied.  To set options at creation time in a reliable way, they must be
+/// passed to the creation function.  This structure is used to pass those options.
+///
+/// For the meaning of these fields, see ISteamNetworkingUtils::SetConfigValue.  Basically
+/// when the object is created, we just iterate over the list of options and call
+/// ISteamNetworkingUtils::SetConfigValueStruct, where the scope arguments are supplied by the
+/// object being created.
+struct SteamNetworkingConfigValue_t
+{
+	/// Which option is being set
+	ESteamNetworkingConfigValue m_eValue;
+
+	/// Which field below did you fill in?
+	ESteamNetworkingConfigDataType m_eDataType;
+
+	/// Option value
+	union
+	{
+		int32_t m_int32;
+		int64_t m_int64;
+		float m_float;
+		const char *m_string; // Points to your '\0'-terminated buffer
+		void *m_functionPtr;
+	} m_val;
+};
+
+/// Return value of ISteamNetworkintgUtils::GetConfigValue
+enum ESteamNetworkingGetConfigValueResult
+{
+	k_ESteamNetworkingGetConfigValue_BadValue = -1,	// No such configuration value
+	k_ESteamNetworkingGetConfigValue_BadScopeObj = -2,	// Bad connection handle, etc
+	k_ESteamNetworkingGetConfigValue_BufferTooSmall = -3, // Couldn't fit the result in your buffer
+	k_ESteamNetworkingGetConfigValue_OK = 1,
+	k_ESteamNetworkingGetConfigValue_OKInherited = 2, // A value was not set at this level, but the effective (inherited) value was returned.
+
+	k_ESteamNetworkingGetConfigValueResult__Force32Bit = 0x7fffffff
+};
+
+//
+// Debug output
+//
+
+/// Detail level for diagnostic output callback.
+/// See ISteamNetworkingUtils::SetDebugOutputFunction
+enum ESteamNetworkingSocketsDebugOutputType
+{
+	k_ESteamNetworkingSocketsDebugOutputType_None = 0,
+	k_ESteamNetworkingSocketsDebugOutputType_Bug = 1, // You used the API incorrectly, or an internal error happened
+	k_ESteamNetworkingSocketsDebugOutputType_Error = 2, // Run-time error condition that isn't the result of a bug.  (E.g. we are offline, cannot bind a port, etc)
+	k_ESteamNetworkingSocketsDebugOutputType_Important = 3, // Nothing is wrong, but this is an important notification
+	k_ESteamNetworkingSocketsDebugOutputType_Warning = 4,
+	k_ESteamNetworkingSocketsDebugOutputType_Msg = 5, // Recommended amount
+	k_ESteamNetworkingSocketsDebugOutputType_Verbose = 6, // Quite a bit
+	k_ESteamNetworkingSocketsDebugOutputType_Debug = 7, // Practically everything
+	k_ESteamNetworkingSocketsDebugOutputType_Everything = 8, // Wall of text, detailed packet contents breakdown, etc
+
+	k_ESteamNetworkingSocketsDebugOutputType__Force32Bit = 0x7fffffff
+};
+
+/// Setup callback for debug output, and the desired verbosity you want.
+typedef void (*FSteamNetworkingSocketsDebugOutput)( ESteamNetworkingSocketsDebugOutputType nType, const char *pszMsg );
+
+//
+// Valve data centers
+//
+
+/// Convert 3- or 4-character ID to 32-bit int.
+inline SteamNetworkingPOPID CalculateSteamNetworkingPOPIDFromString( const char *pszCode )
+{
+	// OK we made a bad decision when we decided how to pack 3-character codes into a uint32.  We'd like to support
+	// 4-character codes, but we don't want to break compatibility.  The migration path has some subtleties that make
+	// this nontrivial, and there are already some IDs stored in SQL.  Ug, so the 4 character code "abcd" will
+	// be encoded with the digits like "0xddaabbcc".
+	//
+	// Also: we don't currently use 1- or 2-character codes, but if ever do in the future, let's make sure don't read
+	// past the end of the string and access uninitialized memory.  (And if the string is empty, we always want
+	// to return 0 and not read bytes past the '\0'.)
+	//
+	// There is also extra paranoia to make sure the bytes are not treated as signed.
+	SteamNetworkingPOPID result = (uint32)(uint8)pszCode[0] << 16U;
+	if ( pszCode[1] )
+	{
+		result |= ( (uint32)(uint8)pszCode[1] << 8U );
+		if ( pszCode[2] )
+		{
+			result |= (uint32)(uint8)pszCode[2] | ( (uint32)(uint8)pszCode[3] << 24U );
+		}
+	}
+	return result;
+}
+
+/// Unpack integer to string representation, including terminating '\0'
+template <int N>
+inline void GetSteamNetworkingLocationPOPStringFromID( SteamNetworkingPOPID id, char (&szCode)[N] )
+{
+	static_assert( N >= 5, "Fixed-size buffer not big enough to hold SDR POP ID" );
+	szCode[0] = char( id >> 16U );
+	szCode[1] = char( id >> 8U );
+	szCode[2] = char( id );
+	szCode[3] = char( id >> 24U ); // See comment above about deep regret and sadness
+	szCode[4] = 0;
+}
+
+/// The POPID "dev" is used in non-production environments for testing.
+const SteamNetworkingPOPID k_SteamDatagramPOPID_dev = ( (uint32)'d' << 16U ) | ( (uint32)'e' << 8U ) | (uint32)'v';
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// Internal stuff
+#ifndef API_GEN
+
+// For code compatibility
+typedef SteamNetworkingMessage_t ISteamNetworkingMessage;
+typedef SteamNetworkingErrMsg SteamDatagramErrMsg;
+
+inline void SteamNetworkingIPAddr::Clear() { memset( this, 0, sizeof(*this) ); }
+inline bool SteamNetworkingIPAddr::IsIPv6AllZeros() const { const uint64 *q = (const uint64 *)m_ipv6; return q[0] == 0 && q[1] == 0; }
+inline void SteamNetworkingIPAddr::SetIPv6( const uint8 *ipv6, uint16 nPort ) { memcpy( m_ipv6, ipv6, 16 ); m_port = nPort; }
+inline void SteamNetworkingIPAddr::SetIPv4( uint32 nIP, uint16 nPort ) { m_ipv4.m_8zeros = 0; m_ipv4.m_0000 = 0; m_ipv4.m_ffff = 0xffff; m_ipv4.m_ip[0] = uint8(nIP>>24); m_ipv4.m_ip[1] = uint8(nIP>>16); m_ipv4.m_ip[2] = uint8(nIP>>8); m_ipv4.m_ip[3] = uint8(nIP); m_port = nPort; }
+inline bool SteamNetworkingIPAddr::IsIPv4() const { return m_ipv4.m_8zeros == 0 && m_ipv4.m_0000 == 0 && m_ipv4.m_ffff == 0xffff; }
+inline uint32 SteamNetworkingIPAddr::GetIPv4() const { return IsIPv4() ? ( (uint32(m_ipv4.m_ip[0])<<24) | (uint32(m_ipv4.m_ip[1])<<16) | (uint32(m_ipv4.m_ip[2])<<8) | uint32(m_ipv4.m_ip[3]) ) : 0; }
+inline void SteamNetworkingIPAddr::SetIPv6LocalHost( uint16 nPort ) { m_ipv4.m_8zeros = 0; m_ipv4.m_0000 = 0; m_ipv4.m_ffff = 0; m_ipv6[12] = 0; m_ipv6[13] = 0; m_ipv6[14] = 0; m_ipv6[15] = 1; m_port = nPort; }
+inline bool SteamNetworkingIPAddr::IsLocalHost() const { return ( m_ipv4.m_8zeros == 0 && m_ipv4.m_0000 == 0 && m_ipv4.m_ffff == 0 && m_ipv6[12] == 0 && m_ipv6[13] == 0 && m_ipv6[14] == 0 && m_ipv6[15] == 1 ) || ( GetIPv4() == 0x7f000001 ); }
+inline bool SteamNetworkingIPAddr::operator==(const SteamNetworkingIPAddr &x ) const { return memcmp( this, &x, sizeof(SteamNetworkingIPAddr) ) == 0; }
+
+inline void SteamNetworkingIdentity::Clear() { memset( this, 0, sizeof(*this) ); }
+inline bool SteamNetworkingIdentity::IsInvalid() const { return m_eType == k_ESteamNetworkingIdentityType_Invalid; }
+inline void SteamNetworkingIdentity::SetSteamID( CSteamID steamID ) { SetSteamID64( steamID.ConvertToUint64() ); }
+inline CSteamID SteamNetworkingIdentity::GetSteamID() const { return CSteamID( GetSteamID64() ); }
+inline void SteamNetworkingIdentity::SetSteamID64( uint64 steamID ) { m_eType = k_ESteamNetworkingIdentityType_SteamID; m_cbSize = sizeof( m_steamID64 ); m_steamID64 = steamID; }
+inline uint64 SteamNetworkingIdentity::GetSteamID64() const { return m_eType == k_ESteamNetworkingIdentityType_SteamID ? m_steamID64 : 0; }
+inline void SteamNetworkingIdentity::SetIPAddr( const SteamNetworkingIPAddr &addr ) { m_eType = k_ESteamNetworkingIdentityType_IPAddress; m_cbSize = (int)sizeof(m_ip); m_ip = addr; }
+inline const SteamNetworkingIPAddr *SteamNetworkingIdentity::GetIPAddr() const { return m_eType == k_ESteamNetworkingIdentityType_IPAddress ? &m_ip : NULL; }
+inline void SteamNetworkingIdentity::SetLocalHost() { m_eType = k_ESteamNetworkingIdentityType_IPAddress; m_cbSize = (int)sizeof(m_ip); m_ip.SetIPv6LocalHost(); }
+inline bool SteamNetworkingIdentity::IsLocalHost() const { return m_eType == k_ESteamNetworkingIdentityType_IPAddress && m_ip.IsLocalHost(); }
+inline bool SteamNetworkingIdentity::SetGenericString( const char *pszString ) { size_t l = strlen( pszString ); if ( l >= sizeof(m_szGenericString) ) return false;
+	m_eType = k_ESteamNetworkingIdentityType_GenericString; m_cbSize = int(l+1); memcpy( m_szGenericString, pszString, m_cbSize ); return true; }
+inline const char *SteamNetworkingIdentity::GetGenericString() const { return m_eType == k_ESteamNetworkingIdentityType_GenericString ? m_szGenericString : NULL; }
+inline bool SteamNetworkingIdentity::SetGenericBytes( const void *data, size_t cbLen ) { if ( cbLen > sizeof(m_genericBytes) ) return false;
+	m_eType = k_ESteamNetworkingIdentityType_GenericBytes; m_cbSize = int(cbLen); memcpy( m_genericBytes, data, m_cbSize ); return true; }
+inline const uint8 *SteamNetworkingIdentity::GetGenericBytes( int &cbLen ) const { if ( m_eType != k_ESteamNetworkingIdentityType_GenericBytes ) return NULL;
+	cbLen = m_cbSize; return m_genericBytes; }
+inline bool SteamNetworkingIdentity::operator==(const SteamNetworkingIdentity &x ) const { return m_eType == x.m_eType && m_cbSize == x.m_cbSize && memcmp( m_genericBytes, x.m_genericBytes, m_cbSize ) == 0; }
+inline void SteamNetworkingMessage_t::Release() { (*m_pfnRelease)( this ); }
+
+#if defined( STEAMNETWORKINGSOCKETS_STATIC_LINK ) || !defined( STEAMNETWORKINGSOCKETS_STEAMCLIENT )
+STEAMNETWORKINGSOCKETS_INTERFACE void SteamAPI_SteamNetworkingIPAddr_ToString( const SteamNetworkingIPAddr *pAddr, char *buf, size_t cbBuf, bool bWithPort );
+STEAMNETWORKINGSOCKETS_INTERFACE bool SteamAPI_SteamNetworkingIPAddr_ParseString( SteamNetworkingIPAddr *pAddr, const char *pszStr );
+STEAMNETWORKINGSOCKETS_INTERFACE void SteamAPI_SteamNetworkingIdentity_ToString( const SteamNetworkingIdentity &identity, char *buf, size_t cbBuf );
+STEAMNETWORKINGSOCKETS_INTERFACE bool SteamAPI_SteamNetworkingIdentity_ParseString( SteamNetworkingIdentity *pIdentity, size_t sizeofIdentity, const char *pszStr );
+inline void SteamNetworkingIPAddr::ToString( char *buf, size_t cbBuf, bool bWithPort ) const { SteamAPI_SteamNetworkingIPAddr_ToString( this, buf, cbBuf, bWithPort ); }
+inline bool SteamNetworkingIPAddr::ParseString( const char *pszStr ) { return SteamAPI_SteamNetworkingIPAddr_ParseString( this, pszStr ); }
+inline void SteamNetworkingIdentity::ToString( char *buf, size_t cbBuf ) const { SteamAPI_SteamNetworkingIdentity_ToString( *this, buf, cbBuf ); }
+inline bool SteamNetworkingIdentity::ParseString( const char *pszStr ) { return SteamAPI_SteamNetworkingIdentity_ParseString( this, sizeof(*this), pszStr ); }
+#endif
+
+#endif // #ifndef API_GEN
+
+#endif // #ifndef STEAMNETWORKINGTYPES

--- a/lsteamclient/steamworks_sdk_148a/steamps3params.h
+++ b/lsteamclient/steamworks_sdk_148a/steamps3params.h
@@ -1,0 +1,112 @@
+//====== Copyright 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: 
+//
+//=============================================================================
+
+#ifndef STEAMPS3PARAMS_H
+#define STEAMPS3PARAMS_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+//	PlayStation 3 initialization parameters
+//
+//	The following structure must be passed to when loading steam_api_ps3.prx
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+#define STEAM_PS3_PATH_MAX 1055
+#define STEAM_PS3_SERVICE_ID_MAX 32
+#define STEAM_PS3_COMMUNICATION_ID_MAX 10
+#define STEAM_PS3_COMMUNICATION_SIG_MAX 160
+#define STEAM_PS3_LANGUAGE_MAX 64
+#define STEAM_PS3_REGION_CODE_MAX 16
+#define STEAM_PS3_CURRENT_PARAMS_VER 2
+struct SteamPS3Params_t
+{
+	uint32 m_unVersion;										// set to STEAM_PS3_CURRENT_PARAMS_VER
+	
+	void *pReserved;
+	uint32 m_nAppId;										// set to your game's appid
+
+	char m_rgchInstallationPath[ STEAM_PS3_PATH_MAX ];		// directory containing latest steam prx's and sdata. Can be read only (BDVD)
+	char m_rgchSystemCache[ STEAM_PS3_PATH_MAX ];			// temp working cache, not persistent 
+	char m_rgchGameData[ STEAM_PS3_PATH_MAX ];				// persistent game data path for storing user data
+	char m_rgchNpServiceID[ STEAM_PS3_SERVICE_ID_MAX ];
+	char m_rgchNpCommunicationID[ STEAM_PS3_COMMUNICATION_ID_MAX ];
+	char m_rgchNpCommunicationSig[ STEAM_PS3_COMMUNICATION_SIG_MAX ];
+
+	// Language should be one of the following. must be zero terminated
+	// danish
+	// dutch
+	// english
+	// finnish
+	// french
+	// german
+	// italian
+	// korean
+	// norwegian
+	// polish
+	// portuguese
+	// russian
+	// schinese
+	// spanish
+	// swedish
+	// tchinese
+	char m_rgchSteamLanguage[ STEAM_PS3_LANGUAGE_MAX ];
+
+	// region codes are "SCEA", "SCEE", "SCEJ". must be zero terminated
+	char m_rgchRegionCode[ STEAM_PS3_REGION_CODE_MAX ];
+
+	// Should be SYS_TTYP3 through SYS_TTYP10, if it's 0 then Steam won't spawn a 
+	// thread to read console input at all.  Using this let's you use Steam console commands
+	// like: profile_on, profile_off, profile_dump, mem_stats, mem_validate.
+	unsigned int m_cSteamInputTTY;
+
+	struct Ps3netInit_t
+	{
+		bool m_bNeedInit;
+		void *m_pMemory;
+		int m_nMemorySize;
+		int m_flags;
+	} m_sysNetInitInfo;
+
+	struct Ps3jpgInit_t
+	{
+		bool m_bNeedInit;
+	} m_sysJpgInitInfo;
+
+	struct Ps3pngInit_t
+	{
+		bool m_bNeedInit;
+	} m_sysPngInitInfo;
+	
+	struct Ps3sysutilUserInfo_t
+	{
+		bool m_bNeedInit;
+	} m_sysSysUtilUserInfo;
+
+	bool m_bIncludeNewsPage;
+};
+
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+// PlayStation 3 memory structure
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+#define STEAMPS3_MALLOC_INUSE 0x53D04A51
+#define STEAMPS3_MALLOC_SYSTEM 0x0D102C48
+#define STEAMPS3_MALLOC_OK 0xFFD04A51
+struct SteamPS3Memory_t
+{
+	bool m_bSingleAllocation;		// If true, Steam will request one 6MB allocation and use the returned memory for all future allocations
+									// If false, Steam will make call malloc for each allocation
+
+	// required function pointers
+	void* (*m_pfMalloc)(size_t);
+	void* (*m_pfRealloc)(void *, size_t);
+	void (*m_pfFree)(void *);
+	size_t (*m_pUsable_size)(void*);
+};
+
+
+#endif // STEAMPS3PARAMS_H

--- a/lsteamclient/steamworks_sdk_148a/steamtypes.h
+++ b/lsteamclient/steamworks_sdk_148a/steamtypes.h
@@ -1,0 +1,263 @@
+//========= Copyright © 1996-2008, Valve LLC, All rights reserved. ============
+//
+// Purpose:
+//
+//=============================================================================
+
+#ifndef STEAMTYPES_H
+#define STEAMTYPES_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#define S_CALLTYPE __cdecl
+
+// Steam-specific types. Defined here so this header file can be included in other code bases.
+#ifndef WCHARTYPES_H
+typedef unsigned char uint8;
+#endif
+
+#if defined( __GNUC__ ) && !defined(POSIX)
+	#if __GNUC__ < 4
+		#error "Steamworks requires GCC 4.X (4.2 or 4.4 have been tested)"
+	#endif
+	#define POSIX 1
+#endif
+
+#if defined(__x86_64__) || defined(_WIN64) || defined(__aarch64__)
+#define X64BITS
+#endif
+
+// Make sure VALVE_BIG_ENDIAN gets set on PS3, may already be set previously in Valve internal code.
+#if !defined(VALVE_BIG_ENDIAN) && defined(_PS3)
+#define VALVE_BIG_ENDIAN
+#endif
+
+typedef unsigned char uint8;
+typedef signed char int8;
+
+#if defined( _WIN32 )
+
+typedef __int16 int16;
+typedef unsigned __int16 uint16;
+typedef __int32 int32;
+typedef unsigned __int32 uint32;
+typedef __int64 int64;
+typedef unsigned __int64 uint64;
+
+typedef int64 lint64;
+typedef uint64 ulint64;
+
+#ifdef X64BITS
+typedef __int64 intp;				// intp is an integer that can accomodate a pointer
+typedef unsigned __int64 uintp;		// (ie, sizeof(intp) >= sizeof(int) && sizeof(intp) >= sizeof(void *)
+#else
+typedef __int32 intp;
+typedef unsigned __int32 uintp;
+#endif
+
+#else // _WIN32
+
+typedef short int16;
+typedef unsigned short uint16;
+typedef int int32;
+typedef unsigned int uint32;
+typedef long long int64;
+typedef unsigned long long uint64;
+
+// [u]int64 are actually defined as 'long long' and gcc 64-bit
+// doesn't automatically consider them the same as 'long int'.
+// Changing the types for [u]int64 is complicated by
+// there being many definitions, so we just
+// define a 'long int' here and use it in places that would
+// otherwise confuse the compiler.
+typedef long int lint64;
+typedef unsigned long int ulint64;
+
+#ifdef X64BITS
+typedef long long intp;
+typedef unsigned long long uintp;
+#else
+typedef int intp;
+typedef unsigned int uintp;
+#endif
+
+#endif // else _WIN32
+
+#ifdef API_GEN
+# define STEAM_CLANG_ATTR(ATTR) __attribute__((annotate( ATTR )))
+#else
+# define STEAM_CLANG_ATTR(ATTR)
+#endif
+
+#define STEAM_METHOD_DESC(DESC) STEAM_CLANG_ATTR( "desc:" #DESC ";" )
+#define STEAM_IGNOREATTR() STEAM_CLANG_ATTR( "ignore" )
+#define STEAM_OUT_STRUCT() STEAM_CLANG_ATTR( "out_struct: ;" )
+#define STEAM_OUT_STRING() STEAM_CLANG_ATTR( "out_string: ;" )
+#define STEAM_OUT_ARRAY_CALL(COUNTER,FUNCTION,PARAMS) STEAM_CLANG_ATTR( "out_array_call:" #COUNTER "," #FUNCTION "," #PARAMS ";" )
+#define STEAM_OUT_ARRAY_COUNT(COUNTER, DESC) STEAM_CLANG_ATTR( "out_array_count:" #COUNTER  ";desc:" #DESC )
+#define STEAM_ARRAY_COUNT(COUNTER) STEAM_CLANG_ATTR( "array_count:" #COUNTER ";" )
+#define STEAM_ARRAY_COUNT_D(COUNTER, DESC) STEAM_CLANG_ATTR( "array_count:" #COUNTER ";desc:" #DESC )
+#define STEAM_BUFFER_COUNT(COUNTER) STEAM_CLANG_ATTR( "buffer_count:" #COUNTER ";" )
+#define STEAM_OUT_BUFFER_COUNT(COUNTER) STEAM_CLANG_ATTR( "out_buffer_count:" #COUNTER ";" )
+#define STEAM_OUT_STRING_COUNT(COUNTER) STEAM_CLANG_ATTR( "out_string_count:" #COUNTER ";" )
+#define STEAM_DESC(DESC) STEAM_CLANG_ATTR("desc:" #DESC ";")
+#define STEAM_CALL_RESULT(RESULT_TYPE) STEAM_CLANG_ATTR("callresult:" #RESULT_TYPE ";")
+#define STEAM_CALL_BACK(RESULT_TYPE) STEAM_CLANG_ATTR("callback:" #RESULT_TYPE ";")
+#define STEAM_FLAT_NAME(NAME) STEAM_CLANG_ATTR("flat_name:" #NAME ";")
+
+const int k_cubSaltSize   = 8;
+typedef	uint8 Salt_t[ k_cubSaltSize ];
+
+//-----------------------------------------------------------------------------
+// GID (GlobalID) stuff
+// This is a globally unique identifier.  It's guaranteed to be unique across all
+// racks and servers for as long as a given universe persists.
+//-----------------------------------------------------------------------------
+// NOTE: for GID parsing/rendering and other utils, see gid.h
+typedef uint64 GID_t;
+
+const GID_t k_GIDNil = 0xffffffffffffffffull;
+
+// For convenience, we define a number of types that are just new names for GIDs
+typedef uint64 JobID_t;			// Each Job has a unique ID
+typedef GID_t TxnID_t;			// Each financial transaction has a unique ID
+
+const GID_t k_TxnIDNil = k_GIDNil;
+const GID_t k_TxnIDUnknown = 0;
+
+const JobID_t k_JobIDNil = 0xffffffffffffffffull;
+
+// this is baked into client messages and interfaces as an int, 
+// make sure we never break this.
+typedef uint32 PackageId_t;
+const PackageId_t k_uPackageIdInvalid = 0xFFFFFFFF;
+
+typedef uint32 BundleId_t;
+const BundleId_t k_uBundleIdInvalid = 0;
+
+// this is baked into client messages and interfaces as an int, 
+// make sure we never break this.
+typedef uint32 AppId_t;
+const AppId_t k_uAppIdInvalid = 0x0;
+
+typedef uint64 AssetClassId_t;
+const AssetClassId_t k_ulAssetClassIdInvalid = 0x0;
+
+typedef uint32 PhysicalItemId_t;
+const PhysicalItemId_t k_uPhysicalItemIdInvalid = 0x0;
+
+
+// this is baked into client messages and interfaces as an int, 
+// make sure we never break this.  AppIds and DepotIDs also presently
+// share the same namespace, but since we'd like to change that in the future
+// I've defined it seperately here.
+typedef uint32 DepotId_t;
+const DepotId_t k_uDepotIdInvalid = 0x0;
+
+// RTime32
+// We use this 32 bit time representing real world time.
+// It offers 1 second resolution beginning on January 1, 1970 (Unix time)
+typedef uint32 RTime32;
+
+typedef uint32 CellID_t;
+const CellID_t k_uCellIDInvalid = 0xFFFFFFFF;
+
+// handle to a Steam API call
+typedef uint64 SteamAPICall_t;
+const SteamAPICall_t k_uAPICallInvalid = 0x0;
+
+typedef uint32 AccountID_t;
+
+typedef uint32 PartnerId_t;
+const PartnerId_t k_uPartnerIdInvalid = 0;
+
+// ID for a depot content manifest
+typedef uint64 ManifestId_t; 
+const ManifestId_t k_uManifestIdInvalid = 0;
+
+// ID for cafe sites
+typedef uint64 SiteId_t;
+const SiteId_t k_ulSiteIdInvalid = 0;
+
+// Party Beacon ID
+typedef uint64 PartyBeaconID_t;
+const PartyBeaconID_t k_ulPartyBeaconIdInvalid = 0;
+
+enum ESteamIPType
+{
+	k_ESteamIPTypeIPv4 = 0,
+	k_ESteamIPTypeIPv6 = 1,
+};
+
+#pragma pack( push, 1 )
+
+struct SteamIPAddress_t
+{
+	union {
+
+		uint32			m_unIPv4;		// Host order
+		uint8			m_rgubIPv6[16];		// Network order! Same as inaddr_in6.  (0011:2233:4455:6677:8899:aabb:ccdd:eeff)
+
+		// Internal use only
+		uint64			m_ipv6Qword[2];	// big endian
+	};
+
+	ESteamIPType m_eType;
+
+	bool IsSet() const 
+	{ 
+		if ( k_ESteamIPTypeIPv4 == m_eType )
+		{
+			return m_unIPv4 != 0;
+		}
+		else 
+		{
+			return m_ipv6Qword[0] !=0 || m_ipv6Qword[1] != 0; 
+		}
+	}
+
+	static SteamIPAddress_t IPv4Any()
+	{
+		SteamIPAddress_t ipOut;
+		ipOut.m_eType = k_ESteamIPTypeIPv4;
+		ipOut.m_unIPv4 = 0;
+
+		return ipOut;
+	}
+
+	static SteamIPAddress_t IPv6Any()
+	{
+		SteamIPAddress_t ipOut;
+		ipOut.m_eType = k_ESteamIPTypeIPv6;
+		ipOut.m_ipv6Qword[0] = 0;
+		ipOut.m_ipv6Qword[1] = 0;
+
+		return ipOut;
+	}
+
+	static SteamIPAddress_t IPv4Loopback()
+	{
+		SteamIPAddress_t ipOut;
+		ipOut.m_eType = k_ESteamIPTypeIPv4;
+		ipOut.m_unIPv4 = 0x7f000001;
+
+		return ipOut;
+	}
+
+	static SteamIPAddress_t IPv6Loopback()
+	{
+		SteamIPAddress_t ipOut;
+		ipOut.m_eType = k_ESteamIPTypeIPv6;
+		ipOut.m_ipv6Qword[0] = 0;
+		ipOut.m_ipv6Qword[1] = 0;
+		ipOut.m_rgubIPv6[15] = 1;
+
+		return ipOut;
+	}
+};
+
+#pragma pack( pop )
+
+
+#endif // STEAMTYPES_H

--- a/lsteamclient/steamworks_sdk_148a/steamuniverse.h
+++ b/lsteamclient/steamworks_sdk_148a/steamuniverse.h
@@ -1,0 +1,27 @@
+//========= Copyright � 1996-2008, Valve LLC, All rights reserved. ============
+//
+// Purpose:
+//
+//=============================================================================
+
+#ifndef STEAMUNIVERSE_H
+#define STEAMUNIVERSE_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+
+// Steam universes.  Each universe is a self-contained Steam instance.
+enum EUniverse
+{
+	k_EUniverseInvalid = 0,
+	k_EUniversePublic = 1,
+	k_EUniverseBeta = 2,
+	k_EUniverseInternal = 3,
+	k_EUniverseDev = 4,
+	// k_EUniverseRC = 5,				// no such universe anymore
+	k_EUniverseMax
+};
+
+
+#endif // STEAMUNIVERSE_H

--- a/lsteamclient/struct_converters.h
+++ b/lsteamclient/struct_converters.h
@@ -1,3 +1,24 @@
+#if defined(SDKVER_148a) || !defined(__cplusplus)
+#pragma pack( push, 8 )
+struct winSteamNetworkingMessage_t_148a {
+    void * m_pData;
+    int m_cbSize;
+    HSteamNetConnection m_conn;
+    SteamNetworkingIdentity m_identityPeer __attribute__((aligned(1)));
+    int64 m_nConnUserData;
+    SteamNetworkingMicroseconds m_usecTimeReceived;
+    int64 m_nMessageNumber;
+    void *m_pfnFreeData; /*fn pointer*/
+    void *m_pfnRelease; /*fn pointer*/
+    int m_nChannel;
+    int m_nFlags;
+    int64 m_nUserData;
+}  __attribute__ ((ms_struct));
+#pragma pack( pop )
+typedef struct winSteamNetworkingMessage_t_148a winSteamNetworkingMessage_t_148a;
+struct SteamNetworkingMessage_t;
+#endif
+
 #if defined(SDKVER_147) || !defined(__cplusplus)
 #pragma pack( push, 8 )
 struct winSteamPartyBeaconLocation_t_147 {

--- a/lsteamclient/winISteamNetworkingSockets.c
+++ b/lsteamclient/winISteamNetworkingSockets.c
@@ -15,6 +15,362 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(steamclient);
 
+#include "cppISteamNetworkingSockets_SteamNetworkingSockets008.h"
+
+typedef struct __winISteamNetworkingSockets_SteamNetworkingSockets008 {
+    vtable_ptr *vtable;
+    void *linux_side;
+} winISteamNetworkingSockets_SteamNetworkingSockets008;
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_CreateListenSocketIP, 16)
+HSteamListenSocket __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_CreateListenSocketIP(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, const SteamNetworkingIPAddr * localAddress, int nOptions, const SteamNetworkingConfigValue_t * pOptions)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_CreateListenSocketIP(_this->linux_side, localAddress, nOptions, pOptions);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_ConnectByIPAddress, 16)
+HSteamNetConnection __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_ConnectByIPAddress(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, const SteamNetworkingIPAddr * address, int nOptions, const SteamNetworkingConfigValue_t * pOptions)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_ConnectByIPAddress(_this->linux_side, address, nOptions, pOptions);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_CreateListenSocketP2P, 16)
+HSteamListenSocket __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_CreateListenSocketP2P(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, int nVirtualPort, int nOptions, const SteamNetworkingConfigValue_t * pOptions)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_CreateListenSocketP2P(_this->linux_side, nVirtualPort, nOptions, pOptions);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_ConnectP2P, 20)
+HSteamNetConnection __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_ConnectP2P(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, const SteamNetworkingIdentity * identityRemote, int nVirtualPort, int nOptions, const SteamNetworkingConfigValue_t * pOptions)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_ConnectP2P(_this->linux_side, identityRemote, nVirtualPort, nOptions, pOptions);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_AcceptConnection, 8)
+EResult __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_AcceptConnection(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, HSteamNetConnection hConn)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_AcceptConnection(_this->linux_side, hConn);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_CloseConnection, 20)
+bool __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_CloseConnection(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, HSteamNetConnection hPeer, int nReason, const char * pszDebug, bool bEnableLinger)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_CloseConnection(_this->linux_side, hPeer, nReason, pszDebug, bEnableLinger);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_CloseListenSocket, 8)
+bool __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_CloseListenSocket(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, HSteamListenSocket hSocket)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_CloseListenSocket(_this->linux_side, hSocket);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_SetConnectionUserData, 16)
+bool __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_SetConnectionUserData(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, HSteamNetConnection hPeer, int64 nUserData)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_SetConnectionUserData(_this->linux_side, hPeer, nUserData);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_GetConnectionUserData, 8)
+int64 __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_GetConnectionUserData(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, HSteamNetConnection hPeer)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_GetConnectionUserData(_this->linux_side, hPeer);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_SetConnectionName, 12)
+void __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_SetConnectionName(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, HSteamNetConnection hPeer, const char * pszName)
+{
+    TRACE("%p\n", _this);
+    cppISteamNetworkingSockets_SteamNetworkingSockets008_SetConnectionName(_this->linux_side, hPeer, pszName);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_GetConnectionName, 16)
+bool __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_GetConnectionName(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, HSteamNetConnection hPeer, char * pszName, int nMaxLen)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_GetConnectionName(_this->linux_side, hPeer, pszName, nMaxLen);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_SendMessageToConnection, 24)
+EResult __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_SendMessageToConnection(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, HSteamNetConnection hConn, const void * pData, uint32 cbData, int nSendFlags, int64 * pOutMessageNumber)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_SendMessageToConnection(_this->linux_side, hConn, pData, cbData, nSendFlags, pOutMessageNumber);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_SendMessages, 16)
+void __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_SendMessages(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, int nMessages, winSteamNetworkingMessage_t_148a ** pMessages, int64 * pOutMessageNumberOrResult)
+{
+    TRACE("%p\n", _this);
+    cppISteamNetworkingSockets_SteamNetworkingSockets008_SendMessages(_this->linux_side, nMessages, pMessages, pOutMessageNumberOrResult);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_FlushMessagesOnConnection, 8)
+EResult __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_FlushMessagesOnConnection(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, HSteamNetConnection hConn)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_FlushMessagesOnConnection(_this->linux_side, hConn);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_ReceiveMessagesOnConnection, 16)
+int __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_ReceiveMessagesOnConnection(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, HSteamNetConnection hConn, winSteamNetworkingMessage_t_148a ** ppOutMessages, int nMaxMessages)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_ReceiveMessagesOnConnection(_this->linux_side, hConn, ppOutMessages, nMaxMessages);
+}
+
+// Removed.
+// DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_ReceiveMessagesOnListenSocket, 16)
+// int __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_ReceiveMessagesOnListenSocket(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, HSteamListenSocket hSocket, winSteamNetworkingMessage_t_148a ** ppOutMessages, int nMaxMessages)
+// {
+//     TRACE("%p\n", _this);
+//     return cppISteamNetworkingSockets_SteamNetworkingSockets008_ReceiveMessagesOnListenSocket(_this->linux_side, hSocket, ppOutMessages, nMaxMessages);
+// }
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_GetConnectionInfo, 12)
+bool __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_GetConnectionInfo(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, HSteamNetConnection hConn, SteamNetConnectionInfo_t * pInfo)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_GetConnectionInfo(_this->linux_side, hConn, pInfo);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_GetQuickConnectionStatus, 12)
+bool __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_GetQuickConnectionStatus(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, HSteamNetConnection hConn, SteamNetworkingQuickConnectionStatus * pStats)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_GetQuickConnectionStatus(_this->linux_side, hConn, pStats);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_GetDetailedConnectionStatus, 16)
+int __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_GetDetailedConnectionStatus(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, HSteamNetConnection hConn, char * pszBuf, int cbBuf)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_GetDetailedConnectionStatus(_this->linux_side, hConn, pszBuf, cbBuf);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_GetListenSocketAddress, 12)
+bool __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_GetListenSocketAddress(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, HSteamListenSocket hSocket, SteamNetworkingIPAddr * address)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_GetListenSocketAddress(_this->linux_side, hSocket, address);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_CreateSocketPair, 24)
+bool __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_CreateSocketPair(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, HSteamNetConnection * pOutConnection1, HSteamNetConnection * pOutConnection2, bool bUseNetworkLoopback, const SteamNetworkingIdentity * pIdentity1, const SteamNetworkingIdentity * pIdentity2)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_CreateSocketPair(_this->linux_side, pOutConnection1, pOutConnection2, bUseNetworkLoopback, pIdentity1, pIdentity2);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_GetIdentity, 8)
+bool __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_GetIdentity(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, SteamNetworkingIdentity * pIdentity)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_GetIdentity(_this->linux_side, pIdentity);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_InitAuthentication, 4)
+ESteamNetworkingAvailability __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_InitAuthentication(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_InitAuthentication(_this->linux_side);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_GetAuthenticationStatus, 8)
+ESteamNetworkingAvailability __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_GetAuthenticationStatus(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, SteamNetAuthenticationStatus_t * pDetails)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_GetAuthenticationStatus(_this->linux_side, pDetails);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_ReceivedRelayAuthTicket, 16)
+bool __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_ReceivedRelayAuthTicket(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, const void * pvTicket, int cbTicket, SteamDatagramRelayAuthTicket * pOutParsedTicket)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_ReceivedRelayAuthTicket(_this->linux_side, pvTicket, cbTicket, pOutParsedTicket);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_FindRelayAuthTicketForServer, 16)
+int __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_FindRelayAuthTicketForServer(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, const SteamNetworkingIdentity * identityGameServer, int nVirtualPort, SteamDatagramRelayAuthTicket * pOutParsedTicket)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_FindRelayAuthTicketForServer(_this->linux_side, identityGameServer, nVirtualPort, pOutParsedTicket);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_ConnectToHostedDedicatedServer, 20)
+HSteamNetConnection __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_ConnectToHostedDedicatedServer(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, const SteamNetworkingIdentity * identityTarget, int nVirtualPort, int nOptions, const SteamNetworkingConfigValue_t * pOptions)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_ConnectToHostedDedicatedServer(_this->linux_side, identityTarget, nVirtualPort, nOptions, pOptions);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_GetHostedDedicatedServerPort, 4)
+uint16 __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_GetHostedDedicatedServerPort(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_GetHostedDedicatedServerPort(_this->linux_side);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_GetHostedDedicatedServerPOPID, 4)
+SteamNetworkingPOPID __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_GetHostedDedicatedServerPOPID(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_GetHostedDedicatedServerPOPID(_this->linux_side);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_GetHostedDedicatedServerAddress, 8)
+EResult __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_GetHostedDedicatedServerAddress(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, SteamDatagramHostedAddress * pRouting)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_GetHostedDedicatedServerAddress(_this->linux_side, pRouting);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_CreateHostedDedicatedServerListenSocket, 16)
+HSteamListenSocket __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_CreateHostedDedicatedServerListenSocket(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, int nVirtualPort, int nOptions, const SteamNetworkingConfigValue_t * pOptions)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_CreateHostedDedicatedServerListenSocket(_this->linux_side, nVirtualPort, nOptions, pOptions);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_GetGameCoordinatorServerLogin, 16)
+EResult __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_GetGameCoordinatorServerLogin(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, SteamDatagramGameCoordinatorServerLogin * pLoginInfo, int * pcbSignedBlob, void * pBlob)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_GetGameCoordinatorServerLogin(_this->linux_side, pLoginInfo, pcbSignedBlob, pBlob);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_ConnectP2PCustomSignaling, 20)
+HSteamNetConnection __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_ConnectP2PCustomSignaling(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, ISteamNetworkingConnectionCustomSignaling * pSignaling, const SteamNetworkingIdentity * pPeerIdentity, int nOptions, const SteamNetworkingConfigValue_t * pOptions)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_ConnectP2PCustomSignaling(_this->linux_side, pSignaling, pPeerIdentity, nOptions, pOptions);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_ReceivedP2PCustomSignal, 16)
+bool __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_ReceivedP2PCustomSignal(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, const void * pMsg, int cbMsg, ISteamNetworkingCustomSignalingRecvContext * pContext)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_ReceivedP2PCustomSignal(_this->linux_side, pMsg, cbMsg, pContext);
+}
+
+// SDK 148a
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_GetCertificateRequest, 16)
+bool __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_GetCertificateRequest(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, int * pcbBlob, void * pBlob, SteamNetworkingErrMsg * errMsg )
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_GetCertificateRequest(_this->linux_side, pcbBlob, pBlob,*errMsg);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_SetCertificate, 16)
+bool __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_SetCertificate(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, const void * pCertificate, int cbCertificate, SteamNetworkingErrMsg * errMsg)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_SetCertificate(_this->linux_side, pCertificate,cbCertificate,*errMsg);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_CreatePollGroup, 4)
+bool __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_CreatePollGroup(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_CreatePollGroup(_this->linux_side);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_DestroyPollGroup, 8)
+bool __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_DestroyPollGroup(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, HSteamNetPollGroup hPollGroup)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_DestroyPollGroup(_this->linux_side, hPollGroup);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_SetConnectionPollGroup, 12)
+bool __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_SetConnectionPollGroup(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, HSteamNetConnection hConn, HSteamNetPollGroup hPollGroup)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_SetConnectionPollGroup(_this->linux_side, hConn ,hPollGroup );
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_ReceiveMessagesOnPollGroup, 16)
+bool __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_ReceiveMessagesOnPollGroup(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this, HSteamNetPollGroup hPollGroup, winSteamNetworkingMessage_t_148a ** ppOutMessages, int nMaxMessages)
+{
+    TRACE("%p\n", _this);
+    return cppISteamNetworkingSockets_SteamNetworkingSockets008_ReceiveMessagesOnPollGroup(_this->linux_side, hPollGroup,(SteamNetworkingMessage_t **)ppOutMessages,nMaxMessages);
+}
+
+DEFINE_THISCALL_WRAPPER(winISteamNetworkingSockets_SteamNetworkingSockets008_destructor, 4)
+void __thiscall winISteamNetworkingSockets_SteamNetworkingSockets008_destructor(winISteamNetworkingSockets_SteamNetworkingSockets008 *_this)
+{/* never called */}
+
+extern vtable_ptr winISteamNetworkingSockets_SteamNetworkingSockets008_vtable;
+
+#ifndef __GNUC__
+void __asm_dummy_vtables(void) {
+#endif
+    __ASM_VTABLE(winISteamNetworkingSockets_SteamNetworkingSockets008,
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_CreateListenSocketIP)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_ConnectByIPAddress)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_CreateListenSocketP2P)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_ConnectP2P)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_AcceptConnection)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_CloseConnection)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_CloseListenSocket)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_SetConnectionUserData)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_GetConnectionUserData)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_SetConnectionName)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_GetConnectionName)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_SendMessageToConnection)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_SendMessages)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_FlushMessagesOnConnection)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_ReceiveMessagesOnConnection)
+        //VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_ReceiveMessagesOnListenSocket)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_GetConnectionInfo)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_GetQuickConnectionStatus)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_GetDetailedConnectionStatus)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_GetListenSocketAddress)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_CreateSocketPair)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_GetIdentity)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_InitAuthentication)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_GetAuthenticationStatus)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_ReceivedRelayAuthTicket)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_FindRelayAuthTicketForServer)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_ConnectToHostedDedicatedServer)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_GetHostedDedicatedServerPort)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_GetHostedDedicatedServerPOPID)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_GetHostedDedicatedServerAddress)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_CreateHostedDedicatedServerListenSocket)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_GetGameCoordinatorServerLogin)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_ConnectP2PCustomSignaling)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_ReceivedP2PCustomSignal)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_destructor)
+        // SDK 148a
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_GetCertificateRequest)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_SetCertificate)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_CreatePollGroup)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_DestroyPollGroup)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_SetConnectionPollGroup)
+        VTABLE_ADD_FUNC(winISteamNetworkingSockets_SteamNetworkingSockets008_ReceiveMessagesOnPollGroup)
+
+    );
+#ifndef __GNUC__
+}
+#endif
+
+winISteamNetworkingSockets_SteamNetworkingSockets008 *create_winISteamNetworkingSockets_SteamNetworkingSockets008(void *linux_side)
+{
+    winISteamNetworkingSockets_SteamNetworkingSockets008 *r = HeapAlloc(GetProcessHeap(), 0, sizeof(winISteamNetworkingSockets_SteamNetworkingSockets008));
+    TRACE("-> %p\n", r);
+    r->vtable = &winISteamNetworkingSockets_SteamNetworkingSockets008_vtable;
+    r->linux_side = linux_side;
+    return r;
+}
+
 #include "cppISteamNetworkingSockets_SteamNetworkingSockets006.h"
 
 typedef struct __winISteamNetworkingSockets_SteamNetworkingSockets006 {

--- a/lsteamclient/win_constructors.h
+++ b/lsteamclient/win_constructors.h
@@ -28,6 +28,7 @@ extern void *create_winISteamGameServerStats_SteamGameServerStats001(void *);
 extern void *create_winISteamGameCoordinator_SteamGameCoordinator001(void *);
 extern void *create_winISteamParentalSettings_STEAMPARENTALSETTINGS_INTERFACE_VERSION001(void *);
 extern void *create_winISteamNetworkingSockets_SteamNetworkingSockets006(void *);
+extern void *create_winISteamNetworkingSockets_SteamNetworkingSockets008(void *);
 extern void *create_winISteamNetworkingUtils_SteamNetworkingUtils003(void *);
 extern void *create_winISteamClient_SteamClient019(void *);
 extern void *create_winISteamNetworking_SteamNetworking005(void *);

--- a/lsteamclient/win_constructors_table.dat
+++ b/lsteamclient/win_constructors_table.dat
@@ -28,6 +28,7 @@
     {"SteamGameCoordinator001", &create_winISteamGameCoordinator_SteamGameCoordinator001},
     {"STEAMPARENTALSETTINGS_INTERFACE_VERSION001", &create_winISteamParentalSettings_STEAMPARENTALSETTINGS_INTERFACE_VERSION001},
     {"SteamNetworkingSockets006", &create_winISteamNetworkingSockets_SteamNetworkingSockets006},
+    {"SteamNetworkingSockets008", &create_winISteamNetworkingSockets_SteamNetworkingSockets008},
     {"SteamNetworkingUtils003", &create_winISteamNetworkingUtils_SteamNetworkingUtils003},
     {"SteamClient019", &create_winISteamClient_SteamClient019},
     {"SteamNetworking005", &create_winISteamNetworking_SteamNetworking005},


### PR DESCRIPTION
This addresses https://github.com/ValveSoftware/Proton/issues/2165 where SteamNetworkingSockets008 is not a defined interface. I grabbed SDK 148 where these headers are and implemented them in Proton.

For our purposes of inclusion into main branch, I tested 5.0-7 and it works. A link to that binary: https://github.com/stevenlafl/Proton/releases/tag/proton-5.0-7-sdk148

I also tested on 4.11-13 (Download and code available: https://github.com/stevenlafl/Proton/releases/tag/proton-4.11-13-sdk-148) as this **loads Scrap Mechanic faster**. The game will now make it all the way through and is playable with these changes.

I tested SDK 148 networking and it appears to be flawless, but this implementation may not utilize PollGroups. So:
1. I need some review here to be sure this the correct way to go about things.
2. I may need some help implementing ReceiveMessagesOnPollGroup.

See also: https://github.com/ValveSoftware/Proton/issues/3747#issuecomment-611539352