### PR TITLE
Respect VR_OVERRIDE envvar

### DIFF
--- a/steam_helper/steam.cpp
+++ b/steam_helper/steam.cpp
@@ -412,7 +412,11 @@ static bool convert_linux_vrpaths(void)
     }
 
     /* pass original runtime path into Wine */
-    if(root.isMember("runtime") && root["runtime"].isArray() && root["runtime"].size() > 0)
+    const char* vr_override = getenv("VR_OVERRIDE");
+    if(vr_override){
+        set_env_from_unix(L"PROTON_VR_RUNTIME", vr_override);
+    }
+    else if(root.isMember("runtime") && root["runtime"].isArray() && root["runtime"].size() > 0)
     {
         set_env_from_unix(L"PROTON_VR_RUNTIME", root["runtime"][0].asString());
     }


### PR DESCRIPTION
Useful for alternative OpenVR runtimes, such as OpenComposite.