### PR TITLE
Simplify NVIDIA dll discovery

### DIFF
--- a/proton
+++ b/proton
@@ -23,7 +23,6 @@ from ctypes import cast
 from ctypes import c_int
 from ctypes import c_char_p
 from ctypes import c_void_p
-from ctypes.util import find_library
 
 from filelock import FileLock
 
@@ -155,14 +154,8 @@ def try_get_game_library_dir():
 # On failure, returns None
 def find_nvidia_wine_dll_dir():
     try:
-        libdl_soname = find_library("dl")
-
-        # If we couldn't determine the proper soname for libdl, bail out.
-        if libdl_soname is None:
-            return None
-
-        libdl = CDLL(libdl_soname)
-    except (FileNotFoundError, OSError):
+        libdl = CDLL("libdl.so.2")
+    except (OSError):
         return None
 
     try:

--- a/proton
+++ b/proton
@@ -77,7 +77,7 @@ def makedirs(path):
         #already exists
         pass
 
-def try_copy(src, dst, add_write_perm=True):
+def try_copy(src, dst, add_write_perm=True, optional=False):
     try:
         if os.path.isdir(dst):
             dstfile = dst + "/" + os.path.basename(src)
@@ -93,6 +93,12 @@ def try_copy(src, dst, add_write_perm=True):
         if add_write_perm:
             new_mode = os.lstat(dstfile).st_mode | stat.S_IWUSR | stat.S_IWGRP
             os.chmod(dstfile, new_mode)
+
+    except FileNotFoundError as e:
+        if optional:
+            log('Error while copying to \"' + dst + '\": ' + e.strerror)
+        else:
+            raise
 
     except PermissionError as e:
         if e.errno == errno.EPERM:
@@ -708,7 +714,8 @@ class CompatData:
             if nvidia_wine_dll_dir:
                 for dll in ["_nvngx.dll", "nvngx.dll"]:
                     try_copy(nvidia_wine_dll_dir + "/" + dll,
-                             self.prefix_dir + "drive_c/windows/system32/" + dll)
+                             self.prefix_dir + "drive_c/windows/system32/" + dll,
+                             optional=True)
 
             try_copy(g_proton.lib64_dir + "wine/vkd3d-proton/d3d12.dll",
                     self.prefix_dir + "drive_c/windows/system32/d3d12.dll")


### PR DESCRIPTION
After testing DLSS+Proton on a different system than I normally use I discovered that the call to `find_library("dl")` wasn't properly discovering libdl.so.2

Additionally tweak the copy behavior so that if any of the driver-provided DLLs are missing Proton is still able to launch.