### PR TITLE
Fix license.

### DIFF
--- a/media-converter/Cargo.toml
+++ b/media-converter/Cargo.toml
@@ -3,7 +3,7 @@ name = "proton-media-converter"
 version = "7.0.0"
 authors = ["Andrew Eikum <aeikum@codeweavers.com>"]
 repository = "https://github.com/ValveSoftware/Proton/"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 description = "Proton media converter"
 


### PR DESCRIPTION
Use of "/" is deprecated per [this](https://github.com/rust-lang/cargo/pull/4898).