### PR TITLE
proton: make log directory configurable via PROTON_LOG_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,8 @@ the Wine prefix. Removing the option will revert to the previous behavior.
 
 | Compat config string  | Environment Variable           | Description  |
 | :-------------------- | :----------------------------- | :----------- |
-|                       | <tt>PROTON_LOG</tt>            | Convenience method for dumping a useful debug log to `$HOME/steam-$APPID.log`. For more thorough logging, use `user_settings.py`. |
+|                       | <tt>PROTON_LOG</tt>            | Convenience method for dumping a useful debug log to `$HOME/steam-$APPID.log` (Unless PROTON_LOG_DIR is set). For more thorough logging, use `user_settings.py`. |
+|                       | <tt>PROTON_LOG_DIR</tt>        | Makes Proton output its log to the directory specified by this variable's value instead of the user's home. Note that you should **not** specify a filename. |
 |                       | <tt>PROTON_DUMP_DEBUG_COMMANDS</tt> | When running a game, Proton will write some useful debug scripts for that game into `$PROTON_DEBUG_DIR/proton_$USER/`. |
 |                       | <tt>PROTON_DEBUG_DIR</tt>      | Root directory for the Proton debug scripts, `/tmp` by default. |
 | <tt>wined3d</tt>      | <tt>PROTON_USE_WINED3D</tt>    | Use OpenGL-based wined3d instead of Vulkan-based DXVK for d3d11, d3d10, and d3d9. |

--- a/proton
+++ b/proton
@@ -650,6 +650,9 @@ class Session:
             self.env.setdefault("VKD3D_DEBUG", "warn")
             self.env.setdefault("WINE_MONO_TRACE", "E:System.NotImplementedException")
 
+            if "PROTON_LOG_DIR" in self.env and nonzero(self.env["PROTON_LOG_DIR"]):
+                ldir_path = self.env["PROTON_LOG_DIR"]
+
         #for performance, logging is disabled by default; override with user_settings.py
         self.env.setdefault("WINEDEBUG", "-all")
         self.env.setdefault("DXVK_LOG_LEVEL", "none")
@@ -703,7 +706,11 @@ class Session:
 
         if "SteamGameId" in self.env:
             if self.env["WINEDEBUG"] != "-all":
-                lfile_path = os.environ["HOME"] + "/steam-" + os.environ["SteamGameId"] + ".log"
+                if "ldir_path" in locals():
+                    basedir = ldir_path
+                else:
+                    basedir = os.environ["HOME"]
+                lfile_path = basedir + "/steam-" + os.environ["SteamGameId"] + ".log"
                 if os.path.exists(lfile_path):
                     os.remove(lfile_path)
                 self.log_file = open(lfile_path, "w+")


### PR DESCRIPTION
Makes the path which Proton stores its log at configurable via the environment variable PROTON_LOG_DIR. Note that this changes the directory where Proton stores the log, not the entire path, and as such no filename should be specified. Also worth noting is that this path does not make Proton attempt to create the file path necessary to store a file there; if it fails, it fails. I was considering making it so that Proton attempted to create the entire path by itself if it did not exist, but I reasoned that the added complexity wouldn't be worth the small gain, and a user advanced enough to want to change this likely would be able to create the path on their own. That said, if you prefer it to be more robust, I can change this.

Fixes https://github.com/ValveSoftware/Proton/issues/4265