### PR TITLE
proton: Enable amdags for The Last of Us Part I

### DIFF
--- a/proton
+++ b/proton
@@ -1225,6 +1225,7 @@ def default_compat_config():
         if appid in [
                 "1245620", #Elden Ring
                 "1888160", #Armored Core VI
+                "1888930", #the last of us part 1
                 "814380", #Sekiro: Shadows Die Twice
                 "2379390", #Rainbow Six Extraction
                 ]:


### PR DESCRIPTION
`WINEDLLOVERRIDES="amd_ags_x64=b"` was required before to fix:

* outdated graphics driver warning on game start
* wrong vram reported in options
* delayed texture loading

https://github.com/ValveSoftware/Proton/issues/6653
https://www.protondb.com/app/1888930

Tested with `PROTON_ENABLE_AMD_AGS=1` on mesa 23.3.0-rc3 with a RX7800XT on current Proton Experimental `experimental-8.0-20231107c`.