### PR TITLE
wineopenxr: Verify proper number of swapchain formats is returned

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = ../wine
 [submodule "dxvk"]
 	path = dxvk
-	url = https://github.com/doitsujin/dxvk.git
+	url = ../dxvk
 [submodule "openvr"]
 	path = openvr
 	url = https://github.com/ValveSoftware/openvr

--- a/.gitmodules
+++ b/.gitmodules
@@ -54,4 +54,4 @@
 	url = https://github.com/videolan/dav1d.git
 [submodule "gst-plugins-rs"]
 	path = gst-plugins-rs
-	url = https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git
+	url = https://github.com/sdroege/gst-plugin-rs

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ proton: downloads
 	echo "Proton built locally. Use 'install', 'deploy' or 'redist' targets."
 
 install: downloads
+	rm -rf $(STEAM_DIR)/compatibilitytools.d/$(_build_name)/files/ #remove proton's internal files, but preserve user_settings etc from top-level
 	$(MAKE) $(MFLAGS) $(MAKEOVERRIDES) -C $(BUILD_DIR)/ $(UNSTRIPPED) install
 	echo "Proton installed to your local Steam installation"
 
@@ -167,8 +168,8 @@ dxvk: | $(BUILD_ROOT)/dxvk/lib/wine/dxvk
 dxvk: | $(BUILD_ROOT)/dxvk/lib64/wine/dxvk
 dxvk: downloads
 	$(MAKE) $(MFLAGS) $(MAKEOVERRIDES) -C $(BUILD_DIR)/ $(UNSTRIPPED) dxvk && \
-	cp -f $(BUILD_DIR)/dist/dist/lib/wine/dxvk/*.dll $(BUILD_ROOT)/dxvk/lib/wine/dxvk/ && \
-	cp -f $(BUILD_DIR)/dist/dist/lib64/wine/dxvk/*.dll $(BUILD_ROOT)/dxvk/lib64/wine/dxvk/
+	cp -f $(BUILD_DIR)/dist/files/lib/wine/dxvk/*.dll $(BUILD_ROOT)/dxvk/lib/wine/dxvk/ && \
+	cp -f $(BUILD_DIR)/dist/files/lib64/wine/dxvk/*.dll $(BUILD_ROOT)/dxvk/lib64/wine/dxvk/
 
 dxvk-nvapi: | $(BUILD_ROOT)/dxvk-nvapi/lib/wine/nvapi
 dxvk-nvapi: | $(BUILD_ROOT)/dxvk-nvapi/lib64/wine/nvapi
@@ -181,8 +182,8 @@ vkd3d-proton: | $(BUILD_ROOT)/vkd3d-proton/lib/wine/vkd3d-proton
 vkd3d-proton: | $(BUILD_ROOT)/vkd3d-proton/lib64/wine/vkd3d-proton
 vkd3d-proton: downloads
 	$(MAKE) $(MFLAGS) $(MAKEOVERRIDES) -C $(BUILD_DIR)/ $(UNSTRIPPED) vkd3d-proton && \
-	cp -f $(BUILD_DIR)/dist/dist/lib/wine/vkd3d-proton/*.dll $(BUILD_ROOT)/vkd3d-proton/lib/wine/vkd3d-proton/ && \
-	cp -f $(BUILD_DIR)/dist/dist/lib64/wine/vkd3d-proton/*.dll $(BUILD_ROOT)/vkd3d-proton/lib64/wine/vkd3d-proton/
+	cp -f $(BUILD_DIR)/dist/files/lib/wine/vkd3d-proton/*.dll $(BUILD_ROOT)/vkd3d-proton/lib/wine/vkd3d-proton/ && \
+	cp -f $(BUILD_DIR)/dist/files/lib64/wine/vkd3d-proton/*.dll $(BUILD_ROOT)/vkd3d-proton/lib64/wine/vkd3d-proton/
 
 lsteamclient: | $(BUILD_ROOT)/lsteamclient/lib/wine/i386-windows
 lsteamclient: | $(BUILD_ROOT)/lsteamclient/lib/wine/i386-unix
@@ -190,10 +191,10 @@ lsteamclient: | $(BUILD_ROOT)/lsteamclient/lib64/wine/x86_64-windows
 lsteamclient: | $(BUILD_ROOT)/lsteamclient/lib64/wine/x86_64-unix
 lsteamclient: downloads
 	$(MAKE) $(MFLAGS) $(MAKEOVERRIDES) -C $(BUILD_DIR)/ $(UNSTRIPPED) lsteamclient && \
-	cp -f $(BUILD_DIR)/dist/dist/lib/wine/i386-windows/lsteamclient.dll $(BUILD_ROOT)/lsteamclient/lib/wine/i386-windows/ && \
-	cp -f $(BUILD_DIR)/dist/dist/lib/wine/i386-unix/lsteamclient.dll.so $(BUILD_ROOT)/lsteamclient/lib/wine/i386-unix/ && \
-	cp -f $(BUILD_DIR)/dist/dist/lib64/wine/x86_64-windows/lsteamclient.dll $(BUILD_ROOT)/lsteamclient/lib64/wine/x86_64-windows/ && \
-	cp -f $(BUILD_DIR)/dist/dist/lib64/wine/x86_64-unix/lsteamclient.dll.so $(BUILD_ROOT)/lsteamclient/lib64/wine/x86_64-unix/
+	cp -f $(BUILD_DIR)/dist/files/lib/wine/i386-windows/lsteamclient.dll $(BUILD_ROOT)/lsteamclient/lib/wine/i386-windows/ && \
+	cp -f $(BUILD_DIR)/dist/files/lib/wine/i386-unix/lsteamclient.dll.so $(BUILD_ROOT)/lsteamclient/lib/wine/i386-unix/ && \
+	cp -f $(BUILD_DIR)/dist/files/lib64/wine/x86_64-windows/lsteamclient.dll $(BUILD_ROOT)/lsteamclient/lib64/wine/x86_64-windows/ && \
+	cp -f $(BUILD_DIR)/dist/files/lib64/wine/x86_64-unix/lsteamclient.dll.so $(BUILD_ROOT)/lsteamclient/lib64/wine/x86_64-unix/
 
 vrclient: | $(BUILD_ROOT)/vrclient/lib/wine/i386-windows
 vrclient: | $(BUILD_ROOT)/vrclient/lib/wine/i386-unix
@@ -201,17 +202,17 @@ vrclient: | $(BUILD_ROOT)/vrclient/lib64/wine/x86_64-windows
 vrclient: | $(BUILD_ROOT)/vrclient/lib64/wine/x86_64-unix
 vrclient: downloads
 	$(MAKE) $(MFLAGS) $(MAKEOVERRIDES) -C $(BUILD_DIR)/ $(UNSTRIPPED) vrclient && \
-	cp -f $(BUILD_DIR)/dist/dist/lib/wine/i386-windows/vrclient.dll $(BUILD_ROOT)/vrclient/lib/wine/i386-windows/ && \
-	cp -f $(BUILD_DIR)/dist/dist/lib/wine/i386-unix/vrclient.dll.so $(BUILD_ROOT)/vrclient/lib/wine/i386-unix/ && \
-	cp -f $(BUILD_DIR)/dist/dist/lib64/wine/x86_64-windows/vrclient_x64.dll $(BUILD_ROOT)/vrclient/lib64/wine/x86_64-windows/ && \
-	cp -f $(BUILD_DIR)/dist/dist/lib64/wine/x86_64-unix/vrclient_x64.dll.so $(BUILD_ROOT)/vrclient/lib64/wine/x86_64-unix/
+	cp -f $(BUILD_DIR)/dist/files/lib/wine/i386-windows/vrclient.dll $(BUILD_ROOT)/vrclient/lib/wine/i386-windows/ && \
+	cp -f $(BUILD_DIR)/dist/files/lib/wine/i386-unix/vrclient.dll.so $(BUILD_ROOT)/vrclient/lib/wine/i386-unix/ && \
+	cp -f $(BUILD_DIR)/dist/files/lib64/wine/x86_64-windows/vrclient_x64.dll $(BUILD_ROOT)/vrclient/lib64/wine/x86_64-windows/ && \
+	cp -f $(BUILD_DIR)/dist/files/lib64/wine/x86_64-unix/vrclient_x64.dll.so $(BUILD_ROOT)/vrclient/lib64/wine/x86_64-unix/
 
 wineopenxr: | $(BUILD_ROOT)/wineopenxr/lib64/wine/x86_64-windows
 wineopenxr: | $(BUILD_ROOT)/wineopenxr/lib64/wine/x86_64-unix
 wineopenxr: downloads
 	$(MAKE) $(MFLAGS) $(MAKEOVERRIDES) -C $(BUILD_DIR)/ $(UNSTRIPPED) wineopenxr && \
-	cp -f $(BUILD_DIR)/dist/dist/lib64/wine/x86_64-windows/wineopenxr.dll $(BUILD_ROOT)/wineopenxr/lib64/wine/x86_64-windows/ && \
-	cp -f $(BUILD_DIR)/dist/dist/lib64/wine/x86_64-unix/wineopenxr.dll.so $(BUILD_ROOT)/wineopenxr/lib64/wine/x86_64-unix/
+	cp -f $(BUILD_DIR)/dist/files/lib64/wine/x86_64-windows/wineopenxr.dll $(BUILD_ROOT)/wineopenxr/lib64/wine/x86_64-windows/ && \
+	cp -f $(BUILD_DIR)/dist/files/lib64/wine/x86_64-unix/wineopenxr.dll.so $(BUILD_ROOT)/wineopenxr/lib64/wine/x86_64-unix/
 
 battleye: | $(BUILD_ROOT)/battleye/v1/lib/wine/i386-windows
 battleye: | $(BUILD_ROOT)/battleye/v1/lib/wine/i386-unix

--- a/Makefile.in
+++ b/Makefile.in
@@ -190,6 +190,7 @@ COMPAT_MANIFEST_TEMPLATE := $(SRCDIR)/compatibilitytool.vdf.template
 LICENSE := $(SRCDIR)/dist.LICENSE
 OFL_LICENSE := $(SRCDIR)/fonts/liberation-fonts/LICENSE
 AV1_PATENTS := $(SRCDIR)/dav1d/doc/PATENTS
+STEAMPIPE_FIXUPS_PY := $(SRCDIR)/steampipe_fixups.py
 
 GECKO_VER := 2.47.2
 GECKO32_TARBALL := wine-gecko-$(GECKO_VER)-x86.tar.xz
@@ -278,9 +279,10 @@ DIST_TARGETS := $(DIST_COPY_TARGETS) $(DIST_OVR32) $(DIST_OVR64) \
                 $(DIST_COMPAT_MANIFEST) $(DIST_LICENSE) $(DIST_TOOLMANIFEST) \
                 $(DIST_OFL_LICENSE) $(DIST_AV1_PATENTS) $(DIST_FONTS)
 
-DEPLOY_COPY_TARGETS := $(DIST_COPY_TARGETS) $(DIST_VERSION) $(DIST_LICENSE) \
-                       $(DIST_TOOLMANIFEST) $(DIST_OFL_LICENSE) $(DIST_AV1_PATENTS) $(DST_DIR)
-REDIST_COPY_TARGETS := $(DEPLOY_COPY_TARGETS) $(DIST_COMPAT_MANIFEST)
+BASE_COPY_TARGETS := $(DIST_COPY_TARGETS) $(DIST_VERSION) $(DIST_LICENSE) \
+                     $(DIST_TOOLMANIFEST) $(DIST_OFL_LICENSE) $(DIST_AV1_PATENTS) $(DST_DIR)
+DEPLOY_COPY_TARGETS := $(BASE_COPY_TARGETS) $(STEAMPIPE_FIXUPS_PY)
+REDIST_COPY_TARGETS := $(BASE_COPY_TARGETS) $(DIST_COMPAT_MANIFEST)
 
 $(DIST_LICENSE): $(LICENSE)
 	cp -a $< $@
@@ -377,6 +379,7 @@ dist: $(DIST_TARGETS) all-dist dist_wineopenxr | $(DST_DIR)
 deploy: dist | $(filter-out dist deploy install redist,$(MAKECMDGOALS))
 	mkdir -p $(DEPLOY_DIR)
 	cp -af --no-dereference --preserve=mode,links $(DEPLOY_COPY_TARGETS) $(DEPLOY_DIR)
+	python3 $(STEAMPIPE_FIXUPS_PY) process $(DEPLOY_DIR)
 
 install: dist | $(filter-out dist deploy install redist,$(MAKECMDGOALS))
 	if [ ! -d $(STEAM_DIR) ]; then echo >&2 "!! "$(STEAM_DIR)" does not exist, cannot install"; return 1; fi

--- a/Makefile.in
+++ b/Makefile.in
@@ -679,6 +679,35 @@ $(OBJ)/.steamexe-post-build64:
 	cp $(STEAMEXE_SRC)/64/libsteam_api.so $(DST_LIBDIR64)/
 	touch $@
 
+##
+## vkd3d
+##
+
+VKD3D_D3D12_SOURCE_ARGS = \
+  --exclude aclocal.m4 \
+  --exclude autom4te.cache \
+  --exclude bin/ \
+  --exclude configure \
+  --exclude include/config.h.in \
+  --exclude Makefile.in \
+  --exclude m4/libtool.m4 \
+  --exclude m4/ltoptions.m4 \
+  --exclude m4/ltsugar.m4 \
+  --exclude m4/ltversion.m4 \
+  --exclude m4/lt~obsolete.m4 \
+
+VKD3D_D3D12_CONFIGURE_ARGS = \
+  --disable-doxygen-doc \
+  --disable-tests \
+  --disable-demos \
+  --without-ncurses \
+
+VKD3D_D3D12_DEPENDS = vulkan-loader vulkan-headers spirv-headers
+
+$(eval $(call rules-source,vkd3d_d3d12,$(SRCDIR)/vkd3d))
+$(eval $(call rules-autoconf,vkd3d_d3d12,32))
+$(eval $(call rules-autoconf,vkd3d_d3d12,64))
+
 
 ##
 ## wine
@@ -695,7 +724,7 @@ WINE_CONFIGURE_ARGS = \
 
 WINE_CONFIGURE_ARGS64 = --enable-win64
 
-WINE_DEPENDS = gst_orc gstreamer gst_base
+WINE_DEPENDS = gst_orc gstreamer gst_base vkd3d_d3d12
 
 $(eval $(call rules-source,wine,$(SRCDIR)/wine))
 $(eval $(call rules-autoconf,wine,32))

--- a/Makefile.in
+++ b/Makefile.in
@@ -147,7 +147,7 @@ endif
 ##
 
 DST_BASE := $(OBJ)/dist
-DST_DIR := $(DST_BASE)/dist
+DST_DIR := $(DST_BASE)/files
 DST_LIBDIR32 := $(DST_DIR)/lib
 DST_LIBDIR64 := $(DST_DIR)/lib64
 DEPLOY_DIR := ./deploy
@@ -279,7 +279,7 @@ DIST_TARGETS := $(DIST_COPY_TARGETS) $(DIST_OVR32) $(DIST_OVR64) \
                 $(DIST_OFL_LICENSE) $(DIST_AV1_PATENTS) $(DIST_FONTS)
 
 DEPLOY_COPY_TARGETS := $(DIST_COPY_TARGETS) $(DIST_VERSION) $(DIST_LICENSE) \
-                       $(DIST_TOOLMANIFEST) $(DIST_OFL_LICENSE) $(DIST_AV1_PATENTS)
+                       $(DIST_TOOLMANIFEST) $(DIST_OFL_LICENSE) $(DIST_AV1_PATENTS) $(DST_DIR)
 REDIST_COPY_TARGETS := $(DEPLOY_COPY_TARGETS) $(DIST_COMPAT_MANIFEST)
 
 $(DIST_LICENSE): $(LICENSE)
@@ -375,24 +375,20 @@ dist: $(DIST_TARGETS) all-dist dist_wineopenxr | $(DST_DIR)
 	echo `date '+%s'` `GIT_DIR=$(abspath $(SRCDIR)/.git) git describe --tags` > $(DIST_VERSION)
 
 deploy: dist | $(filter-out dist deploy install redist,$(MAKECMDGOALS))
-	mkdir -p $(DEPLOY_DIR) && \
-	cp -a $(DEPLOY_COPY_TARGETS) $(DEPLOY_DIR) && \
-	tar -C $(DST_DIR) -c . > $(DEPLOY_DIR)/proton_dist.tar
-	@echo "Created deployment archive at "$(DEPLOY_DIR)"/proton_dist.tar"
+	mkdir -p $(DEPLOY_DIR)
+	cp -af --no-dereference --preserve=mode,links $(DEPLOY_COPY_TARGETS) $(DEPLOY_DIR)
 
 install: dist | $(filter-out dist deploy install redist,$(MAKECMDGOALS))
 	if [ ! -d $(STEAM_DIR) ]; then echo >&2 "!! "$(STEAM_DIR)" does not exist, cannot install"; return 1; fi
 	mkdir -p $(STEAM_DIR)/compatibilitytools.d/$(BUILD_NAME)
+	# Use -r instead of -a for sshfs
 	cp -rf --no-dereference --preserve=mode,links $(DST_BASE)/* $(STEAM_DIR)/compatibilitytools.d/$(BUILD_NAME)
-	cp -f $(DIST_VERSION) $(STEAM_DIR)/compatibilitytools.d/$(BUILD_NAME)/dist/
 	@echo "Installed Proton to "$(STEAM_DIR)/compatibilitytools.d/$(BUILD_NAME)
 	@echo "You may need to restart Steam to select this tool"
 
 redist: dist | $(filter-out dist deploy install redist,$(MAKECMDGOALS))
 	mkdir -p $(REDIST_DIR)
-	cp -a $(REDIST_COPY_TARGETS) $(REDIST_DIR)
-	tar -C $(DST_DIR) -c . | gzip -c -1 > $(REDIST_DIR)/proton_dist.tar.gz
-	@echo "Created redistribution tarball at "$(REDIST_DIR)"/proton_dist.tar.gz"
+	cp -af --no-dereference --preserve=mode,links $(REDIST_COPY_TARGETS) $(REDIST_DIR)
 
 .PHONY: module32 module64 module
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -192,7 +192,7 @@ OFL_LICENSE := $(SRCDIR)/fonts/liberation-fonts/LICENSE
 AV1_PATENTS := $(SRCDIR)/dav1d/doc/PATENTS
 STEAMPIPE_FIXUPS_PY := $(SRCDIR)/steampipe_fixups.py
 
-GECKO_VER := 2.47.2
+GECKO_VER := 2.47.3
 GECKO32_TARBALL := wine-gecko-$(GECKO_VER)-x86.tar.xz
 GECKO64_TARBALL := wine-gecko-$(GECKO_VER)-x86_64.tar.xz
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -502,6 +502,7 @@ GST_GOOD_MESON_ARGS := \
 	-Dwavparse=enabled \
 	-Did3demux=enabled \
 	-Dmpg123=enabled \
+	-Dsoup=enabled \
 	-Dorc=enabled
 
 GST_GOOD_DEPENDS = gst_orc gstreamer gst_base

--- a/README.md
+++ b/README.md
@@ -150,6 +150,20 @@ is only useful after building Proton.
 `make dxvk` / `make vkd3d-proton` - rebuild DXVK / vkd3d-proton.
 
 
+### Debug Builds
+
+To prevent symbol stripping add `UNSTRIPPED_BUILD=1` to the `make`
+invocation. This should be used only with a clean build directory.
+
+E.g.:
+
+```
+mkdir ../debug-proton-build && cd ../debug-proton-build
+../proton/configure.sh --enable-ccache --build-name=debug_build
+make UNSTRIPPED_BUILD=1 install`
+```
+
+
 Install Proton locally
 ----------------------
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,20 @@ version of Proton to other users, you must adhere to the terms of these
 licenses.
 
 
+Debugging
+---------
+
+Proton builds have their symbols stripped by default. You can switch to
+"debug" beta branch in Steam (search for Proton in your library,
+Properties... -> BETAS -> select "debug") or build without stripping (see
+[Debug Builds section](#debug-builds)).
+
+The symbols are provided through the accompanying `.debug` files which may
+need to be explicitly loaded by the debugging tools. For GDB there's a helper
+script `wine/tools/gdbinit.py` (source it) that provides `load-symbol-files`
+(or `lsf` for short) command which loads the symbols for all the mapped files.
+
+
 Runtime Config Options
 ----------------------
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ the Wine prefix. Removing the option will revert to the previous behavior.
 | `vkd3dfl12`           |                                    | Force the Direct3D 12 feature level to 12, regardless of driver support. |
 | `vkd3dbindlesstb`     |                                    | Put `force_bindless_texel_buffer` into `VKD3D_CONFIG`. |
 | `nomfdxgiman`         | `WINE_DO_NOT_CREATE_DXGI_DEVICE_MANAGER` | Enable hack to work around video issues in some games due to incomplete IMFDXGIDeviceManager support. |
+| `noopwr`              | `WINE_DISABLE_VULKAN_OPWR`               | Enable hack to disable Vulkan other process window rendering which sometimes causes issues on Wayland due to blit being one frame behind. |
 | `hidenvgpu`           | `PROTON_HIDE_NVIDIA_GPU`           | Force Nvidia GPUs to always be reported as AMD GPUs. Some games require this if they depend on Windows-only Nvidia driver functionality. See also DXVK's nvapiHack config, which only affects reporting from Direct3D. |
 |                       | `WINE_FULLSCREEN_INTEGER_SCALING`  | Enable integer scaling mode, to give sharp pixels when upscaling. |
 | `cmdlineappend:`      |                                    | Append the string after the colon as an argument to the game command. May be specified more than once. Escape commas and backslashes with a backslash. |

--- a/configure.sh
+++ b/configure.sh
@@ -182,7 +182,7 @@ function configure() {
 #
 
 arg_steamrt="soldier"
-arg_protonsdk_image="registry.gitlab.steamos.cloud/proton/soldier/sdk:0.20220329.0-0"
+arg_protonsdk_image="registry.gitlab.steamos.cloud/proton/soldier/sdk:0.20220601.0-0"
 arg_no_protonsdk=""
 arg_build_name=""
 arg_container_engine=""

--- a/default_pfx.py
+++ b/default_pfx.py
@@ -71,6 +71,14 @@ def setup_dll_symlinks(default_pfx_dir, dist_dir):
                 os.unlink(filename)
                 make_relative_symlink(target, filename)
 
+#steampipe can't handle filenames with colons, so we remove them here
+#and restore them in the proton script
+def fixup_drive_links(default_pfx_dir):
+    for walk_dir, dirs, files in os.walk(os.path.join(default_pfx_dir, "dosdevices")):
+        for dir_ in dirs:
+            if ":" in dir_:
+                os.remove(os.path.join(walk_dir, dir_))
+
 def make_default_pfx(default_pfx_dir, dist_dir, runtime):
     local_env = dict(os.environ)
 
@@ -94,6 +102,7 @@ def make_default_pfx(default_pfx_dir, dist_dir, runtime):
 
         env=local_env, check=True)
     setup_dll_symlinks(default_pfx_dir, dist_dir)
+    fixup_drive_links(default_pfx_dir)
 
 if __name__ == '__main__':
     import sys

--- a/docker/README.md
+++ b/docker/README.md
@@ -35,7 +35,7 @@ To update the official Proton SDK images:
    repository to point to the new commit, commit and push to trigger a
    new build of "-dev" images.
 
-3) Once the images are satifying, tag the version in Proton SDK
+3) Once the images are satisfying, tag the version in Proton SDK
    repository and push the tag, this will trigger a new build of the
    images and version them with the same tag as the Git tag.
 

--- a/docker/proton.Dockerfile.in
+++ b/docker/proton.Dockerfile.in
@@ -52,6 +52,7 @@ RUN bash -c 'mkdir -p /usr/lib/ccache && ls /usr/bin/{,*-}{cc,c++,gcc,g++}{,-[0-
 ENV PATH=/usr/lib/ccache:$PATH
 
 RUN apt-get install -y \
+  autoconf-archive \
   fontforge \
   fonttools \
   libxpresent-dev \

--- a/docker/proton.Dockerfile.in
+++ b/docker/proton.Dockerfile.in
@@ -56,6 +56,8 @@ RUN apt-get install -y \
   fonttools \
   libxpresent-dev \
   libxpresent-dev:i386 \
+  libopenblas-dev \
+  libopenblas-dev:i386 \
   python3-pefile \
   libcapstone-dev \
   libcapstone-dev:i386 \

--- a/docs/CONTROLLERS.md
+++ b/docs/CONTROLLERS.md
@@ -14,7 +14,7 @@ hid is a layer above rawinput, where Windows will talk HID to the controller on
 the game's behalf. This turns the raw HID protocol data into usable things like
 buttons and joysticks.
 
-dinput is a "legacy" API that allows applictions to talk to any type of
+dinput is a "legacy" API that allows applications to talk to any type of
 joystick. On Windows, it is implemented on top of HID. Notably, dinput allows
 easy access to controllers that no other API does, so it is still used by
 modern games despite being "legacy."

--- a/docs/ICMP_ECHO.md
+++ b/docs/ICMP_ECHO.md
@@ -4,7 +4,7 @@ Some games rely on ICMP ECHO requests to detect network connectivity,
 or to measure connection ping.
 
 Proton supports sending ICMP ECHO requests using RAW sockets or DGRAM
-ICMP sockets, but the former requires elevated priviledges, and the
+ICMP sockets, but the former requires elevated privileges, and the
 latter may also be disabled by default.
 
 DGRAM ICMP sockets can be enabled for a given set of user groups by

--- a/docs/THREAD_PRIORITY.md
+++ b/docs/THREAD_PRIORITY.md
@@ -6,7 +6,7 @@ priority levels. However, most default Linux configurations don't allow
 individual threads to raise their priority, so some system configuration is
 likely required.
 
-It can be configured as a priviledged user by editing the
+It can be configured as a privileged user by editing the
 `/etc/security/limits.conf` file, or using the `/etc/security/limits.d/` conf
 directory, and adding the following line at the end:
 

--- a/lsteamclient/cppISteamClient_SteamClient007.cpp
+++ b/lsteamclient/cppISteamClient_SteamClient007.cpp
@@ -112,6 +112,7 @@ void *cppISteamClient_SteamClient007_GetISteamNetworking(void *linux_side, HStea
 
 void cppISteamClient_SteamClient007_SetWarningMessageHook(void *linux_side, SteamAPIWarningMessageHook_t pFunction)
 {
+    pFunction = (SteamAPIWarningMessageHook_t)manual_convert_SteamAPIWarningMessageHook_t((void*)pFunction);
     ((ISteamClient*)linux_side)->SetWarningMessageHook((SteamAPIWarningMessageHook_t)pFunction);
 }
 

--- a/lsteamclient/cppISteamClient_SteamClient008.cpp
+++ b/lsteamclient/cppISteamClient_SteamClient008.cpp
@@ -112,6 +112,7 @@ uint32 cppISteamClient_SteamClient008_GetIPCCallCount(void *linux_side)
 
 void cppISteamClient_SteamClient008_SetWarningMessageHook(void *linux_side, SteamAPIWarningMessageHook_t pFunction)
 {
+    pFunction = (SteamAPIWarningMessageHook_t)manual_convert_SteamAPIWarningMessageHook_t((void*)pFunction);
     ((ISteamClient*)linux_side)->SetWarningMessageHook((SteamAPIWarningMessageHook_t)pFunction);
 }
 

--- a/lsteamclient/cppISteamClient_SteamClient009.cpp
+++ b/lsteamclient/cppISteamClient_SteamClient009.cpp
@@ -117,6 +117,7 @@ uint32 cppISteamClient_SteamClient009_GetIPCCallCount(void *linux_side)
 
 void cppISteamClient_SteamClient009_SetWarningMessageHook(void *linux_side, SteamAPIWarningMessageHook_t pFunction)
 {
+    pFunction = (SteamAPIWarningMessageHook_t)manual_convert_SteamAPIWarningMessageHook_t((void*)pFunction);
     ((ISteamClient*)linux_side)->SetWarningMessageHook((SteamAPIWarningMessageHook_t)pFunction);
 }
 

--- a/lsteamclient/cppISteamClient_SteamClient010.cpp
+++ b/lsteamclient/cppISteamClient_SteamClient010.cpp
@@ -117,6 +117,7 @@ uint32 cppISteamClient_SteamClient010_GetIPCCallCount(void *linux_side)
 
 void cppISteamClient_SteamClient010_SetWarningMessageHook(void *linux_side, SteamAPIWarningMessageHook_t pFunction)
 {
+    pFunction = (SteamAPIWarningMessageHook_t)manual_convert_SteamAPIWarningMessageHook_t((void*)pFunction);
     ((ISteamClient*)linux_side)->SetWarningMessageHook((SteamAPIWarningMessageHook_t)pFunction);
 }
 

--- a/lsteamclient/cppISteamClient_SteamClient011.cpp
+++ b/lsteamclient/cppISteamClient_SteamClient011.cpp
@@ -122,6 +122,7 @@ uint32 cppISteamClient_SteamClient011_GetIPCCallCount(void *linux_side)
 
 void cppISteamClient_SteamClient011_SetWarningMessageHook(void *linux_side, SteamAPIWarningMessageHook_t pFunction)
 {
+    pFunction = (SteamAPIWarningMessageHook_t)manual_convert_SteamAPIWarningMessageHook_t((void*)pFunction);
     ((ISteamClient*)linux_side)->SetWarningMessageHook((SteamAPIWarningMessageHook_t)pFunction);
 }
 

--- a/lsteamclient/cppISteamClient_SteamClient012.cpp
+++ b/lsteamclient/cppISteamClient_SteamClient012.cpp
@@ -117,6 +117,7 @@ uint32 cppISteamClient_SteamClient012_GetIPCCallCount(void *linux_side)
 
 void cppISteamClient_SteamClient012_SetWarningMessageHook(void *linux_side, SteamAPIWarningMessageHook_t pFunction)
 {
+    pFunction = (SteamAPIWarningMessageHook_t)manual_convert_SteamAPIWarningMessageHook_t((void*)pFunction);
     ((ISteamClient*)linux_side)->SetWarningMessageHook((SteamAPIWarningMessageHook_t)pFunction);
 }
 

--- a/lsteamclient/cppISteamClient_SteamClient013.cpp
+++ b/lsteamclient/cppISteamClient_SteamClient013.cpp
@@ -117,6 +117,7 @@ uint32 cppISteamClient_SteamClient013_GetIPCCallCount(void *linux_side)
 
 void cppISteamClient_SteamClient013_SetWarningMessageHook(void *linux_side, SteamAPIWarningMessageHook_t pFunction)
 {
+    pFunction = (SteamAPIWarningMessageHook_t)manual_convert_SteamAPIWarningMessageHook_t((void*)pFunction);
     ((ISteamClient*)linux_side)->SetWarningMessageHook((SteamAPIWarningMessageHook_t)pFunction);
 }
 

--- a/lsteamclient/cppISteamClient_SteamClient014.cpp
+++ b/lsteamclient/cppISteamClient_SteamClient014.cpp
@@ -117,6 +117,7 @@ uint32 cppISteamClient_SteamClient014_GetIPCCallCount(void *linux_side)
 
 void cppISteamClient_SteamClient014_SetWarningMessageHook(void *linux_side, SteamAPIWarningMessageHook_t pFunction)
 {
+    pFunction = (SteamAPIWarningMessageHook_t)manual_convert_SteamAPIWarningMessageHook_t((void*)pFunction);
     ((ISteamClient*)linux_side)->SetWarningMessageHook((SteamAPIWarningMessageHook_t)pFunction);
 }
 

--- a/lsteamclient/cppISteamClient_SteamClient015.cpp
+++ b/lsteamclient/cppISteamClient_SteamClient015.cpp
@@ -117,6 +117,7 @@ uint32 cppISteamClient_SteamClient015_GetIPCCallCount(void *linux_side)
 
 void cppISteamClient_SteamClient015_SetWarningMessageHook(void *linux_side, SteamAPIWarningMessageHook_t pFunction)
 {
+    pFunction = (SteamAPIWarningMessageHook_t)manual_convert_SteamAPIWarningMessageHook_t((void*)pFunction);
     ((ISteamClient*)linux_side)->SetWarningMessageHook((SteamAPIWarningMessageHook_t)pFunction);
 }
 

--- a/lsteamclient/cppISteamClient_SteamClient016.cpp
+++ b/lsteamclient/cppISteamClient_SteamClient016.cpp
@@ -117,6 +117,7 @@ uint32 cppISteamClient_SteamClient016_GetIPCCallCount(void *linux_side)
 
 void cppISteamClient_SteamClient016_SetWarningMessageHook(void *linux_side, SteamAPIWarningMessageHook_t pFunction)
 {
+    pFunction = (SteamAPIWarningMessageHook_t)manual_convert_SteamAPIWarningMessageHook_t((void*)pFunction);
     ((ISteamClient*)linux_side)->SetWarningMessageHook((SteamAPIWarningMessageHook_t)pFunction);
 }
 

--- a/lsteamclient/cppISteamClient_SteamClient017.cpp
+++ b/lsteamclient/cppISteamClient_SteamClient017.cpp
@@ -117,6 +117,7 @@ uint32 cppISteamClient_SteamClient017_GetIPCCallCount(void *linux_side)
 
 void cppISteamClient_SteamClient017_SetWarningMessageHook(void *linux_side, SteamAPIWarningMessageHook_t pFunction)
 {
+    pFunction = (SteamAPIWarningMessageHook_t)manual_convert_SteamAPIWarningMessageHook_t((void*)pFunction);
     ((ISteamClient*)linux_side)->SetWarningMessageHook((SteamAPIWarningMessageHook_t)pFunction);
 }
 

--- a/lsteamclient/cppISteamClient_SteamClient018.cpp
+++ b/lsteamclient/cppISteamClient_SteamClient018.cpp
@@ -123,6 +123,7 @@ uint32 cppISteamClient_SteamClient018_GetIPCCallCount(void *linux_side)
 
 void cppISteamClient_SteamClient018_SetWarningMessageHook(void *linux_side, SteamAPIWarningMessageHook_t pFunction)
 {
+    pFunction = (SteamAPIWarningMessageHook_t)manual_convert_SteamAPIWarningMessageHook_t((void*)pFunction);
     ((ISteamClient*)linux_side)->SetWarningMessageHook((SteamAPIWarningMessageHook_t)pFunction);
 }
 

--- a/lsteamclient/cppISteamClient_SteamClient019.cpp
+++ b/lsteamclient/cppISteamClient_SteamClient019.cpp
@@ -123,6 +123,7 @@ uint32 cppISteamClient_SteamClient019_GetIPCCallCount(void *linux_side)
 
 void cppISteamClient_SteamClient019_SetWarningMessageHook(void *linux_side, SteamAPIWarningMessageHook_t pFunction)
 {
+    pFunction = (SteamAPIWarningMessageHook_t)manual_convert_SteamAPIWarningMessageHook_t((void*)pFunction);
     ((ISteamClient*)linux_side)->SetWarningMessageHook((SteamAPIWarningMessageHook_t)pFunction);
 }
 

--- a/lsteamclient/cppISteamClient_SteamClient020.cpp
+++ b/lsteamclient/cppISteamClient_SteamClient020.cpp
@@ -123,6 +123,7 @@ uint32 cppISteamClient_SteamClient020_GetIPCCallCount(void *linux_side)
 
 void cppISteamClient_SteamClient020_SetWarningMessageHook(void *linux_side, SteamAPIWarningMessageHook_t pFunction)
 {
+    pFunction = (SteamAPIWarningMessageHook_t)manual_convert_SteamAPIWarningMessageHook_t((void*)pFunction);
     ((ISteamClient*)linux_side)->SetWarningMessageHook((SteamAPIWarningMessageHook_t)pFunction);
 }
 

--- a/lsteamclient/cppISteamUtils_SteamUtils004.cpp
+++ b/lsteamclient/cppISteamUtils_SteamUtils004.cpp
@@ -92,6 +92,7 @@ uint32 cppISteamUtils_SteamUtils004_GetIPCCallCount(void *linux_side)
 
 void cppISteamUtils_SteamUtils004_SetWarningMessageHook(void *linux_side, SteamAPIWarningMessageHook_t pFunction)
 {
+    pFunction = (SteamAPIWarningMessageHook_t)manual_convert_SteamAPIWarningMessageHook_t((void*)pFunction);
     ((ISteamUtils*)linux_side)->SetWarningMessageHook((SteamAPIWarningMessageHook_t)pFunction);
 }
 

--- a/lsteamclient/cppISteamUtils_SteamUtils005.cpp
+++ b/lsteamclient/cppISteamUtils_SteamUtils005.cpp
@@ -92,6 +92,7 @@ uint32 cppISteamUtils_SteamUtils005_GetIPCCallCount(void *linux_side)
 
 void cppISteamUtils_SteamUtils005_SetWarningMessageHook(void *linux_side, SteamAPIWarningMessageHook_t pFunction)
 {
+    pFunction = (SteamAPIWarningMessageHook_t)manual_convert_SteamAPIWarningMessageHook_t((void*)pFunction);
     ((ISteamUtils*)linux_side)->SetWarningMessageHook((SteamAPIWarningMessageHook_t)pFunction);
 }
 

--- a/lsteamclient/cppISteamUtils_SteamUtils006.cpp
+++ b/lsteamclient/cppISteamUtils_SteamUtils006.cpp
@@ -92,6 +92,7 @@ uint32 cppISteamUtils_SteamUtils006_GetIPCCallCount(void *linux_side)
 
 void cppISteamUtils_SteamUtils006_SetWarningMessageHook(void *linux_side, SteamAPIWarningMessageHook_t pFunction)
 {
+    pFunction = (SteamAPIWarningMessageHook_t)manual_convert_SteamAPIWarningMessageHook_t((void*)pFunction);
     ((ISteamUtils*)linux_side)->SetWarningMessageHook((SteamAPIWarningMessageHook_t)pFunction);
 }
 

--- a/lsteamclient/cppISteamUtils_SteamUtils007.cpp
+++ b/lsteamclient/cppISteamUtils_SteamUtils007.cpp
@@ -92,6 +92,7 @@ uint32 cppISteamUtils_SteamUtils007_GetIPCCallCount(void *linux_side)
 
 void cppISteamUtils_SteamUtils007_SetWarningMessageHook(void *linux_side, SteamAPIWarningMessageHook_t pFunction)
 {
+    pFunction = (SteamAPIWarningMessageHook_t)manual_convert_SteamAPIWarningMessageHook_t((void*)pFunction);
     ((ISteamUtils*)linux_side)->SetWarningMessageHook((SteamAPIWarningMessageHook_t)pFunction);
 }
 

--- a/lsteamclient/cppISteamUtils_SteamUtils008.cpp
+++ b/lsteamclient/cppISteamUtils_SteamUtils008.cpp
@@ -92,6 +92,7 @@ uint32 cppISteamUtils_SteamUtils008_GetIPCCallCount(void *linux_side)
 
 void cppISteamUtils_SteamUtils008_SetWarningMessageHook(void *linux_side, SteamAPIWarningMessageHook_t pFunction)
 {
+    pFunction = (SteamAPIWarningMessageHook_t)manual_convert_SteamAPIWarningMessageHook_t((void*)pFunction);
     ((ISteamUtils*)linux_side)->SetWarningMessageHook((SteamAPIWarningMessageHook_t)pFunction);
 }
 

--- a/lsteamclient/cppISteamUtils_SteamUtils009.cpp
+++ b/lsteamclient/cppISteamUtils_SteamUtils009.cpp
@@ -93,6 +93,7 @@ uint32 cppISteamUtils_SteamUtils009_GetIPCCallCount(void *linux_side)
 
 void cppISteamUtils_SteamUtils009_SetWarningMessageHook(void *linux_side, SteamAPIWarningMessageHook_t pFunction)
 {
+    pFunction = (SteamAPIWarningMessageHook_t)manual_convert_SteamAPIWarningMessageHook_t((void*)pFunction);
     ((ISteamUtils*)linux_side)->SetWarningMessageHook((SteamAPIWarningMessageHook_t)pFunction);
 }
 

--- a/lsteamclient/cppISteamUtils_SteamUtils010.cpp
+++ b/lsteamclient/cppISteamUtils_SteamUtils010.cpp
@@ -93,6 +93,7 @@ uint32 cppISteamUtils_SteamUtils010_GetIPCCallCount(void *linux_side)
 
 void cppISteamUtils_SteamUtils010_SetWarningMessageHook(void *linux_side, SteamAPIWarningMessageHook_t pFunction)
 {
+    pFunction = (SteamAPIWarningMessageHook_t)manual_convert_SteamAPIWarningMessageHook_t((void*)pFunction);
     ((ISteamUtils*)linux_side)->SetWarningMessageHook((SteamAPIWarningMessageHook_t)pFunction);
 }
 

--- a/lsteamclient/gen_wrapper.py
+++ b/lsteamclient/gen_wrapper.py
@@ -985,7 +985,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(steamclient);
     else:
         cfile.write(f"    {winclassname} *r = alloc_mem_for_iface(sizeof({winclassname}), \"{iface_version}\");\n")
     cfile.write("    TRACE(\"-> %p\\n\", r);\n")
-    cfile.write(f"    r->vtable = &{winclassname}_vtable;\n")
+    cfile.write(f"    r->vtable = alloc_vtable(&{winclassname}_vtable, {len(methods)}, \"{iface_version}\");\n")
     cfile.write("    r->linux_side = linux_side;\n")
     cfile.write("    return r;\n}\n\n")
 

--- a/lsteamclient/gen_wrapper.py
+++ b/lsteamclient/gen_wrapper.py
@@ -245,6 +245,7 @@ def method_needs_manual_handling(interface_with_version, method_name):
 # manual converters for simple types (function pointers)
 manual_type_converters = [
         "FSteamNetworkingSocketsDebugOutput",
+        "SteamAPIWarningMessageHook_t",
         "SteamAPI_CheckCallbackRegistered_t"
 ]
 

--- a/lsteamclient/steam_defs.h
+++ b/lsteamclient/steam_defs.h
@@ -235,7 +235,7 @@ typedef struct SteamNetConnectionRealTimeLaneStatus_t SteamNetConnectionRealTime
 typedef struct SteamNetworkingFakeIPResult_t SteamNetworkingFakeIPResult_t;
 
 typedef uint32 (*SteamAPI_CheckCallbackRegistered_t)(int cb);
-typedef void *SteamAPIWarningMessageHook_t; //already cdecl, no need for conversion(?)
+typedef void *SteamAPIWarningMessageHook_t;
 typedef void *SteamAPI_PostAPIResultInProcess_t; //unused
 typedef void (*FSteamNetworkingSocketsDebugOutput)(ESteamNetworkingSocketsDebugOutputType nType, const char *pszMsg);
 

--- a/lsteamclient/steamclient_main.c
+++ b/lsteamclient/steamclient_main.c
@@ -692,6 +692,7 @@ static void callback_complete(UINT64 cookie)
 
 typedef void (WINAPI *win_FSteamNetworkingSocketsDebugOutput)(ESteamNetworkingSocketsDebugOutputType nType,
         const char *pszMsg);
+typedef void (CDECL *win_SteamAPIWarningMessageHook_t)(int, const char *pszMsg);
 
 static DWORD WINAPI callback_thread(void *dummy)
 {
@@ -710,6 +711,15 @@ static DWORD WINAPI callback_thread(void *dummy)
                         cb_data.sockets_debug_output.msg);
                 callback_complete(cookie);
                 break;
+            case STEAM_API_WARNING_HOOK:
+                TRACE("STEAM_API_WARNING_HOOK func %p, type %u, msg %s.\n",
+                        cb_data.func, cb_data.steam_api_warning_hook.severity,
+                        wine_dbgstr_a(cb_data.steam_api_warning_hook.msg));
+                ((win_SteamAPIWarningMessageHook_t)cb_data.func)(cb_data.steam_api_warning_hook.severity,
+                        cb_data.steam_api_warning_hook.msg);
+                callback_complete(cookie);
+                break;
+
             default:
                 ERR("Unexpected callback type %u.\n", cb_data.type);
                 break;

--- a/lsteamclient/steamclient_main.c
+++ b/lsteamclient/steamclient_main.c
@@ -615,8 +615,14 @@ void *create_win_interface(const char *name, void *linux_side)
         if (!strcmp(name, constructors[i].iface_version))
         {
             ret = constructors[i].ctor(linux_side);
-            if (allocated_from_steamclient_dll(ret))
+            if (allocated_from_steamclient_dll(ret)
+                    || allocated_from_steamclient_dll(*(void **)ret) /* vtable */)
+            {
+                /* Don't cache interfaces allocated from steamclient.dll space.
+                 * steamclient may get reloaded by the app, miss the previous
+                 * data and potentially have different load address. */
                 break;
+            }
 
             e = HeapAlloc(GetProcessHeap(), 0, sizeof(*e));
             e->name = constructors[i].iface_version;

