### PR TITLE
Ask for Proton logs to be attached as a file

### DIFF
--- a/.github/ISSUE_TEMPLATE/compatibility-report.md
+++ b/.github/ISSUE_TEMPLATE/compatibility-report.md
@@ -19,8 +19,9 @@ about: Game compatibility issues.
 - [ ] that I haven't found an existing compatibility report for this game.
 - [ ] that I have checked whether there are updates for my system available.
 
-<!-- Please add `PROTON_LOG=1 %command%` to the game's launch options and drag
-and drop the generated `$HOME/steam-$APPID.log` into this issue report -->
+<!-- Please add `PROTON_LOG=1 %command%` to the game's launch options and
+attach the generated $HOME/steam-$APPID.log to this issue report as a file.
+(Proton logs compress well if needed.)-->
 
 ## Symptoms <!-- What's the problem? -->
 


### PR DESCRIPTION
Occasionally the previous wording gets read as copy/paste a wall of text into a new compatibility report instead of attaching files, which makes it more difficult to have a discussion when many pages of log are added to the scroll bar.