### PR TITLE
Patch configure.sh for --no-proton-sdk

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -141,20 +141,26 @@ function configure() {
     CONTAINER_MOUNT_OPTS=:Z
   fi
 
-  if [[ -n "$arg_container_engine" ]]; then
-    check_container_engine "$arg_container_engine" || die "Specified container engine \"$arg_container_engine\" doesn't work"
-  else
-    stat "Trying to find usable container engine."
-    if check_container_engine docker; then
-      arg_container_engine="docker"
-    elif check_container_engine podman; then
-      arg_container_engine="podman"
+  if [[ -n "$steamrt_image" ]]; then
+    if [[ -n "$arg_container_engine" ]]; then
+      check_container_engine "$arg_container_engine" || die "Specified container engine \"$arg_container_engine\" doesn't work"
     else
-        die "${arg_container_engine:-Container engine discovery} has failed. Please fix your setup."
+      stat "Trying to find usable container engine."
+      if check_container_engine docker; then
+        arg_container_engine="docker"
+      elif check_container_engine podman; then
+        arg_container_engine="podman"
+      else
+          die "${arg_container_engine:-Container engine discovery} has failed. Please fix your setup."
+      fi
     fi
-  fi
 
-  stat "Using $arg_container_engine."
+    stat "Using $arg_container_engine."
+  elif [[ "$(id -u)" -eq 0 ]]; then
+    ROOTLESS_CONTAINER=1
+  else
+    ROOTLESS_CONTAINER=0
+  fi
 
   ## Write out config
   # Don't die after this point or we'll have rather unhelpfully deleted the Makefile


### PR DESCRIPTION
Previously, `--no-proton-sdk` would effectively crash the configure step, initially on detecting the container system to use, then on undefined `ROOTLESS_CONTAINER` variable. I've patched it to skip the first, and properly set the variable based on the host system.

It allowed the configure step to succeed and started the host build for me, so I'd guess that it did the trick, but I'm not anywhere close to being proton expert, let alone knowing the source structure, so feel free to correct it if deemed appropriate.

Thank you in advance for considering this PR.