### PR TITLE
Remove spam log levels

### DIFF
--- a/proton
+++ b/proton
@@ -1197,7 +1197,7 @@ class Session:
                 log("************************************************")
 
         if "PROTON_LOG" in self.env and nonzero(self.env["PROTON_LOG"]):
-            self.env.setdefault("WINEDEBUG", "+timestamp,+pid,+tid,+seh,+unwind,+debugstr,+loaddll,+mscoree")
+            self.env.setdefault("WINEDEBUG", "+timestamp,+pid,+tid,+debugstr,+loaddll,+mscoree")
             self.env.setdefault("DXVK_LOG_LEVEL", "info")
             self.env.setdefault("VKD3D_DEBUG", "warn")
             self.env.setdefault("VKD3D_SHADER_DEBUG", "fixme")


### PR DESCRIPTION
As explained in [this comment](https://github.com/ValveSoftware/Proton/issues/5285#issuecomment-1487826991), these two log entries cause games to become entirely unplayable while bloating precious drive space with no benefit to troubleshooting. It actually hinders reporting because log files from simply booting the game START at around 2 gigabytes.

All this does is just remove the two offending flags (modes?) that PROTON_LOG=1 appends to the wine debug output.

For direct reference, here is that comment in full:

> Can we get some logging restraints for FH5? The game writes 30+ MB/s to disk with PROTON_LOG=1 and makes the game unplayable when trying to get crash info.
> 
> In a run where I simply boot the game and load in, 2 GB of logging data is generated!
> 
> A total of 17780397 lines are written, of which:
> 
> |||
> |-|-|
> 5508763 | trace:seh:dispatch_exception
> 4543749 | trace:unwind:dump_unwind_info
> 4030062 | trace:seh:call_vectored_handlers
> 2203500 | warn:seh:dispatch_exception
> 694850  | trace:seh:sigsys_handler
> 486708 | trace:unwind:RtlVirtualUnwind
> 167518 | trace:unwind:RtlCaptureStackBackTrace
> 100471 | warn:vkd3d-proton:d3d12_pipeline_state_init_graphics_create_info
> 41235 | warn:vkd3d-proton:rs_desc_from_d3d12
> 977 | trace:loaddll:build_module
> 
> This means that the single "dispatch_exception" trace is responsible for 30% of the spam.
> Worse, the first 9 entries in this table account for 99.980% of all log output while providing no value.