### PR TITLE
proton: Enable gamedrive compat option for Descent 3

### DIFF
--- a/proton
+++ b/proton
@@ -1071,6 +1071,7 @@ def default_compat_config():
                 "4000", #Garry's Mod
                 "383120", #Empyrion - Galactic Survival
                 "2371630", #Sword Art Online: Integral Factor
+                "273590", #Descent 3
                 ]:
             ret.add("gamedrive")
 


### PR DESCRIPTION
Descent 3 corrupts its stack if the installation path is too long. The return pointer gets overwritten with the path to the intro movie and we crash.

Ref #3346 