### PR TITLE
proton: Enable dxvknvapi and amdags for Resident Evil 2 (883710)

### DIFF
--- a/proton
+++ b/proton
@@ -1240,6 +1240,7 @@ def default_compat_config():
                 "883710", #Resident Evil 2
                 "952060", #Resident Evil 3
                 "1196590", #Resident Evil Village
+                "418370", #Resident Evil 7 Biohazard
                 ]:
             ret.add("enableamdags")
 

--- a/proton
+++ b/proton
@@ -1228,6 +1228,7 @@ def default_compat_config():
                 "2379390", #Rainbow Six Extraction
                 "883710", #Resident Evil 2
                 "952060", #Resident Evil 3
+                "1196590", #Resident Evil Village
                 ]:
             ret.add("enablenvapi")
 

--- a/proton
+++ b/proton
@@ -1227,6 +1227,7 @@ def default_compat_config():
                 "1446780", #monster hunter rise
                 "2379390", #Rainbow Six Extraction
                 "883710", #Resident Evil 2
+                "952060", #Resident Evil 3
                 ]:
             ret.add("enablenvapi")
 

--- a/proton
+++ b/proton
@@ -1234,6 +1234,7 @@ def default_compat_config():
                 "1888160", #Armored Core VI
                 "814380", #Sekiro: Shadows Die Twice
                 "2379390", #Rainbow Six Extraction
+                "883710", #Resident Evil 2
                 ]:
             ret.add("enableamdags")
 

--- a/proton
+++ b/proton
@@ -1236,6 +1236,7 @@ def default_compat_config():
                 "814380", #Sekiro: Shadows Die Twice
                 "2379390", #Rainbow Six Extraction
                 "883710", #Resident Evil 2
+                "952060", #Resident Evil 3
                 ]:
             ret.add("enableamdags")
 

--- a/proton
+++ b/proton
@@ -1238,6 +1238,7 @@ def default_compat_config():
                 "2379390", #Rainbow Six Extraction
                 "883710", #Resident Evil 2
                 "952060", #Resident Evil 3
+                "1196590", #Resident Evil Village
                 ]:
             ret.add("enableamdags")
 

--- a/proton
+++ b/proton
@@ -1226,6 +1226,7 @@ def default_compat_config():
                 "1358700", #STRANGER OF PARADISE FINAL FANTASY ORIGIN
                 "1446780", #monster hunter rise
                 "2379390", #Rainbow Six Extraction
+                "883710", #Resident Evil 2
                 ]:
             ret.add("enablenvapi")
 

--- a/proton
+++ b/proton
@@ -1229,6 +1229,7 @@ def default_compat_config():
                 "883710", #Resident Evil 2
                 "952060", #Resident Evil 3
                 "1196590", #Resident Evil Village
+                "418370", #Resident Evil 7 Biohazard
                 ]:
             ret.add("enablenvapi")
 


### PR DESCRIPTION
Needed for HDR functionality.