### PR TITLE
Add two new games to IMFDXGIDeviceManager hack

### DIFF
--- a/proton
+++ b/proton
@@ -935,7 +935,8 @@ def default_compat_config():
                 "1331440", #FUSER
                 "1523720", #Cook-Out
                 "1913910", #Nine Sols Demo
-            
+                "2001540", #Slayers X Demo
+
                 #affected by CW bug 19741
                 "1017900", #Age of Empires: Definitive Edition
                 ]:

--- a/proton
+++ b/proton
@@ -931,10 +931,11 @@ def default_compat_config():
                 "1107790", #The Complex
                 "1161580", #Hardspace: Shipbreaker
                 "1190000", #Car Mechanic Simulator 2021
+                "1328350", #Turbo Overkill
                 "1331440", #FUSER
                 "1523720", #Cook-Out
                 "1913910", #Nine Sols Demo
-
+            
                 #affected by CW bug 19741
                 "1017900", #Age of Empires: Definitive Edition
                 ]:


### PR DESCRIPTION
Turbo Overkill and the demo for Slayers X: Terminal Aftermath: Vengeance of the Slayer both exhibit garbled videos until the WINE_DO_NOT_CREATE_DXGI_DEVICE_MANAGER=1 environment variable is set. I'm guessing this is just a thing now for newer Unity games?