### PR TITLE
proton: Enable dxvk-nvapi logging when PROTON_LOG is used.

### DIFF
--- a/proton
+++ b/proton
@@ -1400,6 +1400,7 @@ class Session:
         if "PROTON_LOG" in self.env and nonzero(self.env["PROTON_LOG"]):
             self.env.setdefault("WINEDEBUG", "+timestamp,+pid,+tid,+seh,+unwind,+threadname,+debugstr,+loaddll,+mscoree")
             self.env.setdefault("DXVK_LOG_LEVEL", "info")
+            self.env.setdefault("DXVK_NVAPI_LOG_LEVEL", "info")
             self.env.setdefault("VKD3D_DEBUG", "warn")
             self.env.setdefault("VKD3D_SHADER_DEBUG", "fixme")
             self.env.setdefault("WINE_MONO_TRACE", "E:System.NotImplementedException")


### PR DESCRIPTION
Some games have greater requirements with regard to which NVAPI functions need to be implemented for them to work correctly, e.g. Cyberpunk 2077 v1.62 required us to add some Opacity-Micromap-related stubs and The Last of Us Part 1 absolutely needed some device queries to succeed. Having dxvk-nvapi logs enabled together with all the other stuff `PROTON_LOG` enables will be useful for debugging cases like that and should hopefully shorten the time to get them working, especially with #7335 enabling NVAPI for almost all games by default.