### PR TITLE
Fix proton version on compat data files

### DIFF
--- a/proton
+++ b/proton
@@ -30,7 +30,7 @@ from random import randrange
 #To enable debug logging, copy "user_settings.sample.py" to "user_settings.py"
 #and edit it if needed.
 
-CURRENT_PREFIX_VERSION="6.3-3"
+CURRENT_PREFIX_VERSION="6.3-8"
 
 PFX="Proton: "
 ld_path_var = "LD_LIBRARY_PATH"


### PR DESCRIPTION
Current proton version is 6.3-8, but since CURRENT_PREFIX_VERSION is hardcoded to 6.3-3 it was displaying the wrong version on compatdata version files.