### PR TITLE
Version fix.

### DIFF
--- a/proton
+++ b/proton
@@ -20,7 +20,7 @@ from filelock import FileLock
 #To enable debug logging, copy "user_settings.sample.py" to "user_settings.py"
 #and edit it if needed.
 
-CURRENT_PREFIX_VERSION="6.3-2"
+CURRENT_PREFIX_VERSION="6.3-4"
 
 PFX="Proton: "
 ld_path_var = "LD_LIBRARY_PATH"


### PR DESCRIPTION
`proton` keeps reporting "updating prefix from xxx to 6.3-2" on a prefix update even for 6.3-4 and current Experimental.

Suggestion: either autogenerate this value or read it from some kind of a repository-wide config.