--- a/lsteamclient/steamclient_private.h
+++ b/lsteamclient/steamclient_private.h
@@ -68,6 +68,7 @@ typedef uint64 SteamAPICall_t; //for ancient SDKs
 bool do_cb_wrap(HSteamPipe pipe, void *linux_side, bool (*cpp_func)(void *, SteamAPICall_t, void *, int, int, bool *), SteamAPICall_t call, void *callback, int callback_len, int cb_expected, bool *failed);
 
 void *alloc_mem_for_iface(size_t size, const char *iface_version);
+void *alloc_vtable(void *vtable, unsigned int method_count, const char *iface_version);
 
 enum callback_type
 {

--- a/lsteamclient/steamclient_private.h
+++ b/lsteamclient/steamclient_private.h
@@ -59,6 +59,7 @@ void *create_LinuxISteamMatchmakingServerListResponse(void *win, const char *ver
 void *create_LinuxISteamMatchmakingPingResponse(void *win, const char *version);
 void *create_LinuxISteamMatchmakingPlayersResponse(void *win, const char *version);
 void *create_LinuxISteamMatchmakingRulesResponse(void *win, const char *version);
+void *manual_convert_SteamAPIWarningMessageHook_t(void *win_func);
 void *manual_convert_FSteamNetworkingSocketsDebugOutput(void *win_func);
 void *manual_convert_SteamAPI_CheckCallbackRegistered_t(void *win_func);
 
@@ -73,6 +74,7 @@ void *alloc_vtable(void *vtable, unsigned int method_count, const char *iface_ve
 enum callback_type
 {
     SOCKET_DEBUG_OUTPUT = 1,
+    STEAM_API_WARNING_HOOK,
 };
 
 struct callback_data
@@ -88,6 +90,12 @@ struct callback_data
             const char *msg;
         }
         sockets_debug_output;
+        struct
+        {
+            int severity;
+            const char *msg;
+        }
+        steam_api_warning_hook;
     };
 };
 

--- a/lsteamclient/steamclient_wrappers.c
+++ b/lsteamclient/steamclient_wrappers.c
@@ -315,6 +315,29 @@ void *manual_convert_FSteamNetworkingSocketsDebugOutput(void *win_func)
 }
 
 
