### PR TITLE
Add support for forwarding commands into the container environment

### DIFF
--- a/proton
+++ b/proton
@@ -1450,6 +1450,11 @@ class Session:
         return subprocess.call(args, env=local_env, stderr=self.log_file, stdout=self.log_file)
 
     def run(self):
+        if shutil.which('steam-runtime-launcher-interface-0') is not None:
+            adverb = ['steam-runtime-launcher-interface-0', 'proton']
+        else:
+            adverb = []
+
         if "PROTON_DUMP_DEBUG_COMMANDS" in self.env and nonzero(self.env["PROTON_DUMP_DEBUG_COMMANDS"]):
             try:
                 self.dump_dbg_scripts()
@@ -1467,9 +1472,11 @@ class Session:
 
         # CoD: Black Ops 3 workaround
         if os.environ.get("SteamGameId", 0) == "311210":
-            rc = self.run_proc([g_proton.wine_bin, "c:\\Program Files (x86)\\Steam\\steam.exe"] + sys.argv[2:] + self.cmdlineappend)
+            argv = [g_proton.wine_bin, "c:\\Program Files (x86)\\Steam\\steam.exe"]
         else:
-            rc = self.run_proc([g_proton.wine64_bin, "c:\\windows\\system32\\steam.exe"] + sys.argv[2:] + self.cmdlineappend)
+            argv = [g_proton.wine64_bin, "c:\\windows\\system32\\steam.exe"]
+
+        rc = self.run_proc(adverb + argv + sys.argv[2:] + self.cmdlineappend)
 
         if remote_debug_proc:
             remote_debug_proc.kill()

--- a/toolmanifest_runtime.vdf
+++ b/toolmanifest_runtime.vdf
@@ -4,4 +4,5 @@
   "commandline" "/proton %verb%"
   "require_tool_appid" "1391110"
   "use_sessions" "1"
+  "compatmanager_layer_name" "proton"
 }


### PR DESCRIPTION
Developed against ~~`proton_7.0-rc`~~ Proton Experimental.

This version requires https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/merge_requests/465, and doesn't alter the `PROTON_DUMP_DEBUG_COMMANDS` scripts. Old version at https://github.com/smcv/Proton/tree/launcher-service1 for reference.

To test with current versions of `SteamLinuxRuntime_soldier` and Steam, some reordering of chickens and eggs is required:

* The Steam client doesn't yet know how to activate command-injection into compat tools, so set `STEAM_COMPAT_LAUNCHER_SERVICE=proton` in Steam's environment or in a game's Launch Options. This will stop being necessary when the work by @TTimo that this is intended to enable gets a bit further.
* ~~SLR_soldier doesn't have the new `steam-runtime-launcher-interface-0`, so replace `SteamLinuxRuntime_soldier/pressure-vessel` with a build from https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/merge_requests/465. https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/jobs/95761/artifacts/raw/_build/production/pressure-vessel-bin.tar.gz should be suitable. This will stop being necessary when `launcher-interface-0` gets merged and released.~~ SLR_soldier `client_beta` is suitable.
* ~~The new `steam-runtime-launcher-interface-0` isn't in `PATH` yet, so set `PRESSURE_VESSEL_SHELL=instead` in Steam's environment or in a game's Launch Options. When you start the game, instead of the actual game, you'll get an `xterm` running in the container. In that `xterm`, use `export PATH=/run/pressure-vessel/pv-from-host/bin:$PATH` to get the necessary tool into the `PATH`, then run `"$@"` (including the quotes) to run Proton and the actual game. This will stop being necessary when `launcher-interface-0` gets merged and released.~~ SLR_soldier `client_beta` is suitable.

~~https://gitlab.steamos.cloud/steamrt/steamlinuxruntime/-/merge_requests/76 is the corresponding glue to get this launched in the soldier/sniper container (`STEAM_COMPAT_LAUNCHER_SERVICE=container-runtime`) or in the scout-on-soldier "layered" environment that can be used for native Linux games (`STEAM_COMPAT_LAUNCHER_SERVICE=scout-in-container`).~~ (This has been integrated.)

---

* proton: Allow forwarding commands into the Proton environment
    
    Recent versions of the Steam Runtime include an IPC server/client pair
    which can be used to run commands inside the container environment
    (or any other special execution environment), analogous to sshd/ssh or
    flatpak-portal/flatpak-spawn. The server runs inside the Steam Runtime
    container and accepts commands over D-Bus; the client runs on the host
    system, asks the server to run a command, and forwards its stdin, stdout
    and stderr back to the host.
    
    https://gitlab.steamos.cloud/steamrt/steamlinuxruntime/-/merge_requests/72
    adds support for injecting commands into the SteamLinuxRuntime_soldier
    compatibility tool (and any later version, such as sniper). However,
    Steam compatibility tools are stackable: in particular, Proton runs in a
    soldier container (or presumably sniper in future). If we are debugging
    a Proton game, then ideally we will want to inject commands into Proton's
    execution environment rather than soldier's, so that they run with the
    correct environment variables etc. to communicate with a running Proton
    session. In particular, it's important that the `WINEPREFIX` is correct.
    
    The steam-runtime-launcher-interface-0 program implements the
    interface for compatibility tools to use to decide where, if anywhere,
    to launch the command server.
    
    This commit does not alter the scripts produced by
    PROTON_DUMP_DEBUG_COMMANDS. To run those scripts' commands in the
    container environment, pass their filenames to
    steam-runtime-launch-client.