### PR TITLE
enable dxvknvapi for monster hunter rise (1446780)

### DIFF
--- a/proton
+++ b/proton
@@ -1174,6 +1174,7 @@ def default_compat_config():
                 "236390", #war thunder
                 "936720", #wrench
                 "1249800", #xuan-yuan sword VII
+                "1446780", #monster hunter rise
                 ]:
             ret.add("enablenvapi")
     return ret


### PR DESCRIPTION
Monster Hunter Rise (1446780) has working DLSS with `PROTON_ENABLE_NVAPI=1`.