### PR TITLE
Enable nativevulkanloader for Forts

### DIFF
--- a/proton
+++ b/proton
@@ -1162,6 +1162,11 @@ def default_compat_config():
                 "712180", # Mugsters
                 ]:
             ret.add("xalia")
+        
+        if appid in [
+                "410900" # Forts
+                ]:
+            ret add("nativevulkanloader")
 
     return ret
 

--- a/proton
+++ b/proton
@@ -1164,9 +1164,9 @@ def default_compat_config():
             ret.add("xalia")
         
         if appid in [
-                "410900" # Forts
+                "410900", # Forts
                 ]:
-            ret add("nativevulkanloader")
+            ret.add("nativevulkanloader")
 
     return ret
 


### PR DESCRIPTION
Fix for Forts - when running Forts with vulkan renderer enabled, everything renders transparent. Enabling "nativevulkanloader" avoids this issue.