### PR TITLE
Fix broken build (cp -a and sshfs)

### DIFF
--- a/build/makefile_base.mak
+++ b/build/makefile_base.mak
@@ -374,7 +374,8 @@ deploy: dist | $(filter-out dist deploy install redist,$(MAKECMDGOALS))
 install: dist | $(filter-out dist deploy install redist,$(MAKECMDGOALS))
 	if [ ! -d $(STEAM_DIR) ]; then echo >&2 "!! "$(STEAM_DIR)" does not exist, cannot install"; return 1; fi
 	mkdir -p $(STEAM_DIR)/compatibilitytools.d/$(BUILD_NAME)
-	cp -af --no-dereference --preserve=mode,links $(DST_BASE)/* $(STEAM_DIR)/compatibilitytools.d/$(BUILD_NAME)
+	# Use -r instead of -a for sshfs
+	cp -rf --no-dereference --preserve=mode,links $(DST_BASE)/* $(STEAM_DIR)/compatibilitytools.d/$(BUILD_NAME)
 	@echo "Installed Proton to "$(STEAM_DIR)/compatibilitytools.d/$(BUILD_NAME)
 	@echo "You may need to restart Steam to select this tool"
 


### PR DESCRIPTION
This patch fixes an error that occurs when `make install` copies files to a directory on sshfs. It seems like commit https://github.com/ValveSoftware/Proton/commit/e2c0c75b1bbcb1aae49e0651bc1474b184335fc6 has been reverted by commit https://github.com/ValveSoftware/Proton/commit/76dfa15e95cf58b6a65919f9c37a8238a25b7d65. Regression?

---

Latest commit (https://github.com/ValveSoftware/Proton/commit/3ba1c093a5e6475bfe94e451d905709a7259ca04):
<details><summary>build log (tail)</summary>

```
wine: created the configuration directory '/home/vagrant/build-experimental_6.3-local/dist/files/share/default_pfx'
wineserver: using server-side synchronization.
wine: RLIMIT_NICE is <= 20, unable to use setpriority safely
wine: configuration in L"/home/vagrant/build-experimental_6.3-local/dist/files/share/default_pfx" has been updated.
mkdir -p /home/vagrant/build-experimental_6.3-local/dist/files/share/default_pfx//drive_c/openxr/
cp -a /home/vagrant/build-experimental_6.3-local/src-wineopenxr/wineopenxr64.json /home/vagrant/build-experimental_6.3-local/dist/files/share/default_pfx//drive_c/openxr/wineopenxr64.json
echo `date '+%s'` `GIT_DIR=/home/vagrant/proton/.git git describe --tags` > /home/vagrant/build-experimental_6.3-local/dist/version
if [ ! -d /vagrant/ ]; then echo >&2 "!! "/vagrant/" does not exist, cannot install"; return 1; fi
mkdir -p /vagrant//compatibilitytools.d/experimental_6.3-local
cp -af --no-dereference --preserve=mode,links /home/vagrant/build-experimental_6.3-local/dist/* /vagrant//compatibilitytools.d/experimental_6.3-local
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/liborc-0.4.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/liborc-0.4.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libjxrglue.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libjpegxr.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libjpegxr.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libjxrglue.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstreamer-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstbase-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstcheck-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstreamer-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstcheck-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstnet-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstbase-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstnet-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstcontroller-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstcontroller-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstsdp-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstapp-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstrtsp-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstpbutils-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstrtp-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstaudio-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstfft-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstaudio-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstallocators-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstallocators-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstapp-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstriff-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgsttag-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstsdp-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstfft-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstriff-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstvideo-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgsttag-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstrtsp-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstvideo-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstrtp-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libgstpbutils-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libFAudio.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libFAudio.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib/libwine.so.1: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/liborc-0.4.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/liborc-0.4.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libjxrglue.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libjpegxr.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libjpegxr.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libjxrglue.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstreamer-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libopenxr_loader.so.1: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstbase-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstcheck-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libopenxr_loader.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstreamer-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstcheck-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstnet-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstbase-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstnet-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstcontroller-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstcontroller-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstsdp-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstapp-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstrtsp-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstpbutils-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstrtp-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstaudio-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstfft-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstaudio-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstallocators-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstallocators-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstapp-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstriff-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgsttag-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstsdp-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstfft-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstriff-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstvideo-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstrtsp-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgsttag-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstvideo-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstrtp-1.0.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libgstpbutils-1.0.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libFAudio.so: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libFAudio.so.0: No such file or directory
cp: failed to preserve ownership for /vagrant//compatibilitytools.d/experimental_6.3-local/files/lib64/libwine.so.1: No such file or directory
make[1]: *** [../proton/build/makefile_base.mak:377: install] Error 1
rm obj-fonts/LiberationSans-Bold.sfd obj-fonts/LiberationSerif-Regular.sfd obj-fonts/LiberationMono-Bold.sfd obj-fonts/LiberationSans-Regular.sfd obj-fonts/LiberationMono-Regular.sfd
make[1]: Leaving directory '/home/vagrant/build-experimental_6.3-local'
make: *** [../proton/build/makefile_base.mak:32: nested_make] Error 2
make: Leaving directory '/home/vagrant/build-experimental_6.3-local'
Connection to 127.0.0.1 closed.
make: *** [Makefile:144: install-internal] エラー 2
```

</details>

With the patch:
<details><summary>build log (tail)</summary>

```
wine: created the configuration directory '/home/vagrant/build-shimonfix-build-2-local/dist/files/share/default_pfx'
wineserver: using server-side synchronization.
wine: RLIMIT_NICE is <= 20, unable to use setpriority safely
wine: configuration in L"/home/vagrant/build-shimonfix-build-2-local/dist/files/share/default_pfx" has been updated.
mkdir -p /home/vagrant/build-shimonfix-build-2-local/dist/files/share/default_pfx//drive_c/openxr/
cp -a /home/vagrant/build-shimonfix-build-2-local/src-wineopenxr/wineopenxr64.json /home/vagrant/build-shimonfix-build-2-local/dist/files/share/default_pfx//drive_c/openxr/wineopenxr64.json
echo `date '+%s'` `GIT_DIR=/home/vagrant/proton/.git git describe --tags` > /home/vagrant/build-shimonfix-build-2-local/dist/version
if [ ! -d /vagrant/ ]; then echo >&2 "!! "/vagrant/" does not exist, cannot install"; return 1; fi
mkdir -p /vagrant//compatibilitytools.d/shimonfix-build-2-local
# Use -r instead of -a for sshfs
cp -rf --no-dereference --preserve=mode,links /home/vagrant/build-shimonfix-build-2-local/dist/* /vagrant//compatibilitytools.d/shimonfix-build-2-local
Installed Proton to /vagrant//compatibilitytools.d/shimonfix-build-2-local
You may need to restart Steam to select this tool
rm obj-fonts/LiberationSans-Bold.sfd obj-fonts/LiberationSerif-Regular.sfd obj-fonts/LiberationMono-Bold.sfd obj-fonts/LiberationSans-Regular.sfd obj-fonts/LiberationMono-Regular.sfd
make[1]: Leaving directory '/home/vagrant/build-shimonfix-build-2-local'
make: Leaving directory '/home/vagrant/build-shimonfix-build-2-local'
Connection to 127.0.0.1 closed.
mkdir -p $HOME/.steam/root/compatibilitytools.d/
rm -rf $HOME/.steam/root/compatibilitytools.d/shimonfix-build-2-local/files/ #remove proton's internal files, but preserve user_settings etc from top-level
cp -Rf --no-dereference --preserve=mode,links vagrant_share/compatibilitytools.d/shimonfix-build-2-local $HOME/.steam/root/compatibilitytools.d/
echo "Proton installed to your local Steam installation"
Proton installed to your local Steam installation
```

</details>