### PR TITLE
vrclient: Convert action manifests to unix paths

### DIFF
--- a/vrclient_x64/gen_wrapper.py
+++ b/vrclient_x64/gen_wrapper.py
@@ -133,6 +133,7 @@ path_conversions = [
         "l2w_lens":[],
         "w2l_names": ["pchActionManifestPath"],
         "w2l_arrays": [False],
+        "file_converter": "json_convert_action_manifest",
         "return_is_size": False
     },
     {
@@ -141,6 +142,7 @@ path_conversions = [
         "l2w_lens":[],
         "w2l_names": ["pchFilePath"],
         "w2l_arrays": [False],
+        "file_converter": None,
         "return_is_size": False
     },
     {
@@ -149,6 +151,7 @@ path_conversions = [
         "l2w_lens":[],
         "w2l_names": ["pchApplicationManifestFullPath"],
         "w2l_arrays": [False],
+        "file_converter": None,
         "return_is_size": False
     },
     {
@@ -157,6 +160,7 @@ path_conversions = [
         "l2w_lens":[],
         "w2l_names": ["pchApplicationManifestFullPath"],
         "w2l_arrays": [False],
+        "file_converter": None,
         "return_is_size": False
     },
     {
@@ -165,6 +169,7 @@ path_conversions = [
         "l2w_lens":[],
         "w2l_names": ["pchPreviewFilename", "pchVRFilename"],
         "w2l_arrays": [False, False],
+        "file_converter": None,
         "return_is_size": False
     },
     {
@@ -173,6 +178,7 @@ path_conversions = [
         "l2w_lens":[],
         "w2l_names": ["pchPreviewFilename", "pchVRFilename"],
         "w2l_arrays": [False, False],
+        "file_converter": None,
         "return_is_size": False
     },
     {
@@ -181,6 +187,7 @@ path_conversions = [
         "l2w_lens":[],
         "w2l_names": ["pchSourcePreviewFilename", "pchSourceVRFilename"],
         "w2l_arrays": [False, False],
+        "file_converter": None,
         "return_is_size": False
     },
     {
@@ -189,6 +196,7 @@ path_conversions = [
         "l2w_lens":["cchFilename"],
         "w2l_names": [],
         "w2l_arrays": [],
+        "file_converter": None,
         "return_is_size": True
     },
     {
@@ -197,6 +205,7 @@ path_conversions = [
         "l2w_lens":[],
         "w2l_names": ["a"],
         "w2l_arrays": [False],
+        "file_converter": None,
         "return_is_size": False
     },
     {
@@ -205,6 +214,7 @@ path_conversions = [
         "l2w_lens":[],
         "w2l_names": ["a"],
         "w2l_arrays": [False],
+        "file_converter": None,
         "return_is_size": False
     },
     {
@@ -213,6 +223,7 @@ path_conversions = [
         "l2w_lens":[],
         "w2l_names": ["pchRenderModelPath"],
         "w2l_arrays": [False],
+        "file_converter": None,
         "return_is_size": False
     },
 
@@ -530,6 +541,8 @@ def handle_method(cfile, classname, winclassname, cppname, method, cpp, cpp_h, e
             else:
                 cfile.write("    char lin_%s[PATH_MAX];\n" % path_conv["w2l_names"][i])
                 cfile.write("    vrclient_dos_path_to_unix_path(%s, lin_%s);\n" % (path_conv["w2l_names"][i], path_conv["w2l_names"][i]))
+                if path_conv["file_converter"] is not None:
+                    cfile.write("    %s(lin_%s);\n" % (path_conv["file_converter"], path_conv["w2l_names"][i]))
         if None in path_conv["l2w_names"]:
             cfile.write("    const char *path_result;\n")
         elif path_conv["return_is_size"]:

--- a/vrclient_x64/vrclient_x64/vrclient_private.h
+++ b/vrclient_x64/vrclient_x64/vrclient_private.h
@@ -7,6 +7,7 @@ extern "C" {
 
 char *json_convert_paths(const char *input);
 char *json_convert_startup_info(const char *startup_info);
+bool  json_convert_action_manifest(const char *manifest_file);
 
 bool vrclient_dos_path_to_unix_path(const char *src, char *dst);
 

--- a/vrclient_x64/vrclient_x64/winIVRInput.c
+++ b/vrclient_x64/vrclient_x64/winIVRInput.c
@@ -30,6 +30,7 @@ EVRInputError __thiscall winIVRInput_IVRInput_010_SetActionManifestPath(winIVRIn
 {
     char lin_pchActionManifestPath[PATH_MAX];
     vrclient_dos_path_to_unix_path(pchActionManifestPath, lin_pchActionManifestPath);
+    json_convert_action_manifest(lin_pchActionManifestPath);
     TRACE("%p\n", _this);
     return cppIVRInput_IVRInput_010_SetActionManifestPath(_this->linux_side, pchActionManifestPath ? lin_pchActionManifestPath : NULL);
 }
@@ -377,6 +378,7 @@ EVRInputError __thiscall winIVRInput_IVRInput_007_SetActionManifestPath(winIVRIn
 {
     char lin_pchActionManifestPath[PATH_MAX];
     vrclient_dos_path_to_unix_path(pchActionManifestPath, lin_pchActionManifestPath);
+    json_convert_action_manifest(lin_pchActionManifestPath);
     TRACE("%p\n", _this);
     return cppIVRInput_IVRInput_007_SetActionManifestPath(_this->linux_side, pchActionManifestPath ? lin_pchActionManifestPath : NULL);
 }
@@ -688,6 +690,7 @@ EVRInputError __thiscall winIVRInput_IVRInput_006_SetActionManifestPath(winIVRIn
 {
     char lin_pchActionManifestPath[PATH_MAX];
     vrclient_dos_path_to_unix_path(pchActionManifestPath, lin_pchActionManifestPath);
+    json_convert_action_manifest(lin_pchActionManifestPath);
     TRACE("%p\n", _this);
     return cppIVRInput_IVRInput_006_SetActionManifestPath(_this->linux_side, pchActionManifestPath ? lin_pchActionManifestPath : NULL);
 }
@@ -981,6 +984,7 @@ EVRInputError __thiscall winIVRInput_IVRInput_005_SetActionManifestPath(winIVRIn
 {
     char lin_pchActionManifestPath[PATH_MAX];
     vrclient_dos_path_to_unix_path(pchActionManifestPath, lin_pchActionManifestPath);
+    json_convert_action_manifest(lin_pchActionManifestPath);
     TRACE("%p\n", _this);
     return cppIVRInput_IVRInput_005_SetActionManifestPath(_this->linux_side, pchActionManifestPath ? lin_pchActionManifestPath : NULL);
 }
@@ -1265,6 +1269,7 @@ EVRInputError __thiscall winIVRInput_IVRInput_004_SetActionManifestPath(winIVRIn
 {
     char lin_pchActionManifestPath[PATH_MAX];
     vrclient_dos_path_to_unix_path(pchActionManifestPath, lin_pchActionManifestPath);
+    json_convert_action_manifest(lin_pchActionManifestPath);
     TRACE("%p\n", _this);
     return cppIVRInput_IVRInput_004_SetActionManifestPath(_this->linux_side, pchActionManifestPath ? lin_pchActionManifestPath : NULL);
 }
@@ -1486,6 +1491,7 @@ EVRInputError __thiscall winIVRInput_IVRInput_003_SetActionManifestPath(winIVRIn
 {
     char lin_pchActionManifestPath[PATH_MAX];
     vrclient_dos_path_to_unix_path(pchActionManifestPath, lin_pchActionManifestPath);
+    json_convert_action_manifest(lin_pchActionManifestPath);
     TRACE("%p\n", _this);
     return cppIVRInput_IVRInput_003_SetActionManifestPath(_this->linux_side, pchActionManifestPath ? lin_pchActionManifestPath : NULL);
 }


### PR DESCRIPTION
Action manifest files contain refernces to default bindings files for different controllers. These binding urls can contain absolute windows path for proton games which need to be converted for SteamVR.

This change has been tested with
[559330] A Fisherman's Tale
]1087500] Groundhog Day: Like Father Like Son

which both become playable out of the box.