### PR TITLE
Create a wine prefix per user

### DIFF
--- a/proton
+++ b/proton
@@ -204,7 +204,8 @@ class Proton:
 
 class CompatData:
     def __init__(self, compatdata):
-        self.base_dir = compatdata + "/"
+        self.base_dir = compatdata + "/" + str(os.getuid()) + "/"
+        os.makedirs(self.base_dir, exist_ok=True)
         self.prefix_dir = self.path("pfx/")
         self.version_file = self.path("version")
         self.config_info_file = self.path("config_info")


### PR DESCRIPTION
Fixes #4820 by setting the base directory of `CompatData` from `steamapps/compatdata/<steamid>/` to `steamapps/compatdata/<steamid>/<userid>/`  (I'm honestly surprised that it worked without a hitch).

The only issue is that the old files still exist.
Ideally we would move them to the new path.
I assume that would belong in `upgrade_pfx`? Or is it even necessary?