### PR TITLE
Fix build failure on Fedora 33

### DIFF
--- a/build/makefile_base.mak
+++ b/build/makefile_base.mak
@@ -63,6 +63,11 @@ ifeq ($(ENABLE_CCACHE),1)
 else
 endif
 
+ifneq ($(which mkdir),'/bin/mkdir')
+	export PATH := $(PATH):/bin
+else
+endif
+
 CC32 := $(CC) -m32 -mstackrealign
 CXX32 := $(CXX) -m32 -mstackrealign
 PKG_CONFIG32 := i686-linux-gnu-pkg-config


### PR DESCRIPTION
In Fedora 33 and some distros, `/bin` is not part of `$PATH` by default. When launching steam-proton-dev with `-e PATH=$(PATH)`, it would complain `/bin/bash: mkdir: command not found`

Signed-off-by: Zhenbo Li <litimetal@gmail.com>