### PR TITLE
configure.sh: Add option to disable SELinux labeling for container volumes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1150,6 +1150,10 @@ else
 	override DOCKER_OPTS := $(CCACHE_ENV) -e CCACHE_DISABLE=1 $(DOCKER_OPTS)
 endif
 
+ifeq ($(DISABLE_LABELING),1)
+	override DOCKER_OPTS := --security-opt label=disable $(DOCKER_OPTS)
+endif
+
 export CARGO_HOME := $(if $(CARGO_HOME),$(CARGO_HOME),$(HOME)/.cargo)
 override DOCKER_OPTS := -v $(CARGO_HOME):$(CARGO_HOME)$(CONTAINER_MOUNT_OPTS) -e CARGO_HOME=$(CARGO_HOME) $(DOCKER_OPTS)
 


### PR DESCRIPTION
Adds `--disable-labeling` to configure.sh. Passing this option passes `--security-opt label=disable` to the container arguments, which disables SELinux labeling. This is something of a nuclear option compared to :z or :Z for volume binds, but far simpler and basically guaranteed to work, and for a build container the security implications hardly matter.

The existing `--relabel-volumes` option which passes `:Z` (capital) is a little bit not-nice because it relabels the files on the host (`:z`, lowercase, only relabels them in the container).