### PR TITLE
gitmodules: Consistently remove trailing slash

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "wine"]
     path = wine
-    url = https://github.com/ValveSoftware/wine/
+    url = https://github.com/ValveSoftware/wine
 [submodule "dxvk"]
 	path = dxvk
-	url = https://github.com/ValveSoftware/dxvk/
+	url = https://github.com/ValveSoftware/dxvk
 [submodule "openvr"]
 	path = openvr
 	url = https://github.com/ValveSoftware/openvr
@@ -12,7 +12,7 @@
 	url = https://github.com/liberationfonts/liberation-fonts
 [submodule "FAudio"]
 	path = FAudio
-	url = https://github.com/FNA-XNA/FAudio/
+	url = https://github.com/FNA-XNA/FAudio
 [submodule "gstreamer"]
 	path = gstreamer
 	url = https://gitlab.freedesktop.org/gstreamer/gstreamer.git


### PR DESCRIPTION
The forms with or without a trailing slash are interchangeable via https,
but the form with a trailing slash doesn't work if you have git configured
to always access Github repositories via ssh, using something like:

    git config --global url."git+ssh://git@github.com/".insteadOf "https://github.com/"