### PR TITLE
Enable dxvknvapi on a bunch of (DLSS) titles I've verified as functioning and stable.

### DIFF
--- a/proton
+++ b/proton
@@ -1058,6 +1058,7 @@ def default_compat_config():
                 "870780", #control ultimate edition
                 "1091500", #cyberpunk 2077
                 "1190460", #death stranding
+                "1850570", #Death Stranding Director's Cut
                 "1252330", #deathloop
                 "548430", #deep rock galactic
                 "428660", #deliver us the moon
@@ -1067,6 +1068,10 @@ def default_compat_config():
                 "1952070", #engine evolution 2022 demo
                 "1128920", #everspace 2
                 "1312800", #everspace 2 demo
+                "1330470", #F.I.S.T.: Forged In Shadow Torch
+                "1332390", #F.I.S.T.: Forged In Shadow Torch Demo
+                "1641960", #Forever Skies
+                "2141060", #Forever Skies Demo
                 "1080110", #f1 2020
                 "1098130", #get stuffed
                 "1139900", #ghostrunner
@@ -1079,6 +1084,8 @@ def default_compat_config():
                 "1987940", #island of the ancients demo
                 "1371480", #iron conflict
                 "1544360", #lego builder's journey
+                "1363080", #Manor Lords
+                "2122820", #Manor Lords Demo
                 "1817070", #marvel's spider-man remastered
                 "784080", #mechwarrior 5: mercenaries
                 "1170950", #mortal online 2

--- a/proton
+++ b/proton
@@ -1042,6 +1042,71 @@ def default_compat_config():
                 ]:
             ret.add("noopwr")
 
+        if appid in [
+                # enable dxvknvapi for titles verified to benefit (e.g. working DLSS)
+                "673130", #amid evil
+                "1291680", #apocalypse: 2.0 edition
+                "979690", #the ascent
+                "805550", #assetto corsa competizione
+                "924970", #back 4 blood
+                "1178830", #bright memory infinite
+                "1409670", #bright memory infinite benchmark
+                "1153640", #chorus
+                "1791040", #chorus demo
+                "1577240", #cions of vega
+                "1632760", #cions of vega demo
+                "870780", #control ultimate edition
+                "1091500", #cyberpunk 2077
+                "1190460", #death stranding
+                "1252330", #deathloop
+                "548430", #deep rock galactic
+                "428660", #deliver us the moon
+                "534380", #dying light 2
+                "269190", #edge of eternity
+                "1871990", #engine evolution 2022
+                "1952070", #engine evolution 2022 demo
+                "1128920", #everspace 2
+                "1312800", #everspace 2 demo
+                "1080110", #f1 2020
+                "1098130", #get stuffed
+                "1139900", #ghostrunner
+                "1249200", #ghostrunner demo
+                "1593500", #god of war
+                "414340", #hellblade: senua's sacrifice
+                "1659040", #hitman 3
+                "1847520", #hitman 3 free starter pack
+                "1650150", #island of the ancients
+                "1987940", #island of the ancients demo
+                "1371480", #iron conflict
+                "1544360", #lego builder's journey
+                "1817070", #marvel's spider-man remastered
+                "784080", #mechwarrior 5: mercenaries
+                "1170950", #mortal online 2
+                "261550", #mount & blade II: bannerlord
+                "275850", #no man's sky
+                "1140100", #the persistence
+                "1322170", #pluviophile
+                "1186640", #pumpkin jack
+                "391220", #rise of the tomb raider
+                "750920", #shadow of the tomb raider
+                "1602080", #soulstice
+                "2015300", #soulstice demo
+                "1296010", #stay in the light
+                "813630", #supraland
+                "487390", #system shock demo
+                "868270", #the cycle: frontier
+                "306130", #the elder scrolls online
+                "1096200", #the orville: interactive fan experience
+                "1843860", #the redress of mira
+                "2050550", #the redress of mira demo
+                "1567740", #to hell with it
+                "1662690", #twin stones: the journey of bukka
+                "236390", #war thunder
+                "936720", #wrench
+                "1249800", #xuan-yuan sword VII
+                ]:
+            ret.add("enablenvapi")
+
     return ret
 
 class Session:

--- a/proton
+++ b/proton
@@ -1045,6 +1045,7 @@ def default_compat_config():
         if appid in [
                 # enable dxvknvapi for titles verified to benefit (e.g. working DLSS)
                 "673130", #amid evil
+                "1182900", #A Plague Tale: Requiem
                 "1291680", #apocalypse: 2.0 edition
                 "979690", #the ascent
                 "805550", #assetto corsa competizione


### PR DESCRIPTION
Note: in some cases I've included the app ID for a game demo but not the full game.  This is only because in those cases I've not tested the full game, and wanted to strictly only include titles I've directly verified as stable'n'good.

However, it's probably very fair to say that if a game demo had good DLSS/nvapi stability then the full game will also have good DLSS/nvapi stability, so if you'd like me to add the app IDs for full titles sight-unseen then I'm happy to do so!  **(edit: done that.)**
