### PR TITLE
Fix typos in documentation

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -35,7 +35,7 @@ To update the official Proton SDK images:
    repository to point to the new commit, commit and push to trigger a
    new build of "-dev" images.
 
-3) Once the images are satifying, tag the version in Proton SDK
+3) Once the images are satisfying, tag the version in Proton SDK
    repository and push the tag, this will trigger a new build of the
    images and version them with the same tag as the Git tag.
 

--- a/docs/CONTROLLERS.md
+++ b/docs/CONTROLLERS.md
@@ -14,7 +14,7 @@ hid is a layer above rawinput, where Windows will talk HID to the controller on
 the game's behalf. This turns the raw HID protocol data into usable things like
 buttons and joysticks.
 
-dinput is a "legacy" API that allows applictions to talk to any type of
+dinput is a "legacy" API that allows applications to talk to any type of
 joystick. On Windows, it is implemented on top of HID. Notably, dinput allows
 easy access to controllers that no other API does, so it is still used by
 modern games despite being "legacy."

--- a/docs/ICMP_ECHO.md
+++ b/docs/ICMP_ECHO.md
@@ -4,7 +4,7 @@ Some games rely on ICMP ECHO requests to detect network connectivity,
 or to measure connection ping.
 
 Proton supports sending ICMP ECHO requests using RAW sockets or DGRAM
-ICMP sockets, but the former requires elevated priviledges, and the
+ICMP sockets, but the former requires elevated privileges, and the
 latter may also be disabled by default.
 
 DGRAM ICMP sockets can be enabled for a given set of user groups by

--- a/docs/THREAD_PRIORITY.md
+++ b/docs/THREAD_PRIORITY.md
@@ -6,7 +6,7 @@ priority levels. However, most default Linux configurations don't allow
 individual threads to raise their priority, so some system configuration is
 likely required.
 
-It can be configured as a priviledged user by editing the
+It can be configured as a privileged user by editing the
 `/etc/security/limits.conf` file, or using the `/etc/security/limits.d/` conf
 directory, and adding the following line at the end:
 


### PR DESCRIPTION
Fix various typos in docs/ and docker/ sub-folders