### PR TITLE
vrclient: Add support for VROverlay (Fixes VR in ACC (805550))

### DIFF
--- a/vrclient_x64/vrclient_x64/vrclient_main.c
+++ b/vrclient_x64/vrclient_x64/vrclient_main.c
@@ -1040,6 +1040,15 @@ EVROverlayError ivroverlay_set_overlay_texture(
                                 }
                         }
 #endif
+                        {
+                                IWineD3D11Texture2D *wine_texture;
+                                if (SUCCEEDED(hr = texture_iface->lpVtbl->QueryInterface(texture_iface,
+                                        &IID_IWineD3D11Texture2D, (void **)&wine_texture)))
+                                {
+                                        FIXME("WineD3D not yet supported by IVROverlay::SetOverlayTexture\n");
+                                        goto overlay_warn_out;
+                                }
+                        }
 overlay_warn_out:
                         WARN("Invalid D3D11 texture %p.\n", texture);
                         return cpp_func(linux_side, overlayHandle, texture);

--- a/vrclient_x64/vrclient_x64/vrclient_main.c
+++ b/vrclient_x64/vrclient_x64/vrclient_main.c
@@ -910,6 +910,14 @@ EVRCompositorError ivrcompositor_submit(
 
             texture_iface = texture->handle;
 
+            TRACE("texture_iface = %p\n", texture_iface);
+
+            if (texture_iface != NULL) {
+                    TRACE("texture_iface->lpVtbl = %p\n", texture_iface->lpVtbl);
+            } else {
+                    goto warn_out;
+            }
+
             if (SUCCEEDED(hr = texture_iface->lpVtbl->QueryInterface(texture_iface,
                     &IID_IWineD3D11Texture2D, (void **)&wine_texture)))
             {
@@ -930,6 +938,7 @@ EVRCompositorError ivrcompositor_submit(
             }
 #endif
 
+warn_out:
             WARN("Invalid D3D11 texture %p.\n", texture);
             return cpp_func(linux_side, eye, texture, bounds, flags);
         }

--- a/vrclient_x64/vrclient_x64/vrclient_private.h
+++ b/vrclient_x64/vrclient_x64/vrclient_private.h
@@ -79,7 +79,17 @@ struct compositor_data
 #endif
 };
 
+struct overlay_data
+{
+	ID3D11Device *d3d11_device;
+	IWineD3D11Device *wined3d_device;
+#ifdef VRCLIENT_HAVE_DXVK
+	IDXGIVkInteropDevice *dxvk_device;
+#endif
+};
+
 void destroy_compositor_data(struct compositor_data *data);
+void destroy_overlay_data(struct overlay_data *data);
 
 EVRInitError ivrclientcore_002_init(EVRInitError (*cpp_func)(void *, EVRApplicationType),
         void *linux_side, EVRApplicationType application_type,
@@ -128,7 +138,7 @@ VRCompositorError ivrcompositor_008_submit(
         unsigned int version, struct compositor_data *user_data);
 EVRCompositorError ivrcompositor_submit(
         EVRCompositorError (*cpp_func)(void *, EVREye, Texture_t *, VRTextureBounds_t *, EVRSubmitFlags),
-        void *linux_side, EVREye eye, Texture_t *texture, VRTextureBounds_t *bounds, EVRSubmitFlags submit_flags,
+        void *linux_side, EVREye eye, Texture_t *texture, VRTextureBounds_t *bounds, EVRSubmitFlags flags,
         unsigned int version, struct compositor_data *user_data);
 
 void ivrcompositor_post_present_handoff(void (*cpp_func)(void *),
@@ -154,6 +164,11 @@ EVRRenderModelError ivrrendermodels_load_into_texture_d3d11_async(
 void ivrrendermodels_free_texture_d3d11(
         void (*cpp_func)(void *, void *),
         void *linux_side, void *dst_texture, unsigned int version);
+
+EVROverlayError ivroverlay_set_overlay_texture(
+		EVROverlayError (*cpp_func)(void *, VROverlayHandle_t, Texture_t *),
+		void *linux_side, VROverlayHandle_t overlayHandle, Texture_t *texture,
+		unsigned int version, struct overlay_data *user_data);
 
 #endif  /* __cplusplus */
 

--- a/vrclient_x64/vrclient_x64/winIVROverlay.c
+++ b/vrclient_x64/vrclient_x64/winIVROverlay.c
@@ -3900,6 +3900,7 @@ void destroy_winIVROverlay_IVROverlay_019_FnTable(void *object)
 typedef struct __winIVROverlay_IVROverlay_018 {
     vtable_ptr *vtable;
     void *linux_side;
+    struct overlay_data user_data;
 } winIVROverlay_IVROverlay_018;
 
 DEFINE_THISCALL_WRAPPER(winIVROverlay_IVROverlay_018_FindOverlay, 12)
@@ -4311,8 +4312,12 @@ EVROverlayError __thiscall winIVROverlay_IVROverlay_018_GetOverlayDualAnalogTran
 DEFINE_THISCALL_WRAPPER(winIVROverlay_IVROverlay_018_SetOverlayTexture, 16)
 EVROverlayError __thiscall winIVROverlay_IVROverlay_018_SetOverlayTexture(winIVROverlay_IVROverlay_018 *_this, VROverlayHandle_t ulOverlayHandle, Texture_t * pTexture)
 {
-    TRACE("%p\n", _this);
-    return cppIVROverlay_IVROverlay_018_SetOverlayTexture(_this->linux_side, ulOverlayHandle, pTexture);
+    TRACE("%p, ulOverlayHandle = %#x, pTexture = %p\n", _this, ulOverlayHandle, pTexture);
+    if (pTexture != NULL) {
+	    TRACE("pTexture->handle = %p\n", pTexture->handle);
+    }
+    // return cppIVROverlay_IVROverlay_018_SetOverlayTexture(_this->linux_side, ulOverlayHandle, pTexture);
+    return ivroverlay_set_overlay_texture(cppIVROverlay_IVROverlay_018_SetOverlayTexture, _this->linux_side, ulOverlayHandle, pTexture, 22, &_this->user_data);
 }
 
 DEFINE_THISCALL_WRAPPER(winIVROverlay_IVROverlay_018_ClearOverlayTexture, 12)


### PR DESCRIPTION
This set of patches adds the same texture translation that occurs in `VRCompositor::Submit` to `VROverlay::SetOverlayTexture` to fix the displaying of VR overlays.

There's a slight re-factor to move the responsibility of the texture translation to a separate function for the DXVK case, as it allows for good code re-use between VRCompositor and VROverlay.

There's also a single fix to `VRCompositor::Submit` to make it not segfault when `texture->handle` is `NULL`. Downstream implementations in SteamVR handle this case gracefully, so we should too, just passing through the NULL handle without segfaulting while trying to read the vptable.

This has been tested with [Assetto Corsa Competizione](https://store.steampowered.com/app/805550/Assetto_Corsa_Competizione/), and I can confirm that VR is working with that game in Proton with these patches on top of the latest 5.0.

This may fix VR usage for other applications that use OpenVR's `VROverlay`, but I haven't found any others yet. I'm thinking it may be common in UE4 games (the engine used by ACC)?

Sorry for the short and scattered PR message; I'm a bit scatter-brained today from lack of sleep, but I wanted to get this submitted before too long.

# Issue References

* [Assetto Corsa Competizione](https://store.steampowered.com/app/805550/Assetto_Corsa_Competizione/) - #1420 