### PR TITLE
Remove LLVM from issue report templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/compatibility-report.md
+++ b/.github/ISSUE_TEMPLATE/compatibility-report.md
@@ -10,7 +10,7 @@ about: Game compatibility issues.
 
 ## System Information
 - GPU: <!-- e.g. RX 580 or GTX 970 -->
-- Driver/LLVM version: <!-- e.g. Mesa 18.2/7.0.0 or nvidia 396.54 -->
+- Video driver version: <!-- e.g. Mesa 18.2 or nvidia 396.54 -->
 - Kernel version: <!-- e.g. 4.17 -->
 - Link to full system information report as [Gist](https://gist.github.com/):
 - Proton version:

--- a/.github/ISSUE_TEMPLATE/compatibility-report.md
+++ b/.github/ISSUE_TEMPLATE/compatibility-report.md
@@ -39,6 +39,8 @@ attach the generated $HOME/steam-$APPID.log to this issue report as a file.
 4. Please copy it to your clipboard by pressing `Ctrl+A` and then `Ctrl+C`.
    Then paste it in a [Gist](https://gist.github.com/) and post the link in
    this issue.
-5. Please search for open issues and pull requests by the name of the game and
+5. Also, please copy the contents of `Help` > `Steam Runtime Information` to
+   the gist.   
+6. Please search for open issues and pull requests by the name of the game and
    find out whether they are relevant and should be referenced above.
 -->

--- a/.github/ISSUE_TEMPLATE/whitelist-request.md
+++ b/.github/ISSUE_TEMPLATE/whitelist-request.md
@@ -10,7 +10,7 @@ about: Games tested and found to have no issues.
 
 ## System Information
 - GPU: <!-- e.g. RX 580 or GTX 970 -->
-- Driver/LLVM version: <!-- e.g. Mesa 18.2/7.0.0 or nvidia 396.54 -->
+- Video driver version: <!-- e.g. Mesa 18.2 or nvidia 396.54 -->
 - Distro version: <!-- e.g. Ubuntu 18.04 -->
 - Link to full system information report as [Gist](https://gist.github.com/):
 - Proton version:


### PR DESCRIPTION
The amount of games influenced by LLVM version is fairly low these days. Low priority adjustment when it is convenient.

EDIT: Also ask users to also share Steam Runtime Information now that has been split from Steam's system information window.