### PR TITLE
Proton build with GitHub actions [experimental_7.0 branch]

### DIFF
--- a/.github/workflows/build_proton.yml
+++ b/.github/workflows/build_proton.yml
@@ -1,0 +1,52 @@
+name: Build Proton
+
+# Allows manual runs, and runs on each commit or release
+on: [workflow_dispatch, push, release]
+
+jobs:
+  make:
+    runs-on: ubuntu-latest
+    name: Make
+    strategy:
+      matrix:
+        build_type: ['redistributable', 'deployment']
+        build_strip: ['stripped', 'unstripped']
+    steps:
+      - name: Checkout the repository
+        id: checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          lfs: true
+
+      - name: Install build dependencies
+        id: dependencies
+        run: sudo apt-get -y install fontforge
+
+      - name: Build proton and generate a ${{ matrix.build_type }} package
+        id: make
+        run: |
+          if [[ "${{ matrix.build_strip }}" == "unstripped" ]]; then
+            export UNSTRIPPED_BUILD=1
+          fi
+          
+          if [[ "${{ matrix.build_type }}" == "redistributable" ]]; then
+            make redist
+          elif [[ "${{ matrix.build_type }}" == "deployment" ]]; then
+            make deploy
+          else
+            exit 1
+          fi
+
+      - name: Recursively list directory contents for debugging
+        id: ls
+        run: ls -Rlah .
+
+      - name: Upload ${{ matrix.build_type }} package artifact
+        id: upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: Proton ${{ matrix.build_type }} ${{ matrix.build_strip }}
+          path: |
+            ./build/*/deploy
+            ./build/*/redist

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "wine"]
 	path = wine
-	url = ../wine
+	url = https://github.com/ValveSoftware/wine
 [submodule "dxvk"]
 	path = dxvk
 	url = https://github.com/doitsujin/dxvk.git


### PR DESCRIPTION
This is a duplicate PR against the experimental branch.

> This pull request adds a GitHub action to build the project on each commit leveraging GitHub's CI environment. The resultant redist package is then uploaded as an artifact which can be downloaded from the actions tab. This PR would have to be merged into each branch for it to run there. If accepted, this should be cherry-picked to every branch.
> 
> Here's what this action looks like in practice, being run on the proton 7.0 branch: https://github.com/dylanmtaylor/Proton/actions/runs/2609849229
> 
> GitHub Actions CI minutes are free to public and open source repositories like Proton. :)
