### PR TITLE
vkd3d-proton: Use widl from mingw-tools

### DIFF
--- a/build-mingw-w64.sh
+++ b/build-mingw-w64.sh
@@ -308,6 +308,18 @@ function build_arch {
             PATH=$NEWPATH make $JOBS install
         popd
 
+        mkdir -p mingw-w64-tools/widl
+        pushd mingw-w64-tools/widl/
+            if [ ! -e Makefile ]; then
+                PATH=$NEWPATH ../../../$MINGW_W64_SRCDIR/mingw-w64-tools/widl/configure \
+                    --prefix=$DST_DIR/ \
+                    --target=$WIN32_TARGET_ARCH \
+                    --program-prefix="${WIN32_TARGET_ARCH}-"
+            fi
+            PATH=$NEWPATH make $JOBS
+            PATH=$NEWPATH make $JOBS install
+        popd
+
     popd
 }
 


### PR DESCRIPTION
This Pull-Request is the counterpart of https://github.com/HansKristian-Work/vkd3d-proton/pull/236

The Pull-Request for vkd3d-proton removes the dependency to wine for cross-builds, but uses widl from mingw-tools. This will break building proton. This PR fixes the breakage by installing widl from mingw-tools. The no longer needed build steps for widl from wine are removed as well.

This PR should only be considered when the vkd3d-proton PR is going to me merged, otherwise it will break building vkd3d-proton. 

@Joshua-Ashton @HansKristian-Work
