### PR TITLE
proton: Delete PID leading zeros instead of all zeros

### DIFF
--- a/proton
+++ b/proton
@@ -1169,7 +1169,7 @@ class Session:
             f.write("#Run winedbg in gdb mode and auto-attach to already-running program\n\n")
             f.write("cd \"" + os.getcwd() + "\"\n")
             f.write("EXE_NAME=${1:-\"" + exe_name + "\"}\n")
-            f.write("WPID_HEX=$(\"" + tmpdir + "winedbg\" --command 'info process' | grep -i \"$EXE_NAME\" | cut -f2 -d' ' | tr -d '0')\n")
+            f.write("WPID_HEX=$(\"" + tmpdir + "winedbg\" --command 'info process' | grep -i \"$EXE_NAME\" | cut -f2 -d' ' | sed -e 's/^0*//')\n")
             f.write("if [ -z \"$WPID_HEX\" ]; then \n")
             f.write("    echo \"Program does not appear to be running: \\\"$EXE_NAME\\\"\"\n")
             f.write("    exit 1\n")


### PR DESCRIPTION
Currently, `gdb_attach` script deletes ALL the zeros of a process ID reported by `winedbg`, possibly under a false assumption that there are zeros only at the beginning. However, the PID can be reported as 0000010c or 000000c0 or whatever. This pull request fixes the issue by removing only the leading zeros.