+static void *stored_SteamAPIWarningMessageHook_t;
+
+static void lin_SteamAPIWarningMessageHook_t(int severity, const char *msg)
+{
+    struct callback_data cb_data = { 0 };
+    /* Only Unix native calls from here (not even TRACE):
+     * this is native Unix thread which is not initialized by Wine. */
+    cb_data.type = STEAM_API_WARNING_HOOK;
+    cb_data.func = stored_SteamAPIWarningMessageHook_t;
+    cb_data.steam_api_warning_hook.severity = severity;
+    cb_data.steam_api_warning_hook.msg = msg;
+    execute_callback(&cb_data);
+}
+
+void *manual_convert_SteamAPIWarningMessageHook_t(void *win_func)
+{
+    TRACE("win_func %p, returning %p.\n", win_func, lin_SteamAPIWarningMessageHook_t);
+
+    stored_SteamAPIWarningMessageHook_t = win_func;
+
+    return &lin_SteamAPIWarningMessageHook_t;
+}
+
 /***** SteamAPI_CheckCallbackRegistered_t *****/
 static uint32 (__attribute__((ms_abi)) *stored_SteamAPI_CheckCallbackRegistered_t)(int cb);
 

--- a/lsteamclient/winISteamAppList.c
+++ b/lsteamclient/winISteamAppList.c
@@ -80,7 +80,7 @@ winISteamAppList_STEAMAPPLIST_INTERFACE_VERSION001 *create_winISteamAppList_STEA
 {
     winISteamAppList_STEAMAPPLIST_INTERFACE_VERSION001 *r = alloc_mem_for_iface(sizeof(winISteamAppList_STEAMAPPLIST_INTERFACE_VERSION001), "STEAMAPPLIST_INTERFACE_VERSION001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamAppList_STEAMAPPLIST_INTERFACE_VERSION001_vtable;
+    r->vtable = alloc_vtable(&winISteamAppList_STEAMAPPLIST_INTERFACE_VERSION001_vtable, 5, "STEAMAPPLIST_INTERFACE_VERSION001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamAppTicket.c
+++ b/lsteamclient/winISteamAppTicket.c
@@ -45,7 +45,7 @@ winISteamAppTicket_STEAMAPPTICKET_INTERFACE_VERSION001 *create_winISteamAppTicke
 {
     winISteamAppTicket_STEAMAPPTICKET_INTERFACE_VERSION001 *r = alloc_mem_for_iface(sizeof(winISteamAppTicket_STEAMAPPTICKET_INTERFACE_VERSION001), "STEAMAPPTICKET_INTERFACE_VERSION001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamAppTicket_STEAMAPPTICKET_INTERFACE_VERSION001_vtable;
+    r->vtable = alloc_vtable(&winISteamAppTicket_STEAMAPPTICKET_INTERFACE_VERSION001_vtable, 1, "STEAMAPPTICKET_INTERFACE_VERSION001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamApps.c
+++ b/lsteamclient/winISteamApps.c
@@ -276,7 +276,7 @@ winISteamApps_STEAMAPPS_INTERFACE_VERSION008 *create_winISteamApps_STEAMAPPS_INT
 {
     winISteamApps_STEAMAPPS_INTERFACE_VERSION008 *r = alloc_mem_for_iface(sizeof(winISteamApps_STEAMAPPS_INTERFACE_VERSION008), "STEAMAPPS_INTERFACE_VERSION008");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamApps_STEAMAPPS_INTERFACE_VERSION008_vtable;
+    r->vtable = alloc_vtable(&winISteamApps_STEAMAPPS_INTERFACE_VERSION008_vtable, 29, "STEAMAPPS_INTERFACE_VERSION008");
     r->linux_side = linux_side;
     return r;
 }
@@ -499,7 +499,7 @@ winISteamApps_STEAMAPPS_INTERFACE_VERSION007 *create_winISteamApps_STEAMAPPS_INT
 {
     winISteamApps_STEAMAPPS_INTERFACE_VERSION007 *r = alloc_mem_for_iface(sizeof(winISteamApps_STEAMAPPS_INTERFACE_VERSION007), "STEAMAPPS_INTERFACE_VERSION007");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamApps_STEAMAPPS_INTERFACE_VERSION007_vtable;
+    r->vtable = alloc_vtable(&winISteamApps_STEAMAPPS_INTERFACE_VERSION007_vtable, 24, "STEAMAPPS_INTERFACE_VERSION007");
     r->linux_side = linux_side;
     return r;
 }
@@ -706,7 +706,7 @@ winISteamApps_STEAMAPPS_INTERFACE_VERSION006 *create_winISteamApps_STEAMAPPS_INT
 {
     winISteamApps_STEAMAPPS_INTERFACE_VERSION006 *r = alloc_mem_for_iface(sizeof(winISteamApps_STEAMAPPS_INTERFACE_VERSION006), "STEAMAPPS_INTERFACE_VERSION006");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamApps_STEAMAPPS_INTERFACE_VERSION006_vtable;
+    r->vtable = alloc_vtable(&winISteamApps_STEAMAPPS_INTERFACE_VERSION006_vtable, 22, "STEAMAPPS_INTERFACE_VERSION006");
     r->linux_side = linux_side;
     return r;
 }
@@ -896,7 +896,7 @@ winISteamApps_STEAMAPPS_INTERFACE_VERSION005 *create_winISteamApps_STEAMAPPS_INT
 {
     winISteamApps_STEAMAPPS_INTERFACE_VERSION005 *r = alloc_mem_for_iface(sizeof(winISteamApps_STEAMAPPS_INTERFACE_VERSION005), "STEAMAPPS_INTERFACE_VERSION005");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamApps_STEAMAPPS_INTERFACE_VERSION005_vtable;
+    r->vtable = alloc_vtable(&winISteamApps_STEAMAPPS_INTERFACE_VERSION005_vtable, 20, "STEAMAPPS_INTERFACE_VERSION005");
     r->linux_side = linux_side;
     return r;
 }
@@ -1035,7 +1035,7 @@ winISteamApps_STEAMAPPS_INTERFACE_VERSION004 *create_winISteamApps_STEAMAPPS_INT
 {
     winISteamApps_STEAMAPPS_INTERFACE_VERSION004 *r = alloc_mem_for_iface(sizeof(winISteamApps_STEAMAPPS_INTERFACE_VERSION004), "STEAMAPPS_INTERFACE_VERSION004");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamApps_STEAMAPPS_INTERFACE_VERSION004_vtable;
+    r->vtable = alloc_vtable(&winISteamApps_STEAMAPPS_INTERFACE_VERSION004_vtable, 14, "STEAMAPPS_INTERFACE_VERSION004");
     r->linux_side = linux_side;
     return r;
 }
@@ -1126,7 +1126,7 @@ winISteamApps_STEAMAPPS_INTERFACE_VERSION003 *create_winISteamApps_STEAMAPPS_INT
 {
     winISteamApps_STEAMAPPS_INTERFACE_VERSION003 *r = alloc_mem_for_iface(sizeof(winISteamApps_STEAMAPPS_INTERFACE_VERSION003), "STEAMAPPS_INTERFACE_VERSION003");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamApps_STEAMAPPS_INTERFACE_VERSION003_vtable;
+    r->vtable = alloc_vtable(&winISteamApps_STEAMAPPS_INTERFACE_VERSION003_vtable, 8, "STEAMAPPS_INTERFACE_VERSION003");
     r->linux_side = linux_side;
     return r;
 }
@@ -1209,7 +1209,7 @@ winISteamApps_STEAMAPPS_INTERFACE_VERSION002 *create_winISteamApps_STEAMAPPS_INT
 {
     winISteamApps_STEAMAPPS_INTERFACE_VERSION002 *r = alloc_mem_for_iface(sizeof(winISteamApps_STEAMAPPS_INTERFACE_VERSION002), "STEAMAPPS_INTERFACE_VERSION002");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamApps_STEAMAPPS_INTERFACE_VERSION002_vtable;
+    r->vtable = alloc_vtable(&winISteamApps_STEAMAPPS_INTERFACE_VERSION002_vtable, 7, "STEAMAPPS_INTERFACE_VERSION002");
     r->linux_side = linux_side;
     return r;
 }
@@ -1244,7 +1244,7 @@ winISteamApps_STEAMAPPS_INTERFACE_VERSION001 *create_winISteamApps_STEAMAPPS_INT
 {
     winISteamApps_STEAMAPPS_INTERFACE_VERSION001 *r = alloc_mem_for_iface(sizeof(winISteamApps_STEAMAPPS_INTERFACE_VERSION001), "STEAMAPPS_INTERFACE_VERSION001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamApps_STEAMAPPS_INTERFACE_VERSION001_vtable;
+    r->vtable = alloc_vtable(&winISteamApps_STEAMAPPS_INTERFACE_VERSION001_vtable, 1, "STEAMAPPS_INTERFACE_VERSION001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamClient.c
+++ b/lsteamclient/winISteamClient.c
@@ -400,7 +400,7 @@ winISteamClient_SteamClient020 *create_winISteamClient_SteamClient020(void *linu
 {
     winISteamClient_SteamClient020 *r = alloc_mem_for_iface(sizeof(winISteamClient_SteamClient020), "SteamClient020");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamClient_SteamClient020_vtable;
+    r->vtable = alloc_vtable(&winISteamClient_SteamClient020_vtable, 42, "SteamClient020");
     r->linux_side = linux_side;
     return r;
 }
@@ -782,7 +782,7 @@ winISteamClient_SteamClient019 *create_winISteamClient_SteamClient019(void *linu
 {
     winISteamClient_SteamClient019 *r = alloc_mem_for_iface(sizeof(winISteamClient_SteamClient019), "SteamClient019");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamClient_SteamClient019_vtable;
+    r->vtable = alloc_vtable(&winISteamClient_SteamClient019_vtable, 41, "SteamClient019");
     r->linux_side = linux_side;
     return r;
 }
@@ -1155,7 +1155,7 @@ winISteamClient_SteamClient018 *create_winISteamClient_SteamClient018(void *linu
 {
     winISteamClient_SteamClient018 *r = alloc_mem_for_iface(sizeof(winISteamClient_SteamClient018), "SteamClient018");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamClient_SteamClient018_vtable;
+    r->vtable = alloc_vtable(&winISteamClient_SteamClient018_vtable, 40, "SteamClient018");
     r->linux_side = linux_side;
     return r;
 }
@@ -1501,7 +1501,7 @@ winISteamClient_SteamClient017 *create_winISteamClient_SteamClient017(void *linu
 {
     winISteamClient_SteamClient017 *r = alloc_mem_for_iface(sizeof(winISteamClient_SteamClient017), "SteamClient017");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamClient_SteamClient017_vtable;
+    r->vtable = alloc_vtable(&winISteamClient_SteamClient017_vtable, 37, "SteamClient017");
     r->linux_side = linux_side;
     return r;
 }
@@ -1821,7 +1821,7 @@ winISteamClient_SteamClient016 *create_winISteamClient_SteamClient016(void *linu
 {
     winISteamClient_SteamClient016 *r = alloc_mem_for_iface(sizeof(winISteamClient_SteamClient016), "SteamClient016");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamClient_SteamClient016_vtable;
+    r->vtable = alloc_vtable(&winISteamClient_SteamClient016_vtable, 34, "SteamClient016");
     r->linux_side = linux_side;
     return r;
 }
@@ -2108,7 +2108,7 @@ winISteamClient_SteamClient015 *create_winISteamClient_SteamClient015(void *linu
 {
     winISteamClient_SteamClient015 *r = alloc_mem_for_iface(sizeof(winISteamClient_SteamClient015), "SteamClient015");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamClient_SteamClient015_vtable;
+    r->vtable = alloc_vtable(&winISteamClient_SteamClient015_vtable, 30, "SteamClient015");
     r->linux_side = linux_side;
     return r;
 }
@@ -2386,7 +2386,7 @@ winISteamClient_SteamClient014 *create_winISteamClient_SteamClient014(void *linu
 {
     winISteamClient_SteamClient014 *r = alloc_mem_for_iface(sizeof(winISteamClient_SteamClient014), "SteamClient014");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamClient_SteamClient014_vtable;
+    r->vtable = alloc_vtable(&winISteamClient_SteamClient014_vtable, 29, "SteamClient014");
     r->linux_side = linux_side;
     return r;
 }
@@ -2671,7 +2671,7 @@ winISteamClient_SteamClient013 *create_winISteamClient_SteamClient013(void *linu
 {
     winISteamClient_SteamClient013 *r = alloc_mem_for_iface(sizeof(winISteamClient_SteamClient013), "SteamClient013");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamClient_SteamClient013_vtable;
+    r->vtable = alloc_vtable(&winISteamClient_SteamClient013_vtable, 30, "SteamClient013");
     r->linux_side = linux_side;
     return r;
 }
@@ -2931,7 +2931,7 @@ winISteamClient_SteamClient012 *create_winISteamClient_SteamClient012(void *linu
 {
     winISteamClient_SteamClient012 *r = alloc_mem_for_iface(sizeof(winISteamClient_SteamClient012), "SteamClient012");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamClient_SteamClient012_vtable;
+    r->vtable = alloc_vtable(&winISteamClient_SteamClient012_vtable, 27, "SteamClient012");
     r->linux_side = linux_side;
     return r;
 }
@@ -3173,7 +3173,7 @@ winISteamClient_SteamClient011 *create_winISteamClient_SteamClient011(void *linu
 {
     winISteamClient_SteamClient011 *r = alloc_mem_for_iface(sizeof(winISteamClient_SteamClient011), "SteamClient011");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamClient_SteamClient011_vtable;
+    r->vtable = alloc_vtable(&winISteamClient_SteamClient011_vtable, 25, "SteamClient011");
     r->linux_side = linux_side;
     return r;
 }
@@ -3406,7 +3406,7 @@ winISteamClient_SteamClient010 *create_winISteamClient_SteamClient010(void *linu
 {
     winISteamClient_SteamClient010 *r = alloc_mem_for_iface(sizeof(winISteamClient_SteamClient010), "SteamClient010");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamClient_SteamClient010_vtable;
+    r->vtable = alloc_vtable(&winISteamClient_SteamClient010_vtable, 24, "SteamClient010");
     r->linux_side = linux_side;
     return r;
 }
@@ -3622,7 +3622,7 @@ winISteamClient_SteamClient009 *create_winISteamClient_SteamClient009(void *linu
 {
     winISteamClient_SteamClient009 *r = alloc_mem_for_iface(sizeof(winISteamClient_SteamClient009), "SteamClient009");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamClient_SteamClient009_vtable;
+    r->vtable = alloc_vtable(&winISteamClient_SteamClient009_vtable, 22, "SteamClient009");
     r->linux_side = linux_side;
     return r;
 }
@@ -3829,7 +3829,7 @@ winISteamClient_SteamClient008 *create_winISteamClient_SteamClient008(void *linu
 {
     winISteamClient_SteamClient008 *r = alloc_mem_for_iface(sizeof(winISteamClient_SteamClient008), "SteamClient008");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamClient_SteamClient008_vtable;
+    r->vtable = alloc_vtable(&winISteamClient_SteamClient008_vtable, 21, "SteamClient008");
     r->linux_side = linux_side;
     return r;
 }
@@ -4045,7 +4045,7 @@ winISteamClient_SteamClient007 *create_winISteamClient_SteamClient007(void *linu
 {
     winISteamClient_SteamClient007 *r = alloc_mem_for_iface(sizeof(winISteamClient_SteamClient007), "SteamClient007");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamClient_SteamClient007_vtable;
+    r->vtable = alloc_vtable(&winISteamClient_SteamClient007_vtable, 22, "SteamClient007");
     r->linux_side = linux_side;
     return r;
 }
@@ -4249,7 +4249,7 @@ winISteamClient_SteamClient006 *create_winISteamClient_SteamClient006(void *linu
 {
     winISteamClient_SteamClient006 *r = alloc_mem_for_iface(sizeof(winISteamClient_SteamClient006), "SteamClient006");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamClient_SteamClient006_vtable;
+    r->vtable = alloc_vtable(&winISteamClient_SteamClient006_vtable, 21, "SteamClient006");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamController.c
+++ b/lsteamclient/winISteamController.c
@@ -312,7 +312,7 @@ winISteamController_SteamController008 *create_winISteamController_SteamControll
 {
     winISteamController_SteamController008 *r = alloc_mem_for_iface(sizeof(winISteamController_SteamController008), "SteamController008");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamController_SteamController008_vtable;
+    r->vtable = alloc_vtable(&winISteamController_SteamController008_vtable, 34, "SteamController008");
     r->linux_side = linux_side;
     return r;
 }
@@ -614,7 +614,7 @@ winISteamController_SteamController007 *create_winISteamController_SteamControll
 {
     winISteamController_SteamController007 *r = alloc_mem_for_iface(sizeof(winISteamController_SteamController007), "SteamController007");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamController_SteamController007_vtable;
+    r->vtable = alloc_vtable(&winISteamController_SteamController007_vtable, 34, "SteamController007");
     r->linux_side = linux_side;
     return r;
 }
@@ -892,7 +892,7 @@ winISteamController_SteamController006 *create_winISteamController_SteamControll
 {
     winISteamController_SteamController006 *r = alloc_mem_for_iface(sizeof(winISteamController_SteamController006), "SteamController006");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamController_SteamController006_vtable;
+    r->vtable = alloc_vtable(&winISteamController_SteamController006_vtable, 31, "SteamController006");
     r->linux_side = linux_side;
     return r;
 }
@@ -1130,7 +1130,7 @@ winISteamController_SteamController005 *create_winISteamController_SteamControll
 {
     winISteamController_SteamController005 *r = alloc_mem_for_iface(sizeof(winISteamController_SteamController005), "SteamController005");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamController_SteamController005_vtable;
+    r->vtable = alloc_vtable(&winISteamController_SteamController005_vtable, 26, "SteamController005");
     r->linux_side = linux_side;
     return r;
 }
@@ -1336,7 +1336,7 @@ winISteamController_SteamController004 *create_winISteamController_SteamControll
 {
     winISteamController_SteamController004 *r = alloc_mem_for_iface(sizeof(winISteamController_SteamController004), "SteamController004");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamController_SteamController004_vtable;
+    r->vtable = alloc_vtable(&winISteamController_SteamController004_vtable, 22, "SteamController004");
     r->linux_side = linux_side;
     return r;
 }
@@ -1501,7 +1501,7 @@ winISteamController_SteamController003 *create_winISteamController_SteamControll
 {
     winISteamController_SteamController003 *r = alloc_mem_for_iface(sizeof(winISteamController_SteamController003), "SteamController003");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamController_SteamController003_vtable;
+    r->vtable = alloc_vtable(&winISteamController_SteamController003_vtable, 17, "SteamController003");
     r->linux_side = linux_side;
     return r;
 }
@@ -1578,7 +1578,7 @@ winISteamController_STEAMCONTROLLER_INTERFACE_VERSION *create_winISteamControlle
 {
     winISteamController_STEAMCONTROLLER_INTERFACE_VERSION *r = alloc_mem_for_iface(sizeof(winISteamController_STEAMCONTROLLER_INTERFACE_VERSION), "STEAMCONTROLLER_INTERFACE_VERSION");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamController_STEAMCONTROLLER_INTERFACE_VERSION_vtable;
+    r->vtable = alloc_vtable(&winISteamController_STEAMCONTROLLER_INTERFACE_VERSION_vtable, 6, "STEAMCONTROLLER_INTERFACE_VERSION");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamFriends.c
+++ b/lsteamclient/winISteamFriends.c
@@ -652,7 +652,7 @@ winISteamFriends_SteamFriends017 *create_winISteamFriends_SteamFriends017(void *
 {
     winISteamFriends_SteamFriends017 *r = alloc_mem_for_iface(sizeof(winISteamFriends_SteamFriends017), "SteamFriends017");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamFriends_SteamFriends017_vtable;
+    r->vtable = alloc_vtable(&winISteamFriends_SteamFriends017_vtable, 76, "SteamFriends017");
     r->linux_side = linux_side;
     return r;
 }
@@ -1262,7 +1262,7 @@ winISteamFriends_SteamFriends015 *create_winISteamFriends_SteamFriends015(void *
 {
     winISteamFriends_SteamFriends015 *r = alloc_mem_for_iface(sizeof(winISteamFriends_SteamFriends015), "SteamFriends015");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamFriends_SteamFriends015_vtable;
+    r->vtable = alloc_vtable(&winISteamFriends_SteamFriends015_vtable, 72, "SteamFriends015");
     r->linux_side = linux_side;
     return r;
 }
@@ -1808,7 +1808,7 @@ winISteamFriends_SteamFriends014 *create_winISteamFriends_SteamFriends014(void *
 {
     winISteamFriends_SteamFriends014 *r = alloc_mem_for_iface(sizeof(winISteamFriends_SteamFriends014), "SteamFriends014");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamFriends_SteamFriends014_vtable;
+    r->vtable = alloc_vtable(&winISteamFriends_SteamFriends014_vtable, 64, "SteamFriends014");
     r->linux_side = linux_side;
     return r;
 }
@@ -2346,7 +2346,7 @@ winISteamFriends_SteamFriends013 *create_winISteamFriends_SteamFriends013(void *
 {
     winISteamFriends_SteamFriends013 *r = alloc_mem_for_iface(sizeof(winISteamFriends_SteamFriends013), "SteamFriends013");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamFriends_SteamFriends013_vtable;
+    r->vtable = alloc_vtable(&winISteamFriends_SteamFriends013_vtable, 63, "SteamFriends013");
     r->linux_side = linux_side;
     return r;
 }
@@ -2884,7 +2884,7 @@ winISteamFriends_SteamFriends012 *create_winISteamFriends_SteamFriends012(void *
 {
     winISteamFriends_SteamFriends012 *r = alloc_mem_for_iface(sizeof(winISteamFriends_SteamFriends012), "SteamFriends012");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamFriends_SteamFriends012_vtable;
+    r->vtable = alloc_vtable(&winISteamFriends_SteamFriends012_vtable, 63, "SteamFriends012");
     r->linux_side = linux_side;
     return r;
 }
@@ -3422,7 +3422,7 @@ winISteamFriends_SteamFriends011 *create_winISteamFriends_SteamFriends011(void *
 {
     winISteamFriends_SteamFriends011 *r = alloc_mem_for_iface(sizeof(winISteamFriends_SteamFriends011), "SteamFriends011");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamFriends_SteamFriends011_vtable;
+    r->vtable = alloc_vtable(&winISteamFriends_SteamFriends011_vtable, 63, "SteamFriends011");
     r->linux_side = linux_side;
     return r;
 }
@@ -3928,7 +3928,7 @@ winISteamFriends_SteamFriends010 *create_winISteamFriends_SteamFriends010(void *
 {
     winISteamFriends_SteamFriends010 *r = alloc_mem_for_iface(sizeof(winISteamFriends_SteamFriends010), "SteamFriends010");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamFriends_SteamFriends010_vtable;
+    r->vtable = alloc_vtable(&winISteamFriends_SteamFriends010_vtable, 59, "SteamFriends010");
     r->linux_side = linux_side;
     return r;
 }
@@ -4313,7 +4313,7 @@ winISteamFriends_SteamFriends009 *create_winISteamFriends_SteamFriends009(void *
 {
     winISteamFriends_SteamFriends009 *r = alloc_mem_for_iface(sizeof(winISteamFriends_SteamFriends009), "SteamFriends009");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamFriends_SteamFriends009_vtable;
+    r->vtable = alloc_vtable(&winISteamFriends_SteamFriends009_vtable, 44, "SteamFriends009");
     r->linux_side = linux_side;
     return r;
 }
@@ -4617,7 +4617,7 @@ winISteamFriends_SteamFriends008 *create_winISteamFriends_SteamFriends008(void *
 {
     winISteamFriends_SteamFriends008 *r = alloc_mem_for_iface(sizeof(winISteamFriends_SteamFriends008), "SteamFriends008");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamFriends_SteamFriends008_vtable;
+    r->vtable = alloc_vtable(&winISteamFriends_SteamFriends008_vtable, 34, "SteamFriends008");
     r->linux_side = linux_side;
     return r;
 }
@@ -4871,7 +4871,7 @@ winISteamFriends_SteamFriends007 *create_winISteamFriends_SteamFriends007(void *
 {
     winISteamFriends_SteamFriends007 *r = alloc_mem_for_iface(sizeof(winISteamFriends_SteamFriends007), "SteamFriends007");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamFriends_SteamFriends007_vtable;
+    r->vtable = alloc_vtable(&winISteamFriends_SteamFriends007_vtable, 28, "SteamFriends007");
     r->linux_side = linux_side;
     return r;
 }
@@ -5109,7 +5109,7 @@ winISteamFriends_SteamFriends006 *create_winISteamFriends_SteamFriends006(void *
 {
     winISteamFriends_SteamFriends006 *r = alloc_mem_for_iface(sizeof(winISteamFriends_SteamFriends006), "SteamFriends006");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamFriends_SteamFriends006_vtable;
+    r->vtable = alloc_vtable(&winISteamFriends_SteamFriends006_vtable, 26, "SteamFriends006");
     r->linux_side = linux_side;
     return r;
 }
@@ -5331,7 +5331,7 @@ winISteamFriends_SteamFriends005 *create_winISteamFriends_SteamFriends005(void *
 {
     winISteamFriends_SteamFriends005 *r = alloc_mem_for_iface(sizeof(winISteamFriends_SteamFriends005), "SteamFriends005");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamFriends_SteamFriends005_vtable;
+    r->vtable = alloc_vtable(&winISteamFriends_SteamFriends005_vtable, 24, "SteamFriends005");
     r->linux_side = linux_side;
     return r;
 }
@@ -5521,7 +5521,7 @@ winISteamFriends_SteamFriends004 *create_winISteamFriends_SteamFriends004(void *
 {
     winISteamFriends_SteamFriends004 *r = alloc_mem_for_iface(sizeof(winISteamFriends_SteamFriends004), "SteamFriends004");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamFriends_SteamFriends004_vtable;
+    r->vtable = alloc_vtable(&winISteamFriends_SteamFriends004_vtable, 20, "SteamFriends004");
     r->linux_side = linux_side;
     return r;
 }
@@ -5711,7 +5711,7 @@ winISteamFriends_SteamFriends003 *create_winISteamFriends_SteamFriends003(void *
 {
     winISteamFriends_SteamFriends003 *r = alloc_mem_for_iface(sizeof(winISteamFriends_SteamFriends003), "SteamFriends003");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamFriends_SteamFriends003_vtable;
+    r->vtable = alloc_vtable(&winISteamFriends_SteamFriends003_vtable, 20, "SteamFriends003");
     r->linux_side = linux_side;
     return r;
 }
@@ -5981,7 +5981,7 @@ winISteamFriends_SteamFriends002 *create_winISteamFriends_SteamFriends002(void *
 {
     winISteamFriends_SteamFriends002 *r = alloc_mem_for_iface(sizeof(winISteamFriends_SteamFriends002), "SteamFriends002");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamFriends_SteamFriends002_vtable;
+    r->vtable = alloc_vtable(&winISteamFriends_SteamFriends002_vtable, 30, "SteamFriends002");
     r->linux_side = linux_side;
     return r;
 }
@@ -6225,7 +6225,7 @@ winISteamFriends_SteamFriends001 *create_winISteamFriends_SteamFriends001(void *
 {
     winISteamFriends_SteamFriends001 *r = alloc_mem_for_iface(sizeof(winISteamFriends_SteamFriends001), "SteamFriends001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamFriends_SteamFriends001_vtable;
+    r->vtable = alloc_vtable(&winISteamFriends_SteamFriends001_vtable, 27, "SteamFriends001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamGameCoordinator.c
+++ b/lsteamclient/winISteamGameCoordinator.c
@@ -61,7 +61,7 @@ winISteamGameCoordinator_SteamGameCoordinator001 *create_winISteamGameCoordinato
 {
     winISteamGameCoordinator_SteamGameCoordinator001 *r = alloc_mem_for_iface(sizeof(winISteamGameCoordinator_SteamGameCoordinator001), "SteamGameCoordinator001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamGameCoordinator_SteamGameCoordinator001_vtable;
+    r->vtable = alloc_vtable(&winISteamGameCoordinator_SteamGameCoordinator001_vtable, 3, "SteamGameCoordinator001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamGameSearch.c
+++ b/lsteamclient/winISteamGameSearch.c
@@ -149,7 +149,7 @@ winISteamGameSearch_SteamMatchGameSearch001 *create_winISteamGameSearch_SteamMat
 {
     winISteamGameSearch_SteamMatchGameSearch001 *r = alloc_mem_for_iface(sizeof(winISteamGameSearch_SteamMatchGameSearch001), "SteamMatchGameSearch001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamGameSearch_SteamMatchGameSearch001_vtable;
+    r->vtable = alloc_vtable(&winISteamGameSearch_SteamMatchGameSearch001_vtable, 14, "SteamMatchGameSearch001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamGameServer.c
+++ b/lsteamclient/winISteamGameServer.c
@@ -392,7 +392,7 @@ winISteamGameServer_SteamGameServer014 *create_winISteamGameServer_SteamGameServ
 {
     winISteamGameServer_SteamGameServer014 *r = alloc_mem_for_iface(sizeof(winISteamGameServer_SteamGameServer014), "SteamGameServer014");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamGameServer_SteamGameServer014_vtable;
+    r->vtable = alloc_vtable(&winISteamGameServer_SteamGameServer014_vtable, 44, "SteamGameServer014");
     r->linux_side = linux_side;
     return r;
 }
@@ -774,7 +774,7 @@ winISteamGameServer_SteamGameServer013 *create_winISteamGameServer_SteamGameServ
 {
     winISteamGameServer_SteamGameServer013 *r = alloc_mem_for_iface(sizeof(winISteamGameServer_SteamGameServer013), "SteamGameServer013");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamGameServer_SteamGameServer013_vtable;
+    r->vtable = alloc_vtable(&winISteamGameServer_SteamGameServer013_vtable, 44, "SteamGameServer013");
     r->linux_side = linux_side;
     return r;
 }
@@ -1155,7 +1155,7 @@ winISteamGameServer_SteamGameServer012 *create_winISteamGameServer_SteamGameServ
 {
     winISteamGameServer_SteamGameServer012 *r = alloc_mem_for_iface(sizeof(winISteamGameServer_SteamGameServer012), "SteamGameServer012");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamGameServer_SteamGameServer012_vtable;
+    r->vtable = alloc_vtable(&winISteamGameServer_SteamGameServer012_vtable, 44, "SteamGameServer012");
     r->linux_side = linux_side;
     return r;
 }
@@ -1536,7 +1536,7 @@ winISteamGameServer_SteamGameServer011 *create_winISteamGameServer_SteamGameServ
 {
     winISteamGameServer_SteamGameServer011 *r = alloc_mem_for_iface(sizeof(winISteamGameServer_SteamGameServer011), "SteamGameServer011");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamGameServer_SteamGameServer011_vtable;
+    r->vtable = alloc_vtable(&winISteamGameServer_SteamGameServer011_vtable, 44, "SteamGameServer011");
     r->linux_side = linux_side;
     return r;
 }
@@ -1749,7 +1749,7 @@ winISteamGameServer_SteamGameServer010 *create_winISteamGameServer_SteamGameServ
 {
     winISteamGameServer_SteamGameServer010 *r = alloc_mem_for_iface(sizeof(winISteamGameServer_SteamGameServer010), "SteamGameServer010");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamGameServer_SteamGameServer010_vtable;
+    r->vtable = alloc_vtable(&winISteamGameServer_SteamGameServer010_vtable, 23, "SteamGameServer010");
     r->linux_side = linux_side;
     return r;
 }
@@ -1930,7 +1930,7 @@ winISteamGameServer_SteamGameServer009 *create_winISteamGameServer_SteamGameServ
 {
     winISteamGameServer_SteamGameServer009 *r = alloc_mem_for_iface(sizeof(winISteamGameServer_SteamGameServer009), "SteamGameServer009");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamGameServer_SteamGameServer009_vtable;
+    r->vtable = alloc_vtable(&winISteamGameServer_SteamGameServer009_vtable, 19, "SteamGameServer009");
     r->linux_side = linux_side;
     return r;
 }
@@ -2095,7 +2095,7 @@ winISteamGameServer_SteamGameServer008 *create_winISteamGameServer_SteamGameServ
 {
     winISteamGameServer_SteamGameServer008 *r = alloc_mem_for_iface(sizeof(winISteamGameServer_SteamGameServer008), "SteamGameServer008");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamGameServer_SteamGameServer008_vtable;
+    r->vtable = alloc_vtable(&winISteamGameServer_SteamGameServer008_vtable, 17, "SteamGameServer008");
     r->linux_side = linux_side;
     return r;
 }
@@ -2236,7 +2236,7 @@ winISteamGameServer_SteamGameServer005 *create_winISteamGameServer_SteamGameServ
 {
     winISteamGameServer_SteamGameServer005 *r = alloc_mem_for_iface(sizeof(winISteamGameServer_SteamGameServer005), "SteamGameServer005");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamGameServer_SteamGameServer005_vtable;
+    r->vtable = alloc_vtable(&winISteamGameServer_SteamGameServer005_vtable, 14, "SteamGameServer005");
     r->linux_side = linux_side;
     return r;
 }
@@ -2377,7 +2377,7 @@ winISteamGameServer_SteamGameServer004 *create_winISteamGameServer_SteamGameServ
 {
     winISteamGameServer_SteamGameServer004 *r = alloc_mem_for_iface(sizeof(winISteamGameServer_SteamGameServer004), "SteamGameServer004");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamGameServer_SteamGameServer004_vtable;
+    r->vtable = alloc_vtable(&winISteamGameServer_SteamGameServer004_vtable, 14, "SteamGameServer004");
     r->linux_side = linux_side;
     return r;
 }
@@ -2541,7 +2541,7 @@ winISteamGameServer_SteamGameServer003 *create_winISteamGameServer_SteamGameServ
 {
     winISteamGameServer_SteamGameServer003 *r = alloc_mem_for_iface(sizeof(winISteamGameServer_SteamGameServer003), "SteamGameServer003");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamGameServer_SteamGameServer003_vtable;
+    r->vtable = alloc_vtable(&winISteamGameServer_SteamGameServer003_vtable, 17, "SteamGameServer003");
     r->linux_side = linux_side;
     return r;
 }
@@ -2737,7 +2737,7 @@ winISteamGameServer_SteamGameServer002 *create_winISteamGameServer_SteamGameServ
 {
     winISteamGameServer_SteamGameServer002 *r = alloc_mem_for_iface(sizeof(winISteamGameServer_SteamGameServer002), "SteamGameServer002");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamGameServer_SteamGameServer002_vtable;
+    r->vtable = alloc_vtable(&winISteamGameServer_SteamGameServer002_vtable, 21, "SteamGameServer002");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamGameServerStats.c
+++ b/lsteamclient/winISteamGameServerStats.c
@@ -117,7 +117,7 @@ winISteamGameServerStats_SteamGameServerStats001 *create_winISteamGameServerStat
 {
     winISteamGameServerStats_SteamGameServerStats001 *r = alloc_mem_for_iface(sizeof(winISteamGameServerStats_SteamGameServerStats001), "SteamGameServerStats001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamGameServerStats_SteamGameServerStats001_vtable;
+    r->vtable = alloc_vtable(&winISteamGameServerStats_SteamGameServerStats001_vtable, 10, "SteamGameServerStats001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamGameStats.c
+++ b/lsteamclient/winISteamGameStats.c
@@ -141,7 +141,7 @@ winISteamGameStats_SteamGameStats001 *create_winISteamGameStats_SteamGameStats00
 {
     winISteamGameStats_SteamGameStats001 *r = alloc_mem_for_iface(sizeof(winISteamGameStats_SteamGameStats001), "SteamGameStats001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamGameStats_SteamGameStats001_vtable;
+    r->vtable = alloc_vtable(&winISteamGameStats_SteamGameStats001_vtable, 13, "SteamGameStats001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamHTMLSurface.c
+++ b/lsteamclient/winISteamHTMLSurface.c
@@ -342,7 +342,7 @@ winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_005 *create_winISteamHTM
 {
     winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_005 *r = alloc_mem_for_iface(sizeof(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_005), "STEAMHTMLSURFACE_INTERFACE_VERSION_005");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_005_vtable;
+    r->vtable = alloc_vtable(&winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_005_vtable, 38, "STEAMHTMLSURFACE_INTERFACE_VERSION_005");
     r->linux_side = linux_side;
     return r;
 }
@@ -666,7 +666,7 @@ winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004 *create_winISteamHTM
 {
     winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004 *r = alloc_mem_for_iface(sizeof(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004), "STEAMHTMLSURFACE_INTERFACE_VERSION_004");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_vtable;
+    r->vtable = alloc_vtable(&winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_004_vtable, 37, "STEAMHTMLSURFACE_INTERFACE_VERSION_004");
     r->linux_side = linux_side;
     return r;
 }
@@ -982,7 +982,7 @@ winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003 *create_winISteamHTM
 {
     winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003 *r = alloc_mem_for_iface(sizeof(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003), "STEAMHTMLSURFACE_INTERFACE_VERSION_003");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_vtable;
+    r->vtable = alloc_vtable(&winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_003_vtable, 36, "STEAMHTMLSURFACE_INTERFACE_VERSION_003");
     r->linux_side = linux_side;
     return r;
 }
@@ -1290,7 +1290,7 @@ winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002 *create_winISteamHTM
 {
     winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002 *r = alloc_mem_for_iface(sizeof(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002), "STEAMHTMLSURFACE_INTERFACE_VERSION_002");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_vtable;
+    r->vtable = alloc_vtable(&winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_002_vtable, 35, "STEAMHTMLSURFACE_INTERFACE_VERSION_002");
     r->linux_side = linux_side;
     return r;
 }
@@ -1582,7 +1582,7 @@ winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_001 *create_winISteamHTM
 {
     winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_001 *r = alloc_mem_for_iface(sizeof(winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_001), "STEAMHTMLSURFACE_INTERFACE_VERSION_001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_001_vtable;
+    r->vtable = alloc_vtable(&winISteamHTMLSurface_STEAMHTMLSURFACE_INTERFACE_VERSION_001_vtable, 33, "STEAMHTMLSURFACE_INTERFACE_VERSION_001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamHTTP.c
+++ b/lsteamclient/winISteamHTTP.c
@@ -237,7 +237,7 @@ winISteamHTTP_STEAMHTTP_INTERFACE_VERSION003 *create_winISteamHTTP_STEAMHTTP_INT
 {
     winISteamHTTP_STEAMHTTP_INTERFACE_VERSION003 *r = alloc_mem_for_iface(sizeof(winISteamHTTP_STEAMHTTP_INTERFACE_VERSION003), "STEAMHTTP_INTERFACE_VERSION003");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamHTTP_STEAMHTTP_INTERFACE_VERSION003_vtable;
+    r->vtable = alloc_vtable(&winISteamHTTP_STEAMHTTP_INTERFACE_VERSION003_vtable, 25, "STEAMHTTP_INTERFACE_VERSION003");
     r->linux_side = linux_side;
     return r;
 }
@@ -464,7 +464,7 @@ winISteamHTTP_STEAMHTTP_INTERFACE_VERSION002 *create_winISteamHTTP_STEAMHTTP_INT
 {
     winISteamHTTP_STEAMHTTP_INTERFACE_VERSION002 *r = alloc_mem_for_iface(sizeof(winISteamHTTP_STEAMHTTP_INTERFACE_VERSION002), "STEAMHTTP_INTERFACE_VERSION002");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamHTTP_STEAMHTTP_INTERFACE_VERSION002_vtable;
+    r->vtable = alloc_vtable(&winISteamHTTP_STEAMHTTP_INTERFACE_VERSION002_vtable, 25, "STEAMHTTP_INTERFACE_VERSION002");
     r->linux_side = linux_side;
     return r;
 }
@@ -611,7 +611,7 @@ winISteamHTTP_STEAMHTTP_INTERFACE_VERSION001 *create_winISteamHTTP_STEAMHTTP_INT
 {
     winISteamHTTP_STEAMHTTP_INTERFACE_VERSION001 *r = alloc_mem_for_iface(sizeof(winISteamHTTP_STEAMHTTP_INTERFACE_VERSION001), "STEAMHTTP_INTERFACE_VERSION001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamHTTP_STEAMHTTP_INTERFACE_VERSION001_vtable;
+    r->vtable = alloc_vtable(&winISteamHTTP_STEAMHTTP_INTERFACE_VERSION001_vtable, 15, "STEAMHTTP_INTERFACE_VERSION001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamInput.c
+++ b/lsteamclient/winISteamInput.c
@@ -418,7 +418,7 @@ winISteamInput_SteamInput006 *create_winISteamInput_SteamInput006(void *linux_si
 {
     winISteamInput_SteamInput006 *r = alloc_mem_for_iface(sizeof(winISteamInput_SteamInput006), "SteamInput006");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamInput_SteamInput006_vtable;
+    r->vtable = alloc_vtable(&winISteamInput_SteamInput006_vtable, 47, "SteamInput006");
     r->linux_side = linux_side;
     return r;
 }
@@ -826,7 +826,7 @@ winISteamInput_SteamInput005 *create_winISteamInput_SteamInput005(void *linux_si
 {
     winISteamInput_SteamInput005 *r = alloc_mem_for_iface(sizeof(winISteamInput_SteamInput005), "SteamInput005");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamInput_SteamInput005_vtable;
+    r->vtable = alloc_vtable(&winISteamInput_SteamInput005_vtable, 47, "SteamInput005");
     r->linux_side = linux_side;
     return r;
 }
@@ -1136,7 +1136,7 @@ winISteamInput_SteamInput002 *create_winISteamInput_SteamInput002(void *linux_si
 {
     winISteamInput_SteamInput002 *r = alloc_mem_for_iface(sizeof(winISteamInput_SteamInput002), "SteamInput002");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamInput_SteamInput002_vtable;
+    r->vtable = alloc_vtable(&winISteamInput_SteamInput002_vtable, 35, "SteamInput002");
     r->linux_side = linux_side;
     return r;
 }
@@ -1446,7 +1446,7 @@ winISteamInput_SteamInput001 *create_winISteamInput_SteamInput001(void *linux_si
 {
     winISteamInput_SteamInput001 *r = alloc_mem_for_iface(sizeof(winISteamInput_SteamInput001), "SteamInput001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamInput_SteamInput001_vtable;
+    r->vtable = alloc_vtable(&winISteamInput_SteamInput001_vtable, 35, "SteamInput001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamInventory.c
+++ b/lsteamclient/winISteamInventory.c
@@ -341,7 +341,7 @@ winISteamInventory_STEAMINVENTORY_INTERFACE_V003 *create_winISteamInventory_STEA
 {
     winISteamInventory_STEAMINVENTORY_INTERFACE_V003 *r = alloc_mem_for_iface(sizeof(winISteamInventory_STEAMINVENTORY_INTERFACE_V003), "STEAMINVENTORY_INTERFACE_V003");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamInventory_STEAMINVENTORY_INTERFACE_V003_vtable;
+    r->vtable = alloc_vtable(&winISteamInventory_STEAMINVENTORY_INTERFACE_V003_vtable, 38, "STEAMINVENTORY_INTERFACE_V003");
     r->linux_side = linux_side;
     return r;
 }
@@ -664,7 +664,7 @@ winISteamInventory_STEAMINVENTORY_INTERFACE_V002 *create_winISteamInventory_STEA
 {
     winISteamInventory_STEAMINVENTORY_INTERFACE_V002 *r = alloc_mem_for_iface(sizeof(winISteamInventory_STEAMINVENTORY_INTERFACE_V002), "STEAMINVENTORY_INTERFACE_V002");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamInventory_STEAMINVENTORY_INTERFACE_V002_vtable;
+    r->vtable = alloc_vtable(&winISteamInventory_STEAMINVENTORY_INTERFACE_V002_vtable, 37, "STEAMINVENTORY_INTERFACE_V002");
     r->linux_side = linux_side;
     return r;
 }
@@ -883,7 +883,7 @@ winISteamInventory_STEAMINVENTORY_INTERFACE_V001 *create_winISteamInventory_STEA
 {
     winISteamInventory_STEAMINVENTORY_INTERFACE_V001 *r = alloc_mem_for_iface(sizeof(winISteamInventory_STEAMINVENTORY_INTERFACE_V001), "STEAMINVENTORY_INTERFACE_V001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamInventory_STEAMINVENTORY_INTERFACE_V001_vtable;
+    r->vtable = alloc_vtable(&winISteamInventory_STEAMINVENTORY_INTERFACE_V001_vtable, 24, "STEAMINVENTORY_INTERFACE_V001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamMasterServerUpdater.c
+++ b/lsteamclient/winISteamMasterServerUpdater.c
@@ -149,7 +149,7 @@ winISteamMasterServerUpdater_SteamMasterServerUpdater001 *create_winISteamMaster
 {
     winISteamMasterServerUpdater_SteamMasterServerUpdater001 *r = alloc_mem_for_iface(sizeof(winISteamMasterServerUpdater_SteamMasterServerUpdater001), "SteamMasterServerUpdater001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamMasterServerUpdater_SteamMasterServerUpdater001_vtable;
+    r->vtable = alloc_vtable(&winISteamMasterServerUpdater_SteamMasterServerUpdater001_vtable, 14, "SteamMasterServerUpdater001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamMatchmaking.c
+++ b/lsteamclient/winISteamMatchmaking.c
@@ -344,7 +344,7 @@ winISteamMatchmaking_SteamMatchMaking009 *create_winISteamMatchmaking_SteamMatch
 {
     winISteamMatchmaking_SteamMatchMaking009 *r = alloc_mem_for_iface(sizeof(winISteamMatchmaking_SteamMatchMaking009), "SteamMatchMaking009");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamMatchmaking_SteamMatchMaking009_vtable;
+    r->vtable = alloc_vtable(&winISteamMatchmaking_SteamMatchMaking009_vtable, 38, "SteamMatchMaking009");
     r->linux_side = linux_side;
     return r;
 }
@@ -662,7 +662,7 @@ winISteamMatchmaking_SteamMatchMaking008 *create_winISteamMatchmaking_SteamMatch
 {
     winISteamMatchmaking_SteamMatchMaking008 *r = alloc_mem_for_iface(sizeof(winISteamMatchmaking_SteamMatchMaking008), "SteamMatchMaking008");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamMatchmaking_SteamMatchMaking008_vtable;
+    r->vtable = alloc_vtable(&winISteamMatchmaking_SteamMatchMaking008_vtable, 36, "SteamMatchMaking008");
     r->linux_side = linux_side;
     return r;
 }
@@ -964,7 +964,7 @@ winISteamMatchmaking_SteamMatchMaking007 *create_winISteamMatchmaking_SteamMatch
 {
     winISteamMatchmaking_SteamMatchMaking007 *r = alloc_mem_for_iface(sizeof(winISteamMatchmaking_SteamMatchMaking007), "SteamMatchMaking007");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamMatchmaking_SteamMatchMaking007_vtable;
+    r->vtable = alloc_vtable(&winISteamMatchmaking_SteamMatchMaking007_vtable, 34, "SteamMatchMaking007");
     r->linux_side = linux_side;
     return r;
 }
@@ -1218,7 +1218,7 @@ winISteamMatchmaking_SteamMatchMaking006 *create_winISteamMatchmaking_SteamMatch
 {
     winISteamMatchmaking_SteamMatchMaking006 *r = alloc_mem_for_iface(sizeof(winISteamMatchmaking_SteamMatchMaking006), "SteamMatchMaking006");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamMatchmaking_SteamMatchMaking006_vtable;
+    r->vtable = alloc_vtable(&winISteamMatchmaking_SteamMatchMaking006_vtable, 28, "SteamMatchMaking006");
     r->linux_side = linux_side;
     return r;
 }
@@ -1496,7 +1496,7 @@ winISteamMatchmaking_SteamMatchMaking005 *create_winISteamMatchmaking_SteamMatch
 {
     winISteamMatchmaking_SteamMatchMaking005 *r = alloc_mem_for_iface(sizeof(winISteamMatchmaking_SteamMatchMaking005), "SteamMatchMaking005");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamMatchmaking_SteamMatchMaking005_vtable;
+    r->vtable = alloc_vtable(&winISteamMatchmaking_SteamMatchMaking005_vtable, 31, "SteamMatchMaking005");
     r->linux_side = linux_side;
     return r;
 }
@@ -1741,7 +1741,7 @@ winISteamMatchmaking_SteamMatchMaking004 *create_winISteamMatchmaking_SteamMatch
 {
     winISteamMatchmaking_SteamMatchMaking004 *r = alloc_mem_for_iface(sizeof(winISteamMatchmaking_SteamMatchMaking004), "SteamMatchMaking004");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamMatchmaking_SteamMatchMaking004_vtable;
+    r->vtable = alloc_vtable(&winISteamMatchmaking_SteamMatchMaking004_vtable, 27, "SteamMatchMaking004");
     r->linux_side = linux_side;
     return r;
 }
@@ -1994,7 +1994,7 @@ winISteamMatchmaking_SteamMatchMaking003 *create_winISteamMatchmaking_SteamMatch
 {
     winISteamMatchmaking_SteamMatchMaking003 *r = alloc_mem_for_iface(sizeof(winISteamMatchmaking_SteamMatchMaking003), "SteamMatchMaking003");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamMatchmaking_SteamMatchMaking003_vtable;
+    r->vtable = alloc_vtable(&winISteamMatchmaking_SteamMatchMaking003_vtable, 28, "SteamMatchMaking003");
     r->linux_side = linux_side;
     return r;
 }
@@ -2183,7 +2183,7 @@ winISteamMatchmaking_SteamMatchMaking002 *create_winISteamMatchmaking_SteamMatch
 {
     winISteamMatchmaking_SteamMatchMaking002 *r = alloc_mem_for_iface(sizeof(winISteamMatchmaking_SteamMatchMaking002), "SteamMatchMaking002");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamMatchmaking_SteamMatchMaking002_vtable;
+    r->vtable = alloc_vtable(&winISteamMatchmaking_SteamMatchMaking002_vtable, 20, "SteamMatchMaking002");
     r->linux_side = linux_side;
     return r;
 }
@@ -2388,7 +2388,7 @@ winISteamMatchmaking_SteamMatchMaking001 *create_winISteamMatchmaking_SteamMatch
 {
     winISteamMatchmaking_SteamMatchMaking001 *r = alloc_mem_for_iface(sizeof(winISteamMatchmaking_SteamMatchMaking001), "SteamMatchMaking001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamMatchmaking_SteamMatchMaking001_vtable;
+    r->vtable = alloc_vtable(&winISteamMatchmaking_SteamMatchMaking001_vtable, 22, "SteamMatchMaking001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamMatchmakingServers.c
+++ b/lsteamclient/winISteamMatchmakingServers.c
@@ -173,7 +173,7 @@ winISteamMatchmakingServers_SteamMatchMakingServers002 *create_winISteamMatchmak
 {
     winISteamMatchmakingServers_SteamMatchMakingServers002 *r = alloc_mem_for_iface(sizeof(winISteamMatchmakingServers_SteamMatchMakingServers002), "SteamMatchMakingServers002");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamMatchmakingServers_SteamMatchMakingServers002_vtable;
+    r->vtable = alloc_vtable(&winISteamMatchmakingServers_SteamMatchMakingServers002_vtable, 17, "SteamMatchMakingServers002");
     r->linux_side = linux_side;
     return r;
 }
@@ -328,7 +328,7 @@ winISteamMatchmakingServers_SteamMatchMakingServers001 *create_winISteamMatchmak
 {
     winISteamMatchmakingServers_SteamMatchMakingServers001 *r = alloc_mem_for_iface(sizeof(winISteamMatchmakingServers_SteamMatchMakingServers001), "SteamMatchMakingServers001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamMatchmakingServers_SteamMatchMakingServers001_vtable;
+    r->vtable = alloc_vtable(&winISteamMatchmakingServers_SteamMatchMakingServers001_vtable, 16, "SteamMatchMakingServers001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamMusic.c
+++ b/lsteamclient/winISteamMusic.c
@@ -109,7 +109,7 @@ winISteamMusic_STEAMMUSIC_INTERFACE_VERSION001 *create_winISteamMusic_STEAMMUSIC
 {
     winISteamMusic_STEAMMUSIC_INTERFACE_VERSION001 *r = alloc_mem_for_iface(sizeof(winISteamMusic_STEAMMUSIC_INTERFACE_VERSION001), "STEAMMUSIC_INTERFACE_VERSION001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamMusic_STEAMMUSIC_INTERFACE_VERSION001_vtable;
+    r->vtable = alloc_vtable(&winISteamMusic_STEAMMUSIC_INTERFACE_VERSION001_vtable, 9, "STEAMMUSIC_INTERFACE_VERSION001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamMusicRemote.c
+++ b/lsteamclient/winISteamMusicRemote.c
@@ -293,7 +293,7 @@ winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001 *create_winISteamMusi
 {
     winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001 *r = alloc_mem_for_iface(sizeof(winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001), "STEAMMUSICREMOTE_INTERFACE_VERSION001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_vtable;
+    r->vtable = alloc_vtable(&winISteamMusicRemote_STEAMMUSICREMOTE_INTERFACE_VERSION001_vtable, 32, "STEAMMUSICREMOTE_INTERFACE_VERSION001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamNetworking.c
+++ b/lsteamclient/winISteamNetworking.c
@@ -213,7 +213,7 @@ winISteamNetworking_SteamNetworking006 *create_winISteamNetworking_SteamNetworki
 {
     winISteamNetworking_SteamNetworking006 *r = alloc_mem_for_iface(sizeof(winISteamNetworking_SteamNetworking006), "SteamNetworking006");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamNetworking_SteamNetworking006_vtable;
+    r->vtable = alloc_vtable(&winISteamNetworking_SteamNetworking006_vtable, 22, "SteamNetworking006");
     r->linux_side = linux_side;
     return r;
 }
@@ -416,7 +416,7 @@ winISteamNetworking_SteamNetworking005 *create_winISteamNetworking_SteamNetworki
 {
     winISteamNetworking_SteamNetworking005 *r = alloc_mem_for_iface(sizeof(winISteamNetworking_SteamNetworking005), "SteamNetworking005");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamNetworking_SteamNetworking005_vtable;
+    r->vtable = alloc_vtable(&winISteamNetworking_SteamNetworking005_vtable, 22, "SteamNetworking005");
     r->linux_side = linux_side;
     return r;
 }
@@ -603,7 +603,7 @@ winISteamNetworking_SteamNetworking004 *create_winISteamNetworking_SteamNetworki
 {
     winISteamNetworking_SteamNetworking004 *r = alloc_mem_for_iface(sizeof(winISteamNetworking_SteamNetworking004), "SteamNetworking004");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamNetworking_SteamNetworking004_vtable;
+    r->vtable = alloc_vtable(&winISteamNetworking_SteamNetworking004_vtable, 20, "SteamNetworking004");
     r->linux_side = linux_side;
     return r;
 }
@@ -790,7 +790,7 @@ winISteamNetworking_SteamNetworking003 *create_winISteamNetworking_SteamNetworki
 {
     winISteamNetworking_SteamNetworking003 *r = alloc_mem_for_iface(sizeof(winISteamNetworking_SteamNetworking003), "SteamNetworking003");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamNetworking_SteamNetworking003_vtable;
+    r->vtable = alloc_vtable(&winISteamNetworking_SteamNetworking003_vtable, 20, "SteamNetworking003");
     r->linux_side = linux_side;
     return r;
 }
@@ -929,7 +929,7 @@ winISteamNetworking_SteamNetworking002 *create_winISteamNetworking_SteamNetworki
 {
     winISteamNetworking_SteamNetworking002 *r = alloc_mem_for_iface(sizeof(winISteamNetworking_SteamNetworking002), "SteamNetworking002");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamNetworking_SteamNetworking002_vtable;
+    r->vtable = alloc_vtable(&winISteamNetworking_SteamNetworking002_vtable, 14, "SteamNetworking002");
     r->linux_side = linux_side;
     return r;
 }
@@ -1052,7 +1052,7 @@ winISteamNetworking_SteamNetworking001 *create_winISteamNetworking_SteamNetworki
 {
     winISteamNetworking_SteamNetworking001 *r = alloc_mem_for_iface(sizeof(winISteamNetworking_SteamNetworking001), "SteamNetworking001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamNetworking_SteamNetworking001_vtable;
+    r->vtable = alloc_vtable(&winISteamNetworking_SteamNetworking001_vtable, 12, "SteamNetworking001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamNetworkingFakeUDPPort.c
+++ b/lsteamclient/winISteamNetworkingFakeUDPPort.c
@@ -69,7 +69,7 @@ winISteamNetworkingFakeUDPPort_SteamNetworkingFakeUDPPort001 *create_winISteamNe
 {
     winISteamNetworkingFakeUDPPort_SteamNetworkingFakeUDPPort001 *r = HeapAlloc(GetProcessHeap(), 0, sizeof(winISteamNetworkingFakeUDPPort_SteamNetworkingFakeUDPPort001));
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamNetworkingFakeUDPPort_SteamNetworkingFakeUDPPort001_vtable;
+    r->vtable = alloc_vtable(&winISteamNetworkingFakeUDPPort_SteamNetworkingFakeUDPPort001_vtable, 4, "SteamNetworkingFakeUDPPort001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamNetworkingMessages.c
+++ b/lsteamclient/winISteamNetworkingMessages.c
@@ -85,7 +85,7 @@ winISteamNetworkingMessages_SteamNetworkingMessages002 *create_winISteamNetworki
 {
     winISteamNetworkingMessages_SteamNetworkingMessages002 *r = alloc_mem_for_iface(sizeof(winISteamNetworkingMessages_SteamNetworkingMessages002), "SteamNetworkingMessages002");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamNetworkingMessages_SteamNetworkingMessages002_vtable;
+    r->vtable = alloc_vtable(&winISteamNetworkingMessages_SteamNetworkingMessages002_vtable, 6, "SteamNetworkingMessages002");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamNetworkingSockets.c
+++ b/lsteamclient/winISteamNetworkingSockets.c
@@ -418,7 +418,7 @@ winISteamNetworkingSockets_SteamNetworkingSockets012 *create_winISteamNetworking
 {
     winISteamNetworkingSockets_SteamNetworkingSockets012 *r = alloc_mem_for_iface(sizeof(winISteamNetworkingSockets_SteamNetworkingSockets012), "SteamNetworkingSockets012");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamNetworkingSockets_SteamNetworkingSockets012_vtable;
+    r->vtable = alloc_vtable(&winISteamNetworkingSockets_SteamNetworkingSockets012_vtable, 48, "SteamNetworkingSockets012");
     r->linux_side = linux_side;
     return r;
 }
@@ -770,7 +770,7 @@ winISteamNetworkingSockets_SteamNetworkingSockets009 *create_winISteamNetworking
 {
     winISteamNetworkingSockets_SteamNetworkingSockets009 *r = alloc_mem_for_iface(sizeof(winISteamNetworkingSockets_SteamNetworkingSockets009), "SteamNetworkingSockets009");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamNetworkingSockets_SteamNetworkingSockets009_vtable;
+    r->vtable = alloc_vtable(&winISteamNetworkingSockets_SteamNetworkingSockets009_vtable, 41, "SteamNetworkingSockets009");
     r->linux_side = linux_side;
     return r;
 }
@@ -1114,7 +1114,7 @@ winISteamNetworkingSockets_SteamNetworkingSockets008 *create_winISteamNetworking
 {
     winISteamNetworkingSockets_SteamNetworkingSockets008 *r = alloc_mem_for_iface(sizeof(winISteamNetworkingSockets_SteamNetworkingSockets008), "SteamNetworkingSockets008");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamNetworkingSockets_SteamNetworkingSockets008_vtable;
+    r->vtable = alloc_vtable(&winISteamNetworkingSockets_SteamNetworkingSockets008_vtable, 40, "SteamNetworkingSockets008");
     r->linux_side = linux_side;
     return r;
 }
@@ -1418,7 +1418,7 @@ winISteamNetworkingSockets_SteamNetworkingSockets006 *create_winISteamNetworking
 {
     winISteamNetworkingSockets_SteamNetworkingSockets006 *r = alloc_mem_for_iface(sizeof(winISteamNetworkingSockets_SteamNetworkingSockets006), "SteamNetworkingSockets006");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamNetworkingSockets_SteamNetworkingSockets006_vtable;
+    r->vtable = alloc_vtable(&winISteamNetworkingSockets_SteamNetworkingSockets006_vtable, 35, "SteamNetworkingSockets006");
     r->linux_side = linux_side;
     return r;
 }
@@ -1698,7 +1698,7 @@ winISteamNetworkingSockets_SteamNetworkingSockets004 *create_winISteamNetworking
 {
     winISteamNetworkingSockets_SteamNetworkingSockets004 *r = alloc_mem_for_iface(sizeof(winISteamNetworkingSockets_SteamNetworkingSockets004), "SteamNetworkingSockets004");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamNetworkingSockets_SteamNetworkingSockets004_vtable;
+    r->vtable = alloc_vtable(&winISteamNetworkingSockets_SteamNetworkingSockets004_vtable, 32, "SteamNetworkingSockets004");
     r->linux_side = linux_side;
     return r;
 }
@@ -1954,7 +1954,7 @@ winISteamNetworkingSockets_SteamNetworkingSockets002 *create_winISteamNetworking
 {
     winISteamNetworkingSockets_SteamNetworkingSockets002 *r = alloc_mem_for_iface(sizeof(winISteamNetworkingSockets_SteamNetworkingSockets002), "SteamNetworkingSockets002");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamNetworkingSockets_SteamNetworkingSockets002_vtable;
+    r->vtable = alloc_vtable(&winISteamNetworkingSockets_SteamNetworkingSockets002_vtable, 29, "SteamNetworkingSockets002");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamNetworkingSocketsSerialized.c
+++ b/lsteamclient/winISteamNetworkingSocketsSerialized.c
@@ -101,7 +101,7 @@ winISteamNetworkingSocketsSerialized_SteamNetworkingSocketsSerialized003 *create
 {
     winISteamNetworkingSocketsSerialized_SteamNetworkingSocketsSerialized003 *r = alloc_mem_for_iface(sizeof(winISteamNetworkingSocketsSerialized_SteamNetworkingSocketsSerialized003), "SteamNetworkingSocketsSerialized003");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamNetworkingSocketsSerialized_SteamNetworkingSocketsSerialized003_vtable;
+    r->vtable = alloc_vtable(&winISteamNetworkingSocketsSerialized_SteamNetworkingSocketsSerialized003_vtable, 8, "SteamNetworkingSocketsSerialized003");
     r->linux_side = linux_side;
     return r;
 }
@@ -192,7 +192,7 @@ winISteamNetworkingSocketsSerialized_SteamNetworkingSocketsSerialized002 *create
 {
     winISteamNetworkingSocketsSerialized_SteamNetworkingSocketsSerialized002 *r = alloc_mem_for_iface(sizeof(winISteamNetworkingSocketsSerialized_SteamNetworkingSocketsSerialized002), "SteamNetworkingSocketsSerialized002");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamNetworkingSocketsSerialized_SteamNetworkingSocketsSerialized002_vtable;
+    r->vtable = alloc_vtable(&winISteamNetworkingSocketsSerialized_SteamNetworkingSocketsSerialized002_vtable, 8, "SteamNetworkingSocketsSerialized002");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamNetworkingUtils.c
+++ b/lsteamclient/winISteamNetworkingUtils.c
@@ -242,7 +242,7 @@ winISteamNetworkingUtils_SteamNetworkingUtils004 *create_winISteamNetworkingUtil
 {
     winISteamNetworkingUtils_SteamNetworkingUtils004 *r = alloc_mem_for_iface(sizeof(winISteamNetworkingUtils_SteamNetworkingUtils004), "SteamNetworkingUtils004");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamNetworkingUtils_SteamNetworkingUtils004_vtable;
+    r->vtable = alloc_vtable(&winISteamNetworkingUtils_SteamNetworkingUtils004_vtable, 26, "SteamNetworkingUtils004");
     r->linux_side = linux_side;
     return r;
 }
@@ -450,7 +450,7 @@ winISteamNetworkingUtils_SteamNetworkingUtils003 *create_winISteamNetworkingUtil
 {
     winISteamNetworkingUtils_SteamNetworkingUtils003 *r = alloc_mem_for_iface(sizeof(winISteamNetworkingUtils_SteamNetworkingUtils003), "SteamNetworkingUtils003");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamNetworkingUtils_SteamNetworkingUtils003_vtable;
+    r->vtable = alloc_vtable(&winISteamNetworkingUtils_SteamNetworkingUtils003_vtable, 23, "SteamNetworkingUtils003");
     r->linux_side = linux_side;
     return r;
 }
@@ -650,7 +650,7 @@ winISteamNetworkingUtils_SteamNetworkingUtils002 *create_winISteamNetworkingUtil
 {
     winISteamNetworkingUtils_SteamNetworkingUtils002 *r = alloc_mem_for_iface(sizeof(winISteamNetworkingUtils_SteamNetworkingUtils002), "SteamNetworkingUtils002");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamNetworkingUtils_SteamNetworkingUtils002_vtable;
+    r->vtable = alloc_vtable(&winISteamNetworkingUtils_SteamNetworkingUtils002_vtable, 22, "SteamNetworkingUtils002");
     r->linux_side = linux_side;
     return r;
 }
@@ -850,7 +850,7 @@ winISteamNetworkingUtils_SteamNetworkingUtils001 *create_winISteamNetworkingUtil
 {
     winISteamNetworkingUtils_SteamNetworkingUtils001 *r = alloc_mem_for_iface(sizeof(winISteamNetworkingUtils_SteamNetworkingUtils001), "SteamNetworkingUtils001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamNetworkingUtils_SteamNetworkingUtils001_vtable;
+    r->vtable = alloc_vtable(&winISteamNetworkingUtils_SteamNetworkingUtils001_vtable, 22, "SteamNetworkingUtils001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamParentalSettings.c
+++ b/lsteamclient/winISteamParentalSettings.c
@@ -85,7 +85,7 @@ winISteamParentalSettings_STEAMPARENTALSETTINGS_INTERFACE_VERSION001 *create_win
 {
     winISteamParentalSettings_STEAMPARENTALSETTINGS_INTERFACE_VERSION001 *r = alloc_mem_for_iface(sizeof(winISteamParentalSettings_STEAMPARENTALSETTINGS_INTERFACE_VERSION001), "STEAMPARENTALSETTINGS_INTERFACE_VERSION001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamParentalSettings_STEAMPARENTALSETTINGS_INTERFACE_VERSION001_vtable;
+    r->vtable = alloc_vtable(&winISteamParentalSettings_STEAMPARENTALSETTINGS_INTERFACE_VERSION001_vtable, 6, "STEAMPARENTALSETTINGS_INTERFACE_VERSION001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamParties.c
+++ b/lsteamclient/winISteamParties.c
@@ -133,7 +133,7 @@ winISteamParties_SteamParties002 *create_winISteamParties_SteamParties002(void *
 {
     winISteamParties_SteamParties002 *r = alloc_mem_for_iface(sizeof(winISteamParties_SteamParties002), "SteamParties002");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamParties_SteamParties002_vtable;
+    r->vtable = alloc_vtable(&winISteamParties_SteamParties002_vtable, 12, "SteamParties002");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamRemotePlay.c
+++ b/lsteamclient/winISteamRemotePlay.c
@@ -94,7 +94,7 @@ winISteamRemotePlay_STEAMREMOTEPLAY_INTERFACE_VERSION001 *create_winISteamRemote
 {
     winISteamRemotePlay_STEAMREMOTEPLAY_INTERFACE_VERSION001 *r = alloc_mem_for_iface(sizeof(winISteamRemotePlay_STEAMREMOTEPLAY_INTERFACE_VERSION001), "STEAMREMOTEPLAY_INTERFACE_VERSION001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamRemotePlay_STEAMREMOTEPLAY_INTERFACE_VERSION001_vtable;
+    r->vtable = alloc_vtable(&winISteamRemotePlay_STEAMREMOTEPLAY_INTERFACE_VERSION001_vtable, 7, "STEAMREMOTEPLAY_INTERFACE_VERSION001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamRemoteStorage.c
+++ b/lsteamclient/winISteamRemoteStorage.c
@@ -521,7 +521,7 @@ winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION016 *create_winISteam
 {
     winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION016 *r = alloc_mem_for_iface(sizeof(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION016), "STEAMREMOTESTORAGE_INTERFACE_VERSION016");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION016_vtable;
+    r->vtable = alloc_vtable(&winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION016_vtable, 59, "STEAMREMOTESTORAGE_INTERFACE_VERSION016");
     r->linux_side = linux_side;
     return r;
 }
@@ -1000,7 +1000,7 @@ winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION014 *create_winISteam
 {
     winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION014 *r = alloc_mem_for_iface(sizeof(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION014), "STEAMREMOTESTORAGE_INTERFACE_VERSION014");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION014_vtable;
+    r->vtable = alloc_vtable(&winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION014_vtable, 55, "STEAMREMOTESTORAGE_INTERFACE_VERSION014");
     r->linux_side = linux_side;
     return r;
 }
@@ -1479,7 +1479,7 @@ winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION013 *create_winISteam
 {
     winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION013 *r = alloc_mem_for_iface(sizeof(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION013), "STEAMREMOTESTORAGE_INTERFACE_VERSION013");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION013_vtable;
+    r->vtable = alloc_vtable(&winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION013_vtable, 55, "STEAMREMOTESTORAGE_INTERFACE_VERSION013");
     r->linux_side = linux_side;
     return r;
 }
@@ -1934,7 +1934,7 @@ winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION012 *create_winISteam
 {
     winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION012 *r = alloc_mem_for_iface(sizeof(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION012), "STEAMREMOTESTORAGE_INTERFACE_VERSION012");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION012_vtable;
+    r->vtable = alloc_vtable(&winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION012_vtable, 52, "STEAMREMOTESTORAGE_INTERFACE_VERSION012");
     r->linux_side = linux_side;
     return r;
 }
@@ -2389,7 +2389,7 @@ winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION011 *create_winISteam
 {
     winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION011 *r = alloc_mem_for_iface(sizeof(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION011), "STEAMREMOTESTORAGE_INTERFACE_VERSION011");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION011_vtable;
+    r->vtable = alloc_vtable(&winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION011_vtable, 52, "STEAMREMOTESTORAGE_INTERFACE_VERSION011");
     r->linux_side = linux_side;
     return r;
 }
@@ -2844,7 +2844,7 @@ winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION010 *create_winISteam
 {
     winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION010 *r = alloc_mem_for_iface(sizeof(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION010), "STEAMREMOTESTORAGE_INTERFACE_VERSION010");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION010_vtable;
+    r->vtable = alloc_vtable(&winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION010_vtable, 52, "STEAMREMOTESTORAGE_INTERFACE_VERSION010");
     r->linux_side = linux_side;
     return r;
 }
@@ -3289,7 +3289,7 @@ winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION009 *create_winISteam
 {
     winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION009 *r = alloc_mem_for_iface(sizeof(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION009), "STEAMREMOTESTORAGE_INTERFACE_VERSION009");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION009_vtable;
+    r->vtable = alloc_vtable(&winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION009_vtable, 51, "STEAMREMOTESTORAGE_INTERFACE_VERSION009");
     r->linux_side = linux_side;
     return r;
 }
@@ -3734,7 +3734,7 @@ winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION008 *create_winISteam
 {
     winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION008 *r = alloc_mem_for_iface(sizeof(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION008), "STEAMREMOTESTORAGE_INTERFACE_VERSION008");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION008_vtable;
+    r->vtable = alloc_vtable(&winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION008_vtable, 51, "STEAMREMOTESTORAGE_INTERFACE_VERSION008");
     r->linux_side = linux_side;
     return r;
 }
@@ -4147,7 +4147,7 @@ winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION007 *create_winISteam
 {
     winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION007 *r = alloc_mem_for_iface(sizeof(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION007), "STEAMREMOTESTORAGE_INTERFACE_VERSION007");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION007_vtable;
+    r->vtable = alloc_vtable(&winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION007_vtable, 47, "STEAMREMOTESTORAGE_INTERFACE_VERSION007");
     r->linux_side = linux_side;
     return r;
 }
@@ -4560,7 +4560,7 @@ winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION006 *create_winISteam
 {
     winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION006 *r = alloc_mem_for_iface(sizeof(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION006), "STEAMREMOTESTORAGE_INTERFACE_VERSION006");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION006_vtable;
+    r->vtable = alloc_vtable(&winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION006_vtable, 47, "STEAMREMOTESTORAGE_INTERFACE_VERSION006");
     r->linux_side = linux_side;
     return r;
 }
@@ -4839,7 +4839,7 @@ winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION005 *create_winISteam
 {
     winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION005 *r = alloc_mem_for_iface(sizeof(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION005), "STEAMREMOTESTORAGE_INTERFACE_VERSION005");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION005_vtable;
+    r->vtable = alloc_vtable(&winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION005_vtable, 31, "STEAMREMOTESTORAGE_INTERFACE_VERSION005");
     r->linux_side = linux_side;
     return r;
 }
@@ -5042,7 +5042,7 @@ winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION004 *create_winISteam
 {
     winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION004 *r = alloc_mem_for_iface(sizeof(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION004), "STEAMREMOTESTORAGE_INTERFACE_VERSION004");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION004_vtable;
+    r->vtable = alloc_vtable(&winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION004_vtable, 22, "STEAMREMOTESTORAGE_INTERFACE_VERSION004");
     r->linux_side = linux_side;
     return r;
 }
@@ -5229,7 +5229,7 @@ winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION003 *create_winISteam
 {
     winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION003 *r = alloc_mem_for_iface(sizeof(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION003), "STEAMREMOTESTORAGE_INTERFACE_VERSION003");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION003_vtable;
+    r->vtable = alloc_vtable(&winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION003_vtable, 20, "STEAMREMOTESTORAGE_INTERFACE_VERSION003");
     r->linux_side = linux_side;
     return r;
 }
@@ -5312,7 +5312,7 @@ winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION002 *create_winISteam
 {
     winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION002 *r = alloc_mem_for_iface(sizeof(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION002), "STEAMREMOTESTORAGE_INTERFACE_VERSION002");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION002_vtable;
+    r->vtable = alloc_vtable(&winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION002_vtable, 7, "STEAMREMOTESTORAGE_INTERFACE_VERSION002");
     r->linux_side = linux_side;
     return r;
 }
@@ -5403,7 +5403,7 @@ winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION001 *create_winISteam
 {
     winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION001 *r = alloc_mem_for_iface(sizeof(winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION001), "STEAMREMOTESTORAGE_INTERFACE_VERSION001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION001_vtable;
+    r->vtable = alloc_vtable(&winISteamRemoteStorage_STEAMREMOTESTORAGE_INTERFACE_VERSION001_vtable, 8, "STEAMREMOTESTORAGE_INTERFACE_VERSION001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamScreenshots.c
+++ b/lsteamclient/winISteamScreenshots.c
@@ -117,7 +117,7 @@ winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION003 *create_winISteamScre
 {
     winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION003 *r = alloc_mem_for_iface(sizeof(winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION003), "STEAMSCREENSHOTS_INTERFACE_VERSION003");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION003_vtable;
+    r->vtable = alloc_vtable(&winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION003_vtable, 9, "STEAMSCREENSHOTS_INTERFACE_VERSION003");
     r->linux_side = linux_side;
     return r;
 }
@@ -204,7 +204,7 @@ winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION002 *create_winISteamScre
 {
     winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION002 *r = alloc_mem_for_iface(sizeof(winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION002), "STEAMSCREENSHOTS_INTERFACE_VERSION002");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION002_vtable;
+    r->vtable = alloc_vtable(&winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION002_vtable, 7, "STEAMSCREENSHOTS_INTERFACE_VERSION002");
     r->linux_side = linux_side;
     return r;
 }
@@ -283,7 +283,7 @@ winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION001 *create_winISteamScre
 {
     winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION001 *r = alloc_mem_for_iface(sizeof(winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION001), "STEAMSCREENSHOTS_INTERFACE_VERSION001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION001_vtable;
+    r->vtable = alloc_vtable(&winISteamScreenshots_STEAMSCREENSHOTS_INTERFACE_VERSION001_vtable, 6, "STEAMSCREENSHOTS_INTERFACE_VERSION001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamUGC.c
+++ b/lsteamclient/winISteamUGC.c
@@ -741,7 +741,7 @@ winISteamUGC_STEAMUGC_INTERFACE_VERSION016 *create_winISteamUGC_STEAMUGC_INTERFA
 {
     winISteamUGC_STEAMUGC_INTERFACE_VERSION016 *r = alloc_mem_for_iface(sizeof(winISteamUGC_STEAMUGC_INTERFACE_VERSION016), "STEAMUGC_INTERFACE_VERSION016");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUGC_STEAMUGC_INTERFACE_VERSION016_vtable;
+    r->vtable = alloc_vtable(&winISteamUGC_STEAMUGC_INTERFACE_VERSION016_vtable, 86, "STEAMUGC_INTERFACE_VERSION016");
     r->linux_side = linux_side;
     return r;
 }
@@ -1456,7 +1456,7 @@ winISteamUGC_STEAMUGC_INTERFACE_VERSION015 *create_winISteamUGC_STEAMUGC_INTERFA
 {
     winISteamUGC_STEAMUGC_INTERFACE_VERSION015 *r = alloc_mem_for_iface(sizeof(winISteamUGC_STEAMUGC_INTERFACE_VERSION015), "STEAMUGC_INTERFACE_VERSION015");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUGC_STEAMUGC_INTERFACE_VERSION015_vtable;
+    r->vtable = alloc_vtable(&winISteamUGC_STEAMUGC_INTERFACE_VERSION015_vtable, 84, "STEAMUGC_INTERFACE_VERSION015");
     r->linux_side = linux_side;
     return r;
 }
@@ -2131,7 +2131,7 @@ winISteamUGC_STEAMUGC_INTERFACE_VERSION014 *create_winISteamUGC_STEAMUGC_INTERFA
 {
     winISteamUGC_STEAMUGC_INTERFACE_VERSION014 *r = alloc_mem_for_iface(sizeof(winISteamUGC_STEAMUGC_INTERFACE_VERSION014), "STEAMUGC_INTERFACE_VERSION014");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUGC_STEAMUGC_INTERFACE_VERSION014_vtable;
+    r->vtable = alloc_vtable(&winISteamUGC_STEAMUGC_INTERFACE_VERSION014_vtable, 79, "STEAMUGC_INTERFACE_VERSION014");
     r->linux_side = linux_side;
     return r;
 }
@@ -2798,7 +2798,7 @@ winISteamUGC_STEAMUGC_INTERFACE_VERSION013 *create_winISteamUGC_STEAMUGC_INTERFA
 {
     winISteamUGC_STEAMUGC_INTERFACE_VERSION013 *r = alloc_mem_for_iface(sizeof(winISteamUGC_STEAMUGC_INTERFACE_VERSION013), "STEAMUGC_INTERFACE_VERSION013");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUGC_STEAMUGC_INTERFACE_VERSION013_vtable;
+    r->vtable = alloc_vtable(&winISteamUGC_STEAMUGC_INTERFACE_VERSION013_vtable, 78, "STEAMUGC_INTERFACE_VERSION013");
     r->linux_side = linux_side;
     return r;
 }
@@ -3449,7 +3449,7 @@ winISteamUGC_STEAMUGC_INTERFACE_VERSION012 *create_winISteamUGC_STEAMUGC_INTERFA
 {
     winISteamUGC_STEAMUGC_INTERFACE_VERSION012 *r = alloc_mem_for_iface(sizeof(winISteamUGC_STEAMUGC_INTERFACE_VERSION012), "STEAMUGC_INTERFACE_VERSION012");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUGC_STEAMUGC_INTERFACE_VERSION012_vtable;
+    r->vtable = alloc_vtable(&winISteamUGC_STEAMUGC_INTERFACE_VERSION012_vtable, 76, "STEAMUGC_INTERFACE_VERSION012");
     r->linux_side = linux_side;
     return r;
 }
@@ -4084,7 +4084,7 @@ winISteamUGC_STEAMUGC_INTERFACE_VERSION010 *create_winISteamUGC_STEAMUGC_INTERFA
 {
     winISteamUGC_STEAMUGC_INTERFACE_VERSION010 *r = alloc_mem_for_iface(sizeof(winISteamUGC_STEAMUGC_INTERFACE_VERSION010), "STEAMUGC_INTERFACE_VERSION010");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUGC_STEAMUGC_INTERFACE_VERSION010_vtable;
+    r->vtable = alloc_vtable(&winISteamUGC_STEAMUGC_INTERFACE_VERSION010_vtable, 74, "STEAMUGC_INTERFACE_VERSION010");
     r->linux_side = linux_side;
     return r;
 }
@@ -4663,7 +4663,7 @@ winISteamUGC_STEAMUGC_INTERFACE_VERSION009 *create_winISteamUGC_STEAMUGC_INTERFA
 {
     winISteamUGC_STEAMUGC_INTERFACE_VERSION009 *r = alloc_mem_for_iface(sizeof(winISteamUGC_STEAMUGC_INTERFACE_VERSION009), "STEAMUGC_INTERFACE_VERSION009");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUGC_STEAMUGC_INTERFACE_VERSION009_vtable;
+    r->vtable = alloc_vtable(&winISteamUGC_STEAMUGC_INTERFACE_VERSION009_vtable, 67, "STEAMUGC_INTERFACE_VERSION009");
     r->linux_side = linux_side;
     return r;
 }
@@ -5210,7 +5210,7 @@ winISteamUGC_STEAMUGC_INTERFACE_VERSION008 *create_winISteamUGC_STEAMUGC_INTERFA
 {
     winISteamUGC_STEAMUGC_INTERFACE_VERSION008 *r = alloc_mem_for_iface(sizeof(winISteamUGC_STEAMUGC_INTERFACE_VERSION008), "STEAMUGC_INTERFACE_VERSION008");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUGC_STEAMUGC_INTERFACE_VERSION008_vtable;
+    r->vtable = alloc_vtable(&winISteamUGC_STEAMUGC_INTERFACE_VERSION008_vtable, 63, "STEAMUGC_INTERFACE_VERSION008");
     r->linux_side = linux_side;
     return r;
 }
@@ -5713,7 +5713,7 @@ winISteamUGC_STEAMUGC_INTERFACE_VERSION007 *create_winISteamUGC_STEAMUGC_INTERFA
 {
     winISteamUGC_STEAMUGC_INTERFACE_VERSION007 *r = alloc_mem_for_iface(sizeof(winISteamUGC_STEAMUGC_INTERFACE_VERSION007), "STEAMUGC_INTERFACE_VERSION007");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUGC_STEAMUGC_INTERFACE_VERSION007_vtable;
+    r->vtable = alloc_vtable(&winISteamUGC_STEAMUGC_INTERFACE_VERSION007_vtable, 58, "STEAMUGC_INTERFACE_VERSION007");
     r->linux_side = linux_side;
     return r;
 }
@@ -6150,7 +6150,7 @@ winISteamUGC_STEAMUGC_INTERFACE_VERSION006 *create_winISteamUGC_STEAMUGC_INTERFA
 {
     winISteamUGC_STEAMUGC_INTERFACE_VERSION006 *r = alloc_mem_for_iface(sizeof(winISteamUGC_STEAMUGC_INTERFACE_VERSION006), "STEAMUGC_INTERFACE_VERSION006");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUGC_STEAMUGC_INTERFACE_VERSION006_vtable;
+    r->vtable = alloc_vtable(&winISteamUGC_STEAMUGC_INTERFACE_VERSION006_vtable, 50, "STEAMUGC_INTERFACE_VERSION006");
     r->linux_side = linux_side;
     return r;
 }
@@ -6555,7 +6555,7 @@ winISteamUGC_STEAMUGC_INTERFACE_VERSION005 *create_winISteamUGC_STEAMUGC_INTERFA
 {
     winISteamUGC_STEAMUGC_INTERFACE_VERSION005 *r = alloc_mem_for_iface(sizeof(winISteamUGC_STEAMUGC_INTERFACE_VERSION005), "STEAMUGC_INTERFACE_VERSION005");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUGC_STEAMUGC_INTERFACE_VERSION005_vtable;
+    r->vtable = alloc_vtable(&winISteamUGC_STEAMUGC_INTERFACE_VERSION005_vtable, 46, "STEAMUGC_INTERFACE_VERSION005");
     r->linux_side = linux_side;
     return r;
 }
@@ -6853,7 +6853,7 @@ winISteamUGC_STEAMUGC_INTERFACE_VERSION004 *create_winISteamUGC_STEAMUGC_INTERFA
 {
     winISteamUGC_STEAMUGC_INTERFACE_VERSION004 *r = alloc_mem_for_iface(sizeof(winISteamUGC_STEAMUGC_INTERFACE_VERSION004), "STEAMUGC_INTERFACE_VERSION004");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUGC_STEAMUGC_INTERFACE_VERSION004_vtable;
+    r->vtable = alloc_vtable(&winISteamUGC_STEAMUGC_INTERFACE_VERSION004_vtable, 33, "STEAMUGC_INTERFACE_VERSION004");
     r->linux_side = linux_side;
     return r;
 }
@@ -7135,7 +7135,7 @@ winISteamUGC_STEAMUGC_INTERFACE_VERSION003 *create_winISteamUGC_STEAMUGC_INTERFA
 {
     winISteamUGC_STEAMUGC_INTERFACE_VERSION003 *r = alloc_mem_for_iface(sizeof(winISteamUGC_STEAMUGC_INTERFACE_VERSION003), "STEAMUGC_INTERFACE_VERSION003");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUGC_STEAMUGC_INTERFACE_VERSION003_vtable;
+    r->vtable = alloc_vtable(&winISteamUGC_STEAMUGC_INTERFACE_VERSION003_vtable, 31, "STEAMUGC_INTERFACE_VERSION003");
     r->linux_side = linux_side;
     return r;
 }
@@ -7417,7 +7417,7 @@ winISteamUGC_STEAMUGC_INTERFACE_VERSION002 *create_winISteamUGC_STEAMUGC_INTERFA
 {
     winISteamUGC_STEAMUGC_INTERFACE_VERSION002 *r = alloc_mem_for_iface(sizeof(winISteamUGC_STEAMUGC_INTERFACE_VERSION002), "STEAMUGC_INTERFACE_VERSION002");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUGC_STEAMUGC_INTERFACE_VERSION002_vtable;
+    r->vtable = alloc_vtable(&winISteamUGC_STEAMUGC_INTERFACE_VERSION002_vtable, 31, "STEAMUGC_INTERFACE_VERSION002");
     r->linux_side = linux_side;
     return r;
 }
@@ -7556,7 +7556,7 @@ winISteamUGC_STEAMUGC_INTERFACE_VERSION001 *create_winISteamUGC_STEAMUGC_INTERFA
 {
     winISteamUGC_STEAMUGC_INTERFACE_VERSION001 *r = alloc_mem_for_iface(sizeof(winISteamUGC_STEAMUGC_INTERFACE_VERSION001), "STEAMUGC_INTERFACE_VERSION001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUGC_STEAMUGC_INTERFACE_VERSION001_vtable;
+    r->vtable = alloc_vtable(&winISteamUGC_STEAMUGC_INTERFACE_VERSION001_vtable, 14, "STEAMUGC_INTERFACE_VERSION001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamUnifiedMessages.c
+++ b/lsteamclient/winISteamUnifiedMessages.c
@@ -77,7 +77,7 @@ winISteamUnifiedMessages_STEAMUNIFIEDMESSAGES_INTERFACE_VERSION001 *create_winIS
 {
     winISteamUnifiedMessages_STEAMUNIFIEDMESSAGES_INTERFACE_VERSION001 *r = alloc_mem_for_iface(sizeof(winISteamUnifiedMessages_STEAMUNIFIEDMESSAGES_INTERFACE_VERSION001), "STEAMUNIFIEDMESSAGES_INTERFACE_VERSION001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUnifiedMessages_STEAMUNIFIEDMESSAGES_INTERFACE_VERSION001_vtable;
+    r->vtable = alloc_vtable(&winISteamUnifiedMessages_STEAMUNIFIEDMESSAGES_INTERFACE_VERSION001_vtable, 5, "STEAMUNIFIEDMESSAGES_INTERFACE_VERSION001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamUser.c
+++ b/lsteamclient/winISteamUser.c
@@ -297,7 +297,7 @@ winISteamUser_SteamUser021 *create_winISteamUser_SteamUser021(void *linux_side)
 {
     winISteamUser_SteamUser021 *r = alloc_mem_for_iface(sizeof(winISteamUser_SteamUser021), "SteamUser021");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUser_SteamUser021_vtable;
+    r->vtable = alloc_vtable(&winISteamUser_SteamUser021_vtable, 32, "SteamUser021");
     r->linux_side = linux_side;
     return r;
 }
@@ -576,7 +576,7 @@ winISteamUser_SteamUser020 *create_winISteamUser_SteamUser020(void *linux_side)
 {
     winISteamUser_SteamUser020 *r = alloc_mem_for_iface(sizeof(winISteamUser_SteamUser020), "SteamUser020");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUser_SteamUser020_vtable;
+    r->vtable = alloc_vtable(&winISteamUser_SteamUser020_vtable, 31, "SteamUser020");
     r->linux_side = linux_side;
     return r;
 }
@@ -839,7 +839,7 @@ winISteamUser_SteamUser019 *create_winISteamUser_SteamUser019(void *linux_side)
 {
     winISteamUser_SteamUser019 *r = alloc_mem_for_iface(sizeof(winISteamUser_SteamUser019), "SteamUser019");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUser_SteamUser019_vtable;
+    r->vtable = alloc_vtable(&winISteamUser_SteamUser019_vtable, 29, "SteamUser019");
     r->linux_side = linux_side;
     return r;
 }
@@ -1070,7 +1070,7 @@ winISteamUser_SteamUser018 *create_winISteamUser_SteamUser018(void *linux_side)
 {
     winISteamUser_SteamUser018 *r = alloc_mem_for_iface(sizeof(winISteamUser_SteamUser018), "SteamUser018");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUser_SteamUser018_vtable;
+    r->vtable = alloc_vtable(&winISteamUser_SteamUser018_vtable, 25, "SteamUser018");
     r->linux_side = linux_side;
     return r;
 }
@@ -1293,7 +1293,7 @@ winISteamUser_SteamUser017 *create_winISteamUser_SteamUser017(void *linux_side)
 {
     winISteamUser_SteamUser017 *r = alloc_mem_for_iface(sizeof(winISteamUser_SteamUser017), "SteamUser017");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUser_SteamUser017_vtable;
+    r->vtable = alloc_vtable(&winISteamUser_SteamUser017_vtable, 24, "SteamUser017");
     r->linux_side = linux_side;
     return r;
 }
@@ -1500,7 +1500,7 @@ winISteamUser_SteamUser016 *create_winISteamUser_SteamUser016(void *linux_side)
 {
     winISteamUser_SteamUser016 *r = alloc_mem_for_iface(sizeof(winISteamUser_SteamUser016), "SteamUser016");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUser_SteamUser016_vtable;
+    r->vtable = alloc_vtable(&winISteamUser_SteamUser016_vtable, 22, "SteamUser016");
     r->linux_side = linux_side;
     return r;
 }
@@ -1707,7 +1707,7 @@ winISteamUser_SteamUser015 *create_winISteamUser_SteamUser015(void *linux_side)
 {
     winISteamUser_SteamUser015 *r = alloc_mem_for_iface(sizeof(winISteamUser_SteamUser015), "SteamUser015");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUser_SteamUser015_vtable;
+    r->vtable = alloc_vtable(&winISteamUser_SteamUser015_vtable, 22, "SteamUser015");
     r->linux_side = linux_side;
     return r;
 }
@@ -1906,7 +1906,7 @@ winISteamUser_SteamUser014 *create_winISteamUser_SteamUser014(void *linux_side)
 {
     winISteamUser_SteamUser014 *r = alloc_mem_for_iface(sizeof(winISteamUser_SteamUser014), "SteamUser014");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUser_SteamUser014_vtable;
+    r->vtable = alloc_vtable(&winISteamUser_SteamUser014_vtable, 21, "SteamUser014");
     r->linux_side = linux_side;
     return r;
 }
@@ -2073,7 +2073,7 @@ winISteamUser_SteamUser013 *create_winISteamUser_SteamUser013(void *linux_side)
 {
     winISteamUser_SteamUser013 *r = alloc_mem_for_iface(sizeof(winISteamUser_SteamUser013), "SteamUser013");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUser_SteamUser013_vtable;
+    r->vtable = alloc_vtable(&winISteamUser_SteamUser013_vtable, 17, "SteamUser013");
     r->linux_side = linux_side;
     return r;
 }
@@ -2232,7 +2232,7 @@ winISteamUser_SteamUser012 *create_winISteamUser_SteamUser012(void *linux_side)
 {
     winISteamUser_SteamUser012 *r = alloc_mem_for_iface(sizeof(winISteamUser_SteamUser012), "SteamUser012");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUser_SteamUser012_vtable;
+    r->vtable = alloc_vtable(&winISteamUser_SteamUser012_vtable, 16, "SteamUser012");
     r->linux_side = linux_side;
     return r;
 }
@@ -2351,7 +2351,7 @@ winISteamUser_SteamUser011 *create_winISteamUser_SteamUser011(void *linux_side)
 {
     winISteamUser_SteamUser011 *r = alloc_mem_for_iface(sizeof(winISteamUser_SteamUser011), "SteamUser011");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUser_SteamUser011_vtable;
+    r->vtable = alloc_vtable(&winISteamUser_SteamUser011_vtable, 11, "SteamUser011");
     r->linux_side = linux_side;
     return r;
 }
@@ -2427,7 +2427,7 @@ winISteamUser_SteamUser010 *create_winISteamUser_SteamUser010(void *linux_side)
 {
     winISteamUser_SteamUser010 *r = alloc_mem_for_iface(sizeof(winISteamUser_SteamUser010), "SteamUser010");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUser_SteamUser010_vtable;
+    r->vtable = alloc_vtable(&winISteamUser_SteamUser010_vtable, 6, "SteamUser010");
     r->linux_side = linux_side;
     return r;
 }
@@ -2511,7 +2511,7 @@ winISteamUser_SteamUser009 *create_winISteamUser_SteamUser009(void *linux_side)
 {
     winISteamUser_SteamUser009 *r = alloc_mem_for_iface(sizeof(winISteamUser_SteamUser009), "SteamUser009");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUser_SteamUser009_vtable;
+    r->vtable = alloc_vtable(&winISteamUser_SteamUser009_vtable, 7, "SteamUser009");
     r->linux_side = linux_side;
     return r;
 }
@@ -2595,7 +2595,7 @@ winISteamUser_SteamUser008 *create_winISteamUser_SteamUser008(void *linux_side)
 {
     winISteamUser_SteamUser008 *r = alloc_mem_for_iface(sizeof(winISteamUser_SteamUser008), "SteamUser008");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUser_SteamUser008_vtable;
+    r->vtable = alloc_vtable(&winISteamUser_SteamUser008_vtable, 7, "SteamUser008");
     r->linux_side = linux_side;
     return r;
 }
@@ -2727,7 +2727,7 @@ winISteamUser_SteamUser007 *create_winISteamUser_SteamUser007(void *linux_side)
 {
     winISteamUser_SteamUser007 *r = alloc_mem_for_iface(sizeof(winISteamUser_SteamUser007), "SteamUser007");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUser_SteamUser007_vtable;
+    r->vtable = alloc_vtable(&winISteamUser_SteamUser007_vtable, 13, "SteamUser007");
     r->linux_side = linux_side;
     return r;
 }
@@ -2851,7 +2851,7 @@ winISteamUser_SteamUser006 *create_winISteamUser_SteamUser006(void *linux_side)
 {
     winISteamUser_SteamUser006 *r = alloc_mem_for_iface(sizeof(winISteamUser_SteamUser006), "SteamUser006");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUser_SteamUser006_vtable;
+    r->vtable = alloc_vtable(&winISteamUser_SteamUser006_vtable, 12, "SteamUser006");
     r->linux_side = linux_side;
     return r;
 }
@@ -3191,7 +3191,7 @@ winISteamUser_SteamUser005 *create_winISteamUser_SteamUser005(void *linux_side)
 {
     winISteamUser_SteamUser005 *r = alloc_mem_for_iface(sizeof(winISteamUser_SteamUser005), "SteamUser005");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUser_SteamUser005_vtable;
+    r->vtable = alloc_vtable(&winISteamUser_SteamUser005_vtable, 39, "SteamUser005");
     r->linux_side = linux_side;
     return r;
 }
@@ -3427,7 +3427,7 @@ winISteamUser_SteamUser004 *create_winISteamUser_SteamUser004(void *linux_side)
 {
     winISteamUser_SteamUser004 *r = alloc_mem_for_iface(sizeof(winISteamUser_SteamUser004), "SteamUser004");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUser_SteamUser004_vtable;
+    r->vtable = alloc_vtable(&winISteamUser_SteamUser004_vtable, 26, "SteamUser004");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamUserStats.c
+++ b/lsteamclient/winISteamUserStats.c
@@ -397,7 +397,7 @@ winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION012 *create_winISteamUserStat
 {
     winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION012 *r = alloc_mem_for_iface(sizeof(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION012), "STEAMUSERSTATS_INTERFACE_VERSION012");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION012_vtable;
+    r->vtable = alloc_vtable(&winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION012_vtable, 45, "STEAMUSERSTATS_INTERFACE_VERSION012");
     r->linux_side = linux_side;
     return r;
 }
@@ -768,7 +768,7 @@ winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION011 *create_winISteamUserStat
 {
     winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION011 *r = alloc_mem_for_iface(sizeof(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION011), "STEAMUSERSTATS_INTERFACE_VERSION011");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION011_vtable;
+    r->vtable = alloc_vtable(&winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION011_vtable, 43, "STEAMUSERSTATS_INTERFACE_VERSION011");
     r->linux_side = linux_side;
     return r;
 }
@@ -1123,7 +1123,7 @@ winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION010 *create_winISteamUserStat
 {
     winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION010 *r = alloc_mem_for_iface(sizeof(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION010), "STEAMUSERSTATS_INTERFACE_VERSION010");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION010_vtable;
+    r->vtable = alloc_vtable(&winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION010_vtable, 41, "STEAMUSERSTATS_INTERFACE_VERSION010");
     r->linux_side = linux_side;
     return r;
 }
@@ -1406,7 +1406,7 @@ winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION009 *create_winISteamUserStat
 {
     winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION009 *r = alloc_mem_for_iface(sizeof(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION009), "STEAMUSERSTATS_INTERFACE_VERSION009");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION009_vtable;
+    r->vtable = alloc_vtable(&winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION009_vtable, 32, "STEAMUSERSTATS_INTERFACE_VERSION009");
     r->linux_side = linux_side;
     return r;
 }
@@ -1681,7 +1681,7 @@ winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION008 *create_winISteamUserStat
 {
     winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION008 *r = alloc_mem_for_iface(sizeof(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION008), "STEAMUSERSTATS_INTERFACE_VERSION008");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION008_vtable;
+    r->vtable = alloc_vtable(&winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION008_vtable, 31, "STEAMUSERSTATS_INTERFACE_VERSION008");
     r->linux_side = linux_side;
     return r;
 }
@@ -1948,7 +1948,7 @@ winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION007 *create_winISteamUserStat
 {
     winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION007 *r = alloc_mem_for_iface(sizeof(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION007), "STEAMUSERSTATS_INTERFACE_VERSION007");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION007_vtable;
+    r->vtable = alloc_vtable(&winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION007_vtable, 30, "STEAMUSERSTATS_INTERFACE_VERSION007");
     r->linux_side = linux_side;
     return r;
 }
@@ -2199,7 +2199,7 @@ winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION006 *create_winISteamUserStat
 {
     winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION006 *r = alloc_mem_for_iface(sizeof(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION006), "STEAMUSERSTATS_INTERFACE_VERSION006");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION006_vtable;
+    r->vtable = alloc_vtable(&winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION006_vtable, 28, "STEAMUSERSTATS_INTERFACE_VERSION006");
     r->linux_side = linux_side;
     return r;
 }
@@ -2442,7 +2442,7 @@ winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION005 *create_winISteamUserStat
 {
     winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION005 *r = alloc_mem_for_iface(sizeof(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION005), "STEAMUSERSTATS_INTERFACE_VERSION005");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION005_vtable;
+    r->vtable = alloc_vtable(&winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION005_vtable, 27, "STEAMUSERSTATS_INTERFACE_VERSION005");
     r->linux_side = linux_side;
     return r;
 }
@@ -2605,7 +2605,7 @@ winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION004 *create_winISteamUserStat
 {
     winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION004 *r = alloc_mem_for_iface(sizeof(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION004), "STEAMUSERSTATS_INTERFACE_VERSION004");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION004_vtable;
+    r->vtable = alloc_vtable(&winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION004_vtable, 17, "STEAMUSERSTATS_INTERFACE_VERSION004");
     r->linux_side = linux_side;
     return r;
 }
@@ -2736,7 +2736,7 @@ winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION003 *create_winISteamUserStat
 {
     winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION003 *r = alloc_mem_for_iface(sizeof(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION003), "STEAMUSERSTATS_INTERFACE_VERSION003");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION003_vtable;
+    r->vtable = alloc_vtable(&winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION003_vtable, 13, "STEAMUSERSTATS_INTERFACE_VERSION003");
     r->linux_side = linux_side;
     return r;
 }
@@ -2907,7 +2907,7 @@ winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *create_winISteamUserStat
 {
     winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *r = alloc_mem_for_iface(sizeof(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002), "STEAMUSERSTATS_INTERFACE_VERSION002");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_vtable;
+    r->vtable = alloc_vtable(&winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_vtable, 18, "STEAMUSERSTATS_INTERFACE_VERSION002");
     r->linux_side = linux_side;
     return r;
 }
@@ -3110,7 +3110,7 @@ winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *create_winISteamUserStat
 {
     winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *r = alloc_mem_for_iface(sizeof(winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001), "STEAMUSERSTATS_INTERFACE_VERSION001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_vtable;
+    r->vtable = alloc_vtable(&winISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_vtable, 22, "STEAMUSERSTATS_INTERFACE_VERSION001");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamUtils.c
+++ b/lsteamclient/winISteamUtils.c
@@ -343,7 +343,7 @@ winISteamUtils_SteamUtils010 *create_winISteamUtils_SteamUtils010(void *linux_si
 {
     winISteamUtils_SteamUtils010 *r = alloc_mem_for_iface(sizeof(winISteamUtils_SteamUtils010), "SteamUtils010");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUtils_SteamUtils010_vtable;
+    r->vtable = alloc_vtable(&winISteamUtils_SteamUtils010_vtable, 38, "SteamUtils010");
     r->linux_side = linux_side;
     return r;
 }
@@ -644,7 +644,7 @@ winISteamUtils_SteamUtils009 *create_winISteamUtils_SteamUtils009(void *linux_si
 {
     winISteamUtils_SteamUtils009 *r = alloc_mem_for_iface(sizeof(winISteamUtils_SteamUtils009), "SteamUtils009");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUtils_SteamUtils009_vtable;
+    r->vtable = alloc_vtable(&winISteamUtils_SteamUtils009_vtable, 34, "SteamUtils009");
     r->linux_side = linux_side;
     return r;
 }
@@ -897,7 +897,7 @@ winISteamUtils_SteamUtils008 *create_winISteamUtils_SteamUtils008(void *linux_si
 {
     winISteamUtils_SteamUtils008 *r = alloc_mem_for_iface(sizeof(winISteamUtils_SteamUtils008), "SteamUtils008");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUtils_SteamUtils008_vtable;
+    r->vtable = alloc_vtable(&winISteamUtils_SteamUtils008_vtable, 28, "SteamUtils008");
     r->linux_side = linux_side;
     return r;
 }
@@ -1134,7 +1134,7 @@ winISteamUtils_SteamUtils007 *create_winISteamUtils_SteamUtils007(void *linux_si
 {
     winISteamUtils_SteamUtils007 *r = alloc_mem_for_iface(sizeof(winISteamUtils_SteamUtils007), "SteamUtils007");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUtils_SteamUtils007_vtable;
+    r->vtable = alloc_vtable(&winISteamUtils_SteamUtils007_vtable, 26, "SteamUtils007");
     r->linux_side = linux_side;
     return r;
 }
@@ -1363,7 +1363,7 @@ winISteamUtils_SteamUtils006 *create_winISteamUtils_SteamUtils006(void *linux_si
 {
     winISteamUtils_SteamUtils006 *r = alloc_mem_for_iface(sizeof(winISteamUtils_SteamUtils006), "SteamUtils006");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUtils_SteamUtils006_vtable;
+    r->vtable = alloc_vtable(&winISteamUtils_SteamUtils006_vtable, 25, "SteamUtils006");
     r->linux_side = linux_side;
     return r;
 }
@@ -1576,7 +1576,7 @@ winISteamUtils_SteamUtils005 *create_winISteamUtils_SteamUtils005(void *linux_si
 {
     winISteamUtils_SteamUtils005 *r = alloc_mem_for_iface(sizeof(winISteamUtils_SteamUtils005), "SteamUtils005");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUtils_SteamUtils005_vtable;
+    r->vtable = alloc_vtable(&winISteamUtils_SteamUtils005_vtable, 23, "SteamUtils005");
     r->linux_side = linux_side;
     return r;
 }
@@ -1747,7 +1747,7 @@ winISteamUtils_SteamUtils004 *create_winISteamUtils_SteamUtils004(void *linux_si
 {
     winISteamUtils_SteamUtils004 *r = alloc_mem_for_iface(sizeof(winISteamUtils_SteamUtils004), "SteamUtils004");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUtils_SteamUtils004_vtable;
+    r->vtable = alloc_vtable(&winISteamUtils_SteamUtils004_vtable, 18, "SteamUtils004");
     r->linux_side = linux_side;
     return r;
 }
@@ -1886,7 +1886,7 @@ winISteamUtils_SteamUtils002 *create_winISteamUtils_SteamUtils002(void *linux_si
 {
     winISteamUtils_SteamUtils002 *r = alloc_mem_for_iface(sizeof(winISteamUtils_SteamUtils002), "SteamUtils002");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamUtils_SteamUtils002_vtable;
+    r->vtable = alloc_vtable(&winISteamUtils_SteamUtils002_vtable, 14, "SteamUtils002");
     r->linux_side = linux_side;
     return r;
 }

--- a/lsteamclient/winISteamVideo.c
+++ b/lsteamclient/winISteamVideo.c
@@ -69,7 +69,7 @@ winISteamVideo_STEAMVIDEO_INTERFACE_V002 *create_winISteamVideo_STEAMVIDEO_INTER
 {
     winISteamVideo_STEAMVIDEO_INTERFACE_V002 *r = alloc_mem_for_iface(sizeof(winISteamVideo_STEAMVIDEO_INTERFACE_V002), "STEAMVIDEO_INTERFACE_V002");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamVideo_STEAMVIDEO_INTERFACE_V002_vtable;
+    r->vtable = alloc_vtable(&winISteamVideo_STEAMVIDEO_INTERFACE_V002_vtable, 4, "STEAMVIDEO_INTERFACE_V002");
     r->linux_side = linux_side;
     return r;
 }
@@ -112,7 +112,7 @@ winISteamVideo_STEAMVIDEO_INTERFACE_V001 *create_winISteamVideo_STEAMVIDEO_INTER
 {
     winISteamVideo_STEAMVIDEO_INTERFACE_V001 *r = alloc_mem_for_iface(sizeof(winISteamVideo_STEAMVIDEO_INTERFACE_V001), "STEAMVIDEO_INTERFACE_V001");
     TRACE("-> %p\n", r);
-    r->vtable = &winISteamVideo_STEAMVIDEO_INTERFACE_V001_vtable;
+    r->vtable = alloc_vtable(&winISteamVideo_STEAMVIDEO_INTERFACE_V001_vtable, 2, "STEAMVIDEO_INTERFACE_V001");
     r->linux_side = linux_side;
     return r;
 }

--- a/media-converter/Cargo.lock
+++ b/media-converter/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
 [[package]]
 name = "gst-plugin-version-helper"
 version = "0.7.2"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs?tag=0.7.2#d0466b3eee114207f851b37cae0015c0e718f021"
+source = "git+https://github.com/sdroege/gst-plugin-rs?tag=0.7.2#d0466b3eee114207f851b37cae0015c0e718f021"
 dependencies = [
  "chrono",
 ]
@@ -180,7 +180,7 @@ dependencies = [
 [[package]]
 name = "gstreamer"
 version = "0.17.4"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?tag=0.17.4#6c9815f0594045ef668bf3fefbaf5e0846516d4b"
+source = "git+https://github.com/sdroege/gstreamer-rs?tag=0.17.4#6c9815f0594045ef668bf3fefbaf5e0846516d4b"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -202,7 +202,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-audio"
 version = "0.17.4"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?tag=0.17.4#6c9815f0594045ef668bf3fefbaf5e0846516d4b"
+source = "git+https://github.com/sdroege/gstreamer-rs?tag=0.17.4#6c9815f0594045ef668bf3fefbaf5e0846516d4b"
 dependencies = [
  "array-init",
  "bitflags",
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-audio-sys"
 version = "0.17.4"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?tag=0.17.4#6c9815f0594045ef668bf3fefbaf5e0846516d4b"
+source = "git+https://github.com/sdroege/gstreamer-rs?tag=0.17.4#6c9815f0594045ef668bf3fefbaf5e0846516d4b"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -231,7 +231,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-base"
 version = "0.17.4"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?tag=0.17.4#6c9815f0594045ef668bf3fefbaf5e0846516d4b"
+source = "git+https://github.com/sdroege/gstreamer-rs?tag=0.17.4#6c9815f0594045ef668bf3fefbaf5e0846516d4b"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -244,7 +244,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-base-sys"
 version = "0.17.4"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?tag=0.17.4#6c9815f0594045ef668bf3fefbaf5e0846516d4b"
+source = "git+https://github.com/sdroege/gstreamer-rs?tag=0.17.4#6c9815f0594045ef668bf3fefbaf5e0846516d4b"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -256,7 +256,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-sys"
 version = "0.17.4"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?tag=0.17.4#6c9815f0594045ef668bf3fefbaf5e0846516d4b"
+source = "git+https://github.com/sdroege/gstreamer-rs?tag=0.17.4#6c9815f0594045ef668bf3fefbaf5e0846516d4b"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -267,7 +267,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-video"
 version = "0.17.4"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?tag=0.17.4#6c9815f0594045ef668bf3fefbaf5e0846516d4b"
+source = "git+https://github.com/sdroege/gstreamer-rs?tag=0.17.4#6c9815f0594045ef668bf3fefbaf5e0846516d4b"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-video-sys"
 version = "0.17.4"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?tag=0.17.4#6c9815f0594045ef668bf3fefbaf5e0846516d4b"
+source = "git+https://github.com/sdroege/gstreamer-rs?tag=0.17.4#6c9815f0594045ef668bf3fefbaf5e0846516d4b"
 dependencies = [
  "glib-sys",
  "gobject-sys",

--- a/media-converter/Cargo.toml
+++ b/media-converter/Cargo.toml
@@ -9,10 +9,10 @@ description = "Proton media converter"
 
 [dependencies]
 glib = "0.14"
-gstreamer = { git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", tag = "0.17.4" }
-gstreamer-base = { git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", tag = "0.17.4" }
-gstreamer-video = { git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", tag = "0.17.4" }
-gstreamer-audio = { git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", tag = "0.17.4" }
+gstreamer = { git = "https://github.com/sdroege/gstreamer-rs", tag = "0.17.4" }
+gstreamer-base = { git = "https://github.com/sdroege/gstreamer-rs", tag = "0.17.4" }
+gstreamer-video = { git = "https://github.com/sdroege/gstreamer-rs", tag = "0.17.4" }
+gstreamer-audio = { git = "https://github.com/sdroege/gstreamer-rs", tag = "0.17.4" }
 once_cell = "1.9"
 crc32fast = "1.3"
 array-init = "2.0"
@@ -23,7 +23,7 @@ crate-type = ["cdylib"]
 path = "src/lib.rs"
 
 [build-dependencies]
-gst-plugin-version-helper = { git = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs", tag = "0.7.2" }
+gst-plugin-version-helper = { git = "https://github.com/sdroege/gst-plugin-rs", tag = "0.7.2" }
 
 [profile.release]
 lto = true
@@ -35,7 +35,7 @@ panic = 'unwind'
 opt-level = 1
 
 #if you need local modifications to gstreamer-rs you can point to it here
-#[patch.'https://gitlab.freedesktop.org/gstreamer/gstreamer-rs']
+#[patch.'https://github.com/sdroege/gstreamer-rs']
 #gstreamer = { path = "../gstreamer-rs/gstreamer" }
 #gstreamer-base = { path = "../gstreamer-rs/gstreamer-base" }
 #gstreamer-video = { path = "../gstreamer-rs/gstreamer-video" }

--- a/proton
+++ b/proton
@@ -429,6 +429,28 @@ class Proton:
                 if file_exists(old_dist_dir, follow_symlinks=True):
                     shutil.rmtree(old_dist_dir)
 
+    def do_steampipe_fixups(self):
+        fixups_json = self.path("steampipe_fixups.json")
+        fixups_mtime = self.path("files/steampipe_fixups_mtime")
+
+        if file_exists(fixups_json, follow_symlinks=True):
+            with self.dist_lock:
+                import steampipe_fixups
+
+                current_fixup_mtime = None
+                if file_exists(fixups_mtime, follow_symlinks=True):
+                    with open(fixups_mtime, "r") as f:
+                        current_fixup_mtime = f.readline().strip()
+
+                new_fixup_mtime = getmtimestr(fixups_json)
+
+                if current_fixup_mtime != new_fixup_mtime:
+                    result_code = steampipe_fixups.do_restore(self.base_dir, fixups_json)
+
+                    if result_code == 0:
+                        with open(fixups_mtime, "w") as f:
+                            f.write(new_fixup_mtime + "\n")
+
     def missing_default_prefix(self):
         '''Check if the default prefix dir is missing. Returns true if missing, false if present'''
         return not os.path.isdir(self.default_pfx_dir)
@@ -764,10 +786,10 @@ class CompatData:
 
             self.migrate_user_paths()
 
-            if not os.path.lexists(self.prefix_dir + "/dosdevices/c:"):
+            if not file_exists(self.prefix_dir + "/dosdevices/c:", follow_symlinks=False):
                 os.symlink("../drive_c", self.prefix_dir + "/dosdevices/c:")
 
-            if not os.path.lexists(self.prefix_dir + "/dosdevices/z:"):
+            if not file_exists(self.prefix_dir + "/dosdevices/z:", follow_symlinks=False):
                 os.symlink("/", self.prefix_dir + "/dosdevices/z:")
 
             # collect configuration info
@@ -1450,6 +1472,7 @@ if __name__ == "__main__":
     g_proton = Proton(os.path.dirname(sys.argv[0]))
 
     g_proton.cleanup_legacy_dist()
+    g_proton.do_steampipe_fixups()
 
     g_compatdata = CompatData(os.environ["STEAM_COMPAT_DATA_PATH"])
 

--- a/proton
+++ b/proton
@@ -764,6 +764,12 @@ class CompatData:
 
             self.migrate_user_paths()
 
+            if not os.path.lexists(self.prefix_dir + "/dosdevices/c:"):
+                os.symlink("../drive_c", self.prefix_dir + "/dosdevices/c:")
+
+            if not os.path.lexists(self.prefix_dir + "/dosdevices/z:"):
+                os.symlink("/", self.prefix_dir + "/dosdevices/z:")
+
             # collect configuration info
             steamdir = os.environ["STEAM_COMPAT_CLIENT_INSTALL_PATH"]
 

--- a/proton
+++ b/proton
@@ -991,40 +991,14 @@ def default_compat_config():
         appid = os.environ["SteamAppId"]
         if appid in [
                 #affected by CW bug 19126
-                "252490", #Rust
-                "305620", #The Long Dark
                 "536280", #Disintegration
-                "585420", #Trailmakers
-                "684450", #Surviving the Aftermath
-                "700580", #Rust Staging
                 "707030", #POSTAL 4: No Regerts
-                "780290", #Gloomhaven
                 "794260", #Outward: Definitive Edition
-                "844260", #Rustler
-                "853050", #El Hijo - A Wild West Tale
-                "960170", #DJMAX RESPECT V
-                "983970", #Haven
-                "1075200", #TOHU
-                "1096530", #Solasta: Crown of the Magister
                 "1102190", #Monster Train
-                "1107790", #The Complex
-                "1110100", #Power Rangers: Battle for the Grid
-                "1135230", #Ember Knights
-                "1161580", #Hardspace: Shipbreaker
-                "1190000", #Car Mechanic Simulator 2021
-                "1311070", #Greak: Memories of Azur
                 "1328350", #Turbo Overkill
                 "1331440", #FUSER
-                "1341290", #We Were Here Forever
                 "1359980", #POSTAL: Brain Damaged
-                "1361320", #The Room 4: Old Sins
-                "1477590", #EZ2ON REBOOT : R
-                "1523720", #Cook-Out
-                "1569550", #Dread X Collection: The Hunt
-                "1604030", #V Rising
-                "1642370", #Terra Nil Demo
                 "1766430", #POSTAL Brain Damaged Demo
-                "1913910", #Nine Sols Demo
                 "2001540", #Slayers X Demo
 
                 #affected by CW bug 19741

--- a/proton
+++ b/proton
@@ -939,6 +939,7 @@ def default_compat_config():
                 "1135230", #Ember Knights
                 "1161580", #Hardspace: Shipbreaker
                 "1190000", #Car Mechanic Simulator 2021
+                "1311070", #Greak: Memories of Azur
                 "1328350", #Turbo Overkill
                 "1331440", #FUSER
                 "1341290", #We Were Here Forever

--- a/proton
+++ b/proton
@@ -941,11 +941,13 @@ def default_compat_config():
                 "1190000", #Car Mechanic Simulator 2021
                 "1331440", #FUSER
                 "1341290", #We Were Here Forever
+                "1359980", #POSTAL: Brain Damaged
                 "1361320", #The Room 4: Old Sins
                 "1477590", #EZ2ON REBOOT : R
                 "1523720", #Cook-Out
                 "1569550", #Dread X Collection: The Hunt
                 "1604030", #V Rising
+                "1766430", #POSTAL Brain Damaged Demo
                 "1913910", #Nine Sols Demo
 
                 #affected by CW bug 19741

--- a/proton
+++ b/proton
@@ -948,6 +948,7 @@ def default_compat_config():
                 "1523720", #Cook-Out
                 "1569550", #Dread X Collection: The Hunt
                 "1604030", #V Rising
+                "1642370", #Terra Nil Demo
                 "1766430", #POSTAL Brain Damaged Demo
                 "1913910", #Nine Sols Demo
                 "2001540", #Slayers X Demo

--- a/proton
+++ b/proton
@@ -1040,6 +1040,7 @@ class Session:
         self.dlloverrides = {
                 "steam.exe": "b", #always use our special built-in steam.exe
                 "dotnetfx35.exe": "b", #replace the broken installer, as does Windows
+                "dotnetfx35setup.exe": "b",
                 "beclient.dll": "b,n",
                 "beclient_x64.dll": "b,n",
         }

--- a/proton
+++ b/proton
@@ -1005,6 +1005,46 @@ def default_compat_config():
                 "1017900", #Age of Empires: Definitive Edition
                 ]:
             ret.add("nomfdxgiman")
+
+        if appid in [
+                # OPWR may be causing text input delays in login windows in these games on Wayland due to
+                # blit happening before presentation
+                "1172620", #Sea of Thieves
+                "962130", #Grounded
+                "495420", #State of Decay 2: Juggernaut Edition
+                "976730", #Halo: The Master Chief Collection
+                "1017900", #Age of Empires: Definitive Edition
+                "1056090", #Ori and the Will of the Wisps
+                "1293830", #Forza Horizon 4
+                "1551360", #Forza Horizon 5
+                "271590", #Grand Theft Auto V
+                "5699", #Grand Theft Auto V Premium Edition
+                "1174180", #Red Dead Redemption 2
+                "1404210", #Red Dead Online
+                "12210", #Grand Theft Auto IV: Complete Edition
+                "204100", #Max Payne 3
+                "110800", #L.A. Noire
+                "12200", #Bully: Scholarship Edition
+                "12120", #Grand Theft Auto: San Andreas
+                "12110", #Grand Theft Auto: Vice City
+                "12100", #Grand Theft Auto III
+                "722230", #L.A. Noire: The VR Case Files
+                "813780", #Age of Empires II: Definitive Edition
+                "933110", #Age of Empires III: Definitive Edition
+                "1466860", #Age of Empires IV
+                "1097840", #Gears 5
+                "1244950", #Battletoads
+                "1189800", #Bleeding Edge
+                "1184050", #Gears Tactics
+                "1240440", #Halo Infinite
+                "1250410", #Microsoft Flight Simulator
+                "1672970", #Minecraft Dungeons
+                "1180660", #Tell Me Why
+                "1238430", #Tell Me Why Chapter 2
+                "1266670", #Tell Me Why Chapter 3
+                ]:
+            ret.add("noopwr")
+
     return ret
 
 class Session:
@@ -1218,6 +1258,9 @@ class Session:
 
         if "nomfdxgiman" in self.compat_config:
             self.env["WINE_DO_NOT_CREATE_DXGI_DEVICE_MANAGER"] = "1"
+
+        if "noopwr" in self.compat_config:
+            self.env["WINE_DISABLE_VULKAN_OPWR"] = "1"
 
         if "PROTON_CRASH_REPORT_DIR" in self.env:
             self.env["WINE_CRASH_REPORT_DIR"] = self.env["PROTON_CRASH_REPORT_DIR"]

--- a/proton
+++ b/proton
@@ -939,6 +939,7 @@ def default_compat_config():
                 "1135230", #Ember Knights
                 "1161580", #Hardspace: Shipbreaker
                 "1190000", #Car Mechanic Simulator 2021
+                "1328350", #Turbo Overkill
                 "1331440", #FUSER
                 "1341290", #We Were Here Forever
                 "1359980", #POSTAL: Brain Damaged

--- a/proton
+++ b/proton
@@ -1042,6 +1042,9 @@ def default_compat_config():
                 "1180660", #Tell Me Why
                 "1238430", #Tell Me Why Chapter 2
                 "1266670", #Tell Me Why Chapter 3
+                # Other issues arising from OWPR code path in apps, e. g., hitting unimplemented bits in
+                # d3dcompiler.
+                "230410", #Warframe
                 ]:
             ret.add("noopwr")
 

--- a/proton
+++ b/proton
@@ -912,9 +912,11 @@ class CompatData:
 
                 if use_wined3d:
                     dxvkfiles = []
-                    wined3dfiles = ["d3d11", "d3d10", "d3d10core", "d3d10_1", "d3d9"]
+                    vkd3d_protonfiles = []
+                    wined3dfiles = ["d3d12", "d3d11", "d3d10", "d3d10core", "d3d10_1", "d3d9"]
                 else:
                     dxvkfiles = ["d3d11", "d3d10core", "d3d9"]
+                    vkd3d_protonfiles = ["d3d12"]
                     wined3dfiles = []
 
                 if use_dxvk_dxgi:
@@ -932,6 +934,13 @@ class CompatData:
                     try_copy(g_proton.lib64_dir + "wine/dxvk/" + f + ".dll", "drive_c/windows/system32",
                             prefix=self.prefix_dir, track_file=tracked_files, link_debug=True)
                     try_copy(g_proton.lib_dir + "wine/dxvk/" + f + ".dll", "drive_c/windows/syswow64",
+                            prefix=self.prefix_dir, track_file=tracked_files, link_debug=True)
+                    g_session.dlloverrides[f] = "n"
+
+                for f in vkd3d_protonfiles:
+                    try_copy(g_proton.lib64_dir + "wine/vkd3d-proton/" + f + ".dll", "drive_c/windows/system32",
+                            prefix=self.prefix_dir, track_file=tracked_files, link_debug=True)
+                    try_copy(g_proton.lib_dir + "wine/vkd3d-proton/" + f + ".dll", "drive_c/windows/syswow64",
                             prefix=self.prefix_dir, track_file=tracked_files, link_debug=True)
                     g_session.dlloverrides[f] = "n"
 
@@ -964,11 +973,6 @@ class CompatData:
                     for dll in ["_nvngx.dll", "nvngx.dll"]:
                         try_copy(nvidia_wine_dll_dir + "/" + dll, "drive_c/windows/system32", optional=True,
                                  prefix=self.prefix_dir, track_file=tracked_files, link_debug=True)
-
-                try_copy(g_proton.lib64_dir + "wine/vkd3d-proton/d3d12.dll", "drive_c/windows/system32",
-                        prefix=self.prefix_dir, track_file=tracked_files, link_debug=True)
-                try_copy(g_proton.lib_dir + "wine/vkd3d-proton/d3d12.dll", "drive_c/windows/syswow64",
-                        prefix=self.prefix_dir, track_file=tracked_files, link_debug=True)
 
             setup_game_dir_drive()
             setup_steam_dir_drive()

--- a/proton
+++ b/proton
@@ -1459,6 +1459,11 @@ class Session:
         return subprocess.call(args, env=local_env, stderr=self.log_file, stdout=self.log_file)
 
     def run(self):
+        if shutil.which('steam-runtime-launcher-interface-0') is not None:
+            adverb = ['steam-runtime-launcher-interface-0', 'proton']
+        else:
+            adverb = []
+
         if "PROTON_DUMP_DEBUG_COMMANDS" in self.env and nonzero(self.env["PROTON_DUMP_DEBUG_COMMANDS"]):
             try:
                 self.dump_dbg_scripts()
@@ -1476,9 +1481,11 @@ class Session:
 
         # CoD: Black Ops 3 workaround
         if os.environ.get("SteamGameId", 0) == "311210":
-            rc = self.run_proc([g_proton.wine_bin, "c:\\Program Files (x86)\\Steam\\steam.exe"] + sys.argv[2:] + self.cmdlineappend)
+            argv = [g_proton.wine_bin, "c:\\Program Files (x86)\\Steam\\steam.exe"]
         else:
-            rc = self.run_proc([g_proton.wine64_bin, "c:\\windows\\system32\\steam.exe"] + sys.argv[2:] + self.cmdlineappend)
+            argv = [g_proton.wine64_bin, "c:\\windows\\system32\\steam.exe"]
+
+        rc = self.run_proc(adverb + argv + sys.argv[2:] + self.cmdlineappend)
 
         if remote_debug_proc:
             remote_debug_proc.kill()

--- a/proton
+++ b/proton
@@ -404,15 +404,15 @@ def set_dir_casefold_bit(dir_path):
 class Proton:
     def __init__(self, base_dir):
         self.base_dir = base_dir + "/"
-        self.dist_dir = self.path("dist/")
-        self.bin_dir = self.path("dist/bin/")
-        self.lib_dir = self.path("dist/lib/")
-        self.lib64_dir = self.path("dist/lib64/")
-        self.fonts_dir = self.path("dist/share/fonts/")
-        self.wine_fonts_dir = self.path("dist/share/wine/fonts/")
-        self.wine_inf = self.path("dist/share/wine/wine.inf")
+        self.dist_dir = self.path("files/")
+        self.bin_dir = self.path("files/bin/")
+        self.lib_dir = self.path("files/lib/")
+        self.lib64_dir = self.path("files/lib64/")
+        self.fonts_dir = self.path("files/share/fonts/")
+        self.wine_fonts_dir = self.path("files/share/wine/fonts/")
+        self.wine_inf = self.path("files/share/wine/wine.inf")
         self.version_file = self.path("version")
-        self.default_pfx_dir = self.path("dist/share/default_pfx/")
+        self.default_pfx_dir = self.path("files/share/default_pfx/")
         self.user_settings_file = self.path("user_settings.py")
         self.wine_bin = self.bin_dir + "wine"
         self.wine64_bin = self.bin_dir + "wine64"
@@ -422,28 +422,12 @@ class Proton:
     def path(self, d):
         return self.base_dir + d
 
-    def need_tarball_extraction(self):
-        '''Checks if the proton_dist tarball archive must be extracted. Returns true if extraction is needed, false otherwise'''
-        return not file_exists(self.dist_dir, follow_symlinks=True) or \
-            not file_exists(self.path("dist/version"), follow_symlinks=True) or \
-            not filecmp.cmp(self.version_file, self.path("dist/version"))
-
-    def extract_tarball(self):
-        with self.dist_lock:
-            if self.need_tarball_extraction():
-                if file_exists(self.dist_dir, follow_symlinks=True):
-                    shutil.rmtree(self.dist_dir)
-                tar = None
-                for sf in ["", ".xz", ".bz2", ".gz"]:
-                    if file_exists(self.path("proton_dist.tar" + sf), follow_symlinks=True):
-                        tar = tarfile.open(self.path("proton_dist.tar" + sf), mode="r:*")
-                        break
-                if not tar:
-                    log("No proton_dist tarball??")
-                    sys.exit(1)
-                tar.extractall(path=self.dist_dir)
-                tar.close()
-                try_copy(self.version_file, self.dist_dir)
+    def cleanup_legacy_dist(self):
+        old_dist_dir = self.path("dist/")
+        if file_exists(old_dist_dir, follow_symlinks=True):
+            with self.dist_lock:
+                if file_exists(old_dist_dir, follow_symlinks=True):
+                    shutil.rmtree(old_dist_dir)
 
     def missing_default_prefix(self):
         '''Check if the default prefix dir is missing. Returns true if missing, false if present'''
@@ -1459,8 +1443,7 @@ if __name__ == "__main__":
 
     g_proton = Proton(os.path.dirname(sys.argv[0]))
 
-    if g_proton.need_tarball_extraction():
-        g_proton.extract_tarball()
+    g_proton.cleanup_legacy_dist()
 
     g_compatdata = CompatData(os.environ["STEAM_COMPAT_DATA_PATH"])
 

--- a/proton
+++ b/proton
@@ -10,6 +10,7 @@ import json
 import os
 import shutil
 import errno
+import platform
 import stat
 import subprocess
 import sys
@@ -17,13 +18,21 @@ import tarfile
 import shlex
 
 from ctypes import CDLL
+from ctypes import CFUNCTYPE
 from ctypes import POINTER
 from ctypes import Structure
 from ctypes import addressof
 from ctypes import cast
+from ctypes import get_errno
+from ctypes import sizeof
 from ctypes import c_int
+from ctypes import c_int64
+from ctypes import c_uint
+from ctypes import c_long
 from ctypes import c_char_p
 from ctypes import c_void_p
+from ctypes import c_size_t
+from ctypes import c_ssize_t
 
 from filelock import FileLock
 from random import randrange
@@ -142,10 +151,15 @@ def try_copy(src, dst, prefix=None, add_write_perm=True, copy_metadata=False, op
         elif track_file and prefix is not None:
             track_file.write(os.path.relpath(dst, prefix) + '\n')
 
-        if copy_metadata:
-            shutil.copy2(src, dst, follow_symlinks=follow_symlinks)
+        if os.path.islink(src) and not follow_symlinks:
+            shutil.copyfile(src, dst, follow_symlinks=False)
         else:
-            shutil.copy(src, dst, follow_symlinks=follow_symlinks)
+            copyfile(src, dst)
+
+        if copy_metadata:
+            shutil.copystat(src, dst, follow_symlinks=follow_symlinks)
+        else:
+            shutil.copymode(src, dst, follow_symlinks=follow_symlinks)
 
         if add_write_perm:
             new_mode = os.lstat(dst).st_mode | stat.S_IWUSR | stat.S_IWGRP
@@ -175,15 +189,62 @@ def try_copy(src, dst, prefix=None, add_write_perm=True, copy_metadata=False, op
         else:
             raise
 
+# copy_file_range implementation for old Python versions
+__syscall__copy_file_range = None
+
+def copy_file_range_ctypes(fd_in, fd_out, count):
+    "Copy data using the copy_file_range syscall through ctypes, assuming x86_64 Linux"
+    global __syscall__copy_file_range
+    __NR_copy_file_range = 326
+
+    if __syscall__copy_file_range is None:
+        c_int64_p = POINTER(c_int64)
+        prototype = CFUNCTYPE(c_ssize_t, c_long, c_int, c_int64_p,
+            c_int, c_int64_p, c_size_t, c_uint, use_errno=True)
+        __syscall__copy_file_range = prototype(('syscall', CDLL(None, use_errno=True)))
+
+    while True:
+        ret = __syscall__copy_file_range(__NR_copy_file_range, fd_in, None, fd_out, None, count, 0)
+        if ret >= 0 or get_errno() != errno.EINTR:
+            break
+
+    if ret < 0:
+        raise OSError(get_errno(), errno.errorcode.get(get_errno(), 'unknown'))
+
+    return ret
+
+def copyfile_reflink(srcname, dstname):
+    "Copy srcname to dstname, making reflink if possible"
+    global copyfile
+    with open(srcname, 'rb', buffering=0) as src:
+        bytes_to_copy = os.fstat(src.fileno()).st_size
+        try:
+            with open(dstname, 'wb', buffering=0) as dst:
+                while bytes_to_copy > 0:
+                    bytes_to_copy -= copy_file_range(src.fileno(), dst.fileno(), bytes_to_copy)
+        except OSError as e:
+            if e.errno not in (errno.EXDEV, errno.ENOSYS, errno.EINVAL):
+                raise e
+            if e.errno == errno.ENOSYS:
+                copyfile = shutil.copyfile
+            shutil.copyfile(srcname, dstname)
+
+if hasattr(os, 'copy_file_range'):
+    copyfile = copyfile_reflink
+    copy_file_range = os.copy_file_range
+elif sys.platform == 'linux' and platform.machine() == 'x86_64' and sizeof(c_void_p) == 8:
+    copyfile = copyfile_reflink
+    copy_file_range = copy_file_range_ctypes
+else:
+    copyfile = shutil.copyfile
+
 def try_copyfile(src, dst):
     try:
         if os.path.isdir(dst):
-            dstfile = dst + "/" + os.path.basename(src)
-            if file_exists(dstfile, follow_symlinks=False):
-                os.remove(dstfile)
-        elif file_exists(dst, follow_symlinks=False):
+            dst = dst + "/" + os.path.basename(src)
+        if file_exists(dst, follow_symlinks=False):
             os.remove(dst)
-        shutil.copyfile(src, dst)
+        copyfile(src, dst)
     except PermissionError as e:
         if e.errno == errno.EPERM:
             #be forgiving about permissions errors; if it's a real problem, things will explode later anyway

--- a/proton
+++ b/proton
@@ -974,7 +974,9 @@ class CompatData:
             setup_steam_dir_drive()
 
             # add Steam ffmpeg libraries to path
-            prepend_to_env_str(g_session.env, ld_path_var, steamdir + "/ubuntu12_64/video/:" + steamdir + "/ubuntu12_32/video/", ":")
+            use_ffmpeg = "PROTON_NO_STEAM_FFMPEG" not in os.environ or not nonzero(os.environ["PROTON_NO_STEAM_FFMPEG"])
+            if use_ffmpeg and 'nosteamffmpeg' not in g_session.compat_config:
+                prepend_to_env_str(g_session.env, ld_path_var, steamdir + "/ubuntu12_64/video/:" + steamdir + "/ubuntu12_32/video/", ":")
 
 def comma_escaped(s):
     escaped = False

--- a/proton
+++ b/proton
@@ -950,6 +950,7 @@ def default_compat_config():
                 "1604030", #V Rising
                 "1766430", #POSTAL Brain Damaged Demo
                 "1913910", #Nine Sols Demo
+                "2001540", #Slayers X Demo
 
                 #affected by CW bug 19741
                 "1017900", #Age of Empires: Definitive Edition

--- a/steam_helper/steam.cpp
+++ b/steam_helper/steam.cpp
@@ -412,7 +412,12 @@ static bool convert_linux_vrpaths(void)
     }
 
     /* pass original runtime path into Wine */
-    if(root.isMember("runtime") && root["runtime"].isArray() && root["runtime"].size() > 0)
+    const char *vr_override = getenv("VR_OVERRIDE");
+    if(vr_override)
+    {
+        set_env_from_unix(L"PROTON_VR_RUNTIME", vr_override);
+    }
+    else if(root.isMember("runtime") && root["runtime"].isArray() && root["runtime"].size() > 0)
     {
         set_env_from_unix(L"PROTON_VR_RUNTIME", root["runtime"][0].asString());
     }

--- a/steampipe_fixups.py
+++ b/steampipe_fixups.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+
+#Steampipe doesn't support certain unix-y things which may be required by
+#native Linux applications. This file will process a directory of Linux files
+#and store the file properties into a manifest file. After a round trip through
+#Steampipe, the original file properties can be restored using this same
+#script.
+
+import json
+import os
+import secrets
+import stat
+
+DEFAULT_MANIFEST_NAME = "steampipe_fixups.json"
+
+def usage():
+    print("Usage:")
+    print("\t" + sys.argv[0] + "\tprepare\t<path to directory to process>\t[manifest output file]")
+    print("\t\tProcess the given path and output the manifest file to the given path, or <path/" + DEFAULT_MANIFEST_NAME + "> if unspecified.")
+    print("")
+    print("\t" + sys.argv[0] + "\trestore\t<path to directory to process>\t[manifest file]")
+    print("\t\tRestore the given path using the manifest file, or <path/" + DEFAULT_MANIFEST_NAME + "> if unspecified.")
+
+empty_dirs = []
+no_write_paths = []
+
+def canonicalize(path, prefix):
+    return path.replace(prefix, "", 1).lstrip('/')
+
+def process_dir(path):
+    for root, subdirs, files in os.walk(path):
+        if len(subdirs) == 0 and len(files) == 0:
+            empty_dirs.append(canonicalize(root, path))
+
+        for file_ in files:
+            this_file = os.path.join(root, file_)
+            stat_result = os.lstat(this_file)
+            if (stat_result.st_mode & stat.S_IWUSR) == 0:
+                no_write_paths.append(canonicalize(this_file, path))
+
+    return 0
+
+def write_manifest(manifest):
+    out = open(manifest, "w")
+    json.dump(
+        {
+            "id": str(secrets.randbits(32)), #we need steampipe to update this file for every build
+            "empty_dirs": empty_dirs,
+            "no_write_paths": no_write_paths,
+        },
+        out,
+        indent = 4,
+        sort_keys = True
+    )
+    return 0
+
+def do_process(path, manifest):
+    if os.path.exists(manifest):
+        os.remove(manifest)
+
+    ret = process_dir(path)
+    if ret != 0:
+        return ret
+
+    #output should be deterministic
+    empty_dirs.sort()
+    no_write_paths.sort()
+
+    ret = write_manifest(manifest)
+    if ret != 0:
+        return ret
+
+    return 0
+
+def do_restore(path, manifest):
+    loaded = json.load(open(manifest, "r"))
+
+    empty_dirs = loaded["empty_dirs"]
+    no_write_paths = loaded["no_write_paths"]
+
+    for empty_dir in empty_dirs:
+        try:
+            os.makedirs(os.path.join(path, empty_dir))
+        except OSError:
+            #already exists
+            pass
+
+    for file_ in no_write_paths:
+        this_file = os.path.join(path, file_)
+        stat_result = os.lstat(this_file)
+        os.chmod(this_file,
+                stat_result.st_mode & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH))
+
+    return 0
+
+if __name__ == '__main__':
+    import sys
+    if len(sys.argv) < 3 or len(sys.argv) > 4:
+        usage()
+        sys.exit(1)
+
+    verb = sys.argv[1]
+    path = sys.argv[2]
+    if len(sys.argv) >= 4:
+        manifest = sys.argv[3]
+    else:
+        manifest = os.path.join(path, DEFAULT_MANIFEST_NAME)
+
+    if verb == "process":
+        sys.exit(do_process(path, manifest))
+
+    if verb == "restore":
+        sys.exit(do_restore(path, manifest))
+
+    usage()
+    sys.exit(1)

--- a/toolmanifest_runtime.vdf
+++ b/toolmanifest_runtime.vdf
@@ -4,4 +4,5 @@
   "commandline" "/proton %verb%"
   "require_tool_appid" "1391110"
   "use_sessions" "1"
+  "compatmanager_layer_name" "proton"
 }


### PR DESCRIPTION
If an OpenXR runtime gives an unrecognized Vulkan format (i.e. one that returns DXGI_FORMAT_UNKNOWN from map_format_vulkan_to_dxgi) for one of its swapchain formats, the formatCountOutput that is returned on the first call to xrEnumerateSwapchainFormats will differ from that of the second call, and apparently games (only tested with Blacktop Hoops) don't like this and will just end the OpenXR session. This is useful in particular for Monado, which advertises a few formats that aren't covered in map_format_vulkan_to_dxgi.