### PR TITLE
Patched Fix bumpalo has use-after-free due to a lifetime error in `Ve…

### DIFF
--- a/media-converter/Cargo.lock
+++ b/media-converter/Cargo.lock
@@ -43,9 +43,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.11.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "cfg-expr"


### PR DESCRIPTION
…c::into_iter()`

## Description :
In affected project of this crate, the lifetime of the iterator produced by `Vec::into_iter()` is not constrained to the lifetime of the Bump that allocated the vector's memory. Using the iterator after the Bump is dropped causes use-after-free accesses.

The following example demonstrates memory corruption arising from a misuse of this unsoundness.
```js
use bumpalo::{collections::Vec, Bump};

fn main() {
    let bump = Bump::new();
    let mut vec = Vec::new_in(&bump);
    vec.extend([0x01u8; 32]);
    let into_iter = vec.into_iter();
    drop(bump);

    for _ in 0..100 {
        let reuse_bump = Bump::new();
        let _reuse_alloc = reuse_bump.alloc([0x41u8; 10]);
    }

    for x in into_iter {
        print!("0x{:02x} ", x);
    }
    println!();
}
```
The issue was corrected in version 3.11.1 by adding a lifetime to the `IntoIter` type, and updating the signature of `Vec::into_iter()` to constrain this lifetime.