### PR TITLE
Fix fallback path

### DIFF
--- a/proton
+++ b/proton
@@ -433,12 +433,8 @@ class CompatData:
                 self.copy_pfx()
 
             # collect configuration info
-            if "STEAM_COMPAT_CLIENT_INSTALL_PATH" in os.environ:
-                #modern steam client sets this
-                steamdir = os.environ["STEAM_COMPAT_CLIENT_INSTALL_PATH"]
-            else:
-                #linux-only fallback, really shouldn't get here
-                steamdir = os.environ["HOME"] + "/.steam/root/"
+            # modern steam client is expected to set this
+            steamdir = os.environ["STEAM_COMPAT_CLIENT_INSTALL_PATH"]
 
             use_wined3d = "wined3d" in g_session.compat_config
             use_dxvk_dxgi = "WINEDLLOVERRIDES" in g_session.env and "dxgi=n" in g_session.env["WINEDLLOVERRIDES"]

--- a/proton
+++ b/proton
@@ -438,7 +438,7 @@ class CompatData:
                 steamdir = os.environ["STEAM_COMPAT_CLIENT_INSTALL_PATH"]
             else:
                 #linux-only fallback, really shouldn't get here
-                steamdir = os.environ["HOME"] + ".steam/root/"
+                steamdir = os.environ["HOME"] + "/.steam/root/"
 
             use_wined3d = "wined3d" in g_session.compat_config
             use_dxvk_dxgi = "WINEDLLOVERRIDES" in g_session.env and "dxgi=n" in g_session.env["WINEDLLOVERRIDES"]


### PR DESCRIPTION
The current fallback path concatenates .steam directly after $HOME, which leads to Steam Client files failing to be copied into a fresh prefix.