### PR TITLE
fix for ValveSoftware/Proton/#4269

### DIFF
--- a/proton
+++ b/proton
@@ -294,7 +294,7 @@ class CompatData:
             if os.path.dirname(contents).endswith(('/lib/wine', '/lib/wine/fakedlls', '/lib64/wine', '/lib64/wine/fakedlls')):
                 # wine builtin dll
                 # make the destination an absolute symlink
-                contents = os.path.normpath(os.path.join(os.path.dirname(src), contents))
+                contents = os.path.abspath(os.path.join(os.path.dirname(src), contents))
             if dll_copy:
                 try_copyfile(src, dst)
             else:


### PR DESCRIPTION
symlinks copied to pfx directory were using wrong relative paths

         ./pfx/drive_c/windows/syswow64/kernel32.dll -> dist/lib/wine/fakedlls/kernel32.dll

fixed to use absolute path