### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sc linguist-detectable=false
+*.SC linguist-detectable=false


### PR DESCRIPTION
Hey there, this is a super-dumb cosmetic fix that should prevent the *.SC font files from being detected as Scala or SuperCollider by GitHub Linguist.

![image](https://user-images.githubusercontent.com/16687318/82472030-ecb43f00-9a9d-11ea-8fc1-72d706b7f33a.png)
