### PR TITLE
steam_helper: clean up OpenVR before getting OpenXR extensions in `initialize_vr_data`

### DIFF
--- a/steam_helper/steam.cpp
+++ b/steam_helper/steam.cpp
@@ -893,6 +893,11 @@ static DWORD WINAPI initialize_vr_data(void *arg)
         }
     }
 
+    if (vr_initialized) {
+        client_core->Cleanup();
+        vr_initialized = FALSE;
+    }
+
     if ((hwineopenxr = LoadLibraryA("wineopenxr.dll")))
     {
         p__wineopenxr_get_extensions_internal = reinterpret_cast<decltype(p__wineopenxr_get_extensions_internal)>


### PR DESCRIPTION
When using OpenComposite, both OpenVR and OpenXR functions may call the same underlying OpenXR loader.

Because the OpenXR loader only supports a single active instance, `initialize_vr_data` currently fails as an OpenXR instance has already been initialized at the time XR extensions are queried.

This commit fixes the problem by cleaning up the temporary OpenVR context *before* initializing OpenXR instead of keeping it open until the end of the call.

Fix for:
https://github.com/ValveSoftware/Proton/issues/7905

----

This is a follow-up to https://github.com/ValveSoftware/Proton/pull/7906.

As @gofman [suggested](https://github.com/ValveSoftware/Proton/pull/7906#issuecomment-2261021371), it is much simpler and safer to just close the OpenVR instance early than what I did before.

Tested with:
- VRChat (OpenVR) + Proton + SteamVR
- Beat Saber (OpenXR) + Proton + SteamVR
- Beat Saber (OpenXR) + Proton + OpenComposite + Monado (this one was broken before)