### PR TITLE
Fix up CGameID param on more old Steam interface versions

### DIFF
--- a/lsteamclient/cppISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001.cpp
+++ b/lsteamclient/cppISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001.cpp
@@ -9,7 +9,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetNumStats( void *
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetNumStats_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetNumStats_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->GetNumStats( params->nGameID );
+    params->_ret = iface->GetNumStats( &params->nGameID );
     return 0;
 }
 
@@ -17,7 +17,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetStatName( void *
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetStatName_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetStatName_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->GetStatName( params->nGameID, params->iStat );
+    params->_ret = iface->GetStatName( &params->nGameID, params->iStat );
     return 0;
 }
 
@@ -25,7 +25,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetStatType( void *
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetStatType_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetStatType_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->GetStatType( params->nGameID, params->pchName );
+    params->_ret = iface->GetStatType( &params->nGameID, params->pchName );
     return 0;
 }
 
@@ -33,7 +33,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetNumAchievements(
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetNumAchievements_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetNumAchievements_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->GetNumAchievements( params->nGameID );
+    params->_ret = iface->GetNumAchievements( &params->nGameID );
     return 0;
 }
 
@@ -41,7 +41,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetAchievementName(
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetAchievementName_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetAchievementName_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->GetAchievementName( params->nGameID, params->iAchievement );
+    params->_ret = iface->GetAchievementName( &params->nGameID, params->iAchievement );
     return 0;
 }
 
@@ -49,7 +49,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetNumGroupAchievem
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetNumGroupAchievements_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetNumGroupAchievements_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->GetNumGroupAchievements( params->nGameID );
+    params->_ret = iface->GetNumGroupAchievements( &params->nGameID );
     return 0;
 }
 
@@ -57,7 +57,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetGroupAchievement
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetGroupAchievementName_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetGroupAchievementName_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->GetGroupAchievementName( params->nGameID, params->iAchievement );
+    params->_ret = iface->GetGroupAchievementName( &params->nGameID, params->iAchievement );
     return 0;
 }
 
@@ -65,7 +65,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_RequestCurrentStats
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_RequestCurrentStats_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_RequestCurrentStats_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->RequestCurrentStats( params->nGameID );
+    params->_ret = iface->RequestCurrentStats( &params->nGameID );
     return 0;
 }
 
@@ -73,7 +73,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetStat( void *args
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetStat_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetStat_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->GetStat( params->nGameID, params->pchName, params->pData );
+    params->_ret = iface->GetStat( &params->nGameID, params->pchName, params->pData );
     return 0;
 }
 
@@ -81,7 +81,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetStat_2( void *ar
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetStat_2_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetStat_2_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->GetStat( params->nGameID, params->pchName, params->pData );
+    params->_ret = iface->GetStat( &params->nGameID, params->pchName, params->pData );
     return 0;
 }
 
@@ -89,7 +89,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_SetStat( void *args
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_SetStat_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_SetStat_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->SetStat( params->nGameID, params->pchName, params->nData );
+    params->_ret = iface->SetStat( &params->nGameID, params->pchName, params->nData );
     return 0;
 }
 
@@ -97,7 +97,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_SetStat_2( void *ar
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_SetStat_2_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_SetStat_2_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->SetStat( params->nGameID, params->pchName, params->fData );
+    params->_ret = iface->SetStat( &params->nGameID, params->pchName, params->fData );
     return 0;
 }
 
@@ -105,7 +105,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_UpdateAvgRateStat( 
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_UpdateAvgRateStat_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_UpdateAvgRateStat_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->UpdateAvgRateStat( params->nGameID, params->pchName, params->flCountThisSession, params->dSessionLength );
+    params->_ret = iface->UpdateAvgRateStat( &params->nGameID, params->pchName, params->flCountThisSession, params->dSessionLength );
     return 0;
 }
 
@@ -113,7 +113,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetAchievement( voi
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetAchievement_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetAchievement_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->GetAchievement( params->nGameID, params->pchName, params->pbAchieved );
+    params->_ret = iface->GetAchievement( &params->nGameID, params->pchName, params->pbAchieved );
     return 0;
 }
 
@@ -121,7 +121,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetGroupAchievement
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetGroupAchievement_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetGroupAchievement_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->GetGroupAchievement( params->nGameID, params->pchName, params->pbAchieved );
+    params->_ret = iface->GetGroupAchievement( &params->nGameID, params->pchName, params->pbAchieved );
     return 0;
 }
 
@@ -129,7 +129,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_SetAchievement( voi
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_SetAchievement_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_SetAchievement_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->SetAchievement( params->nGameID, params->pchName );
+    params->_ret = iface->SetAchievement( &params->nGameID, params->pchName );
     return 0;
 }
 
@@ -137,7 +137,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_SetGroupAchievement
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_SetGroupAchievement_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_SetGroupAchievement_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->SetGroupAchievement( params->nGameID, params->pchName );
+    params->_ret = iface->SetGroupAchievement( &params->nGameID, params->pchName );
     return 0;
 }
 
@@ -145,7 +145,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_StoreStats( void *a
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_StoreStats_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_StoreStats_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->StoreStats( params->nGameID );
+    params->_ret = iface->StoreStats( &params->nGameID );
     return 0;
 }
 
@@ -153,7 +153,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_ClearAchievement( v
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_ClearAchievement_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_ClearAchievement_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->ClearAchievement( params->nGameID, params->pchName );
+    params->_ret = iface->ClearAchievement( &params->nGameID, params->pchName );
     return 0;
 }
 
@@ -161,7 +161,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_ClearGroupAchieveme
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_ClearGroupAchievement_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_ClearGroupAchievement_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->ClearGroupAchievement( params->nGameID, params->pchName );
+    params->_ret = iface->ClearGroupAchievement( &params->nGameID, params->pchName );
     return 0;
 }
 
@@ -169,7 +169,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetAchievementIcon(
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetAchievementIcon_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetAchievementIcon_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->GetAchievementIcon( params->nGameID, params->pchName );
+    params->_ret = iface->GetAchievementIcon( &params->nGameID, params->pchName );
     return 0;
 }
 
@@ -177,7 +177,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetAchievementDispl
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetAchievementDisplayAttribute_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001_GetAchievementDisplayAttribute_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001 *)params->linux_side;
-    params->_ret = iface->GetAchievementDisplayAttribute( params->nGameID, params->pchName, params->pchKey );
+    params->_ret = iface->GetAchievementDisplayAttribute( &params->nGameID, params->pchName, params->pchKey );
     return 0;
 }
 

--- a/lsteamclient/cppISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002.cpp
+++ b/lsteamclient/cppISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002.cpp
@@ -9,7 +9,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetNumStats( void *
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetNumStats_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetNumStats_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->linux_side;
-    params->_ret = iface->GetNumStats( params->nGameID );
+    params->_ret = iface->GetNumStats( &params->nGameID );
     return 0;
 }
 
@@ -17,7 +17,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStatName( void *
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStatName_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStatName_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->linux_side;
-    params->_ret = iface->GetStatName( params->nGameID, params->iStat );
+    params->_ret = iface->GetStatName( &params->nGameID, params->iStat );
     return 0;
 }
 
@@ -25,7 +25,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStatType( void *
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStatType_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStatType_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->linux_side;
-    params->_ret = iface->GetStatType( params->nGameID, params->pchName );
+    params->_ret = iface->GetStatType( &params->nGameID, params->pchName );
     return 0;
 }
 
@@ -33,7 +33,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetNumAchievements(
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetNumAchievements_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetNumAchievements_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->linux_side;
-    params->_ret = iface->GetNumAchievements( params->nGameID );
+    params->_ret = iface->GetNumAchievements( &params->nGameID );
     return 0;
 }
 
@@ -41,7 +41,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementName(
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementName_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementName_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->linux_side;
-    params->_ret = iface->GetAchievementName( params->nGameID, params->iAchievement );
+    params->_ret = iface->GetAchievementName( &params->nGameID, params->iAchievement );
     return 0;
 }
 
@@ -49,7 +49,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_RequestCurrentStats
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_RequestCurrentStats_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_RequestCurrentStats_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->linux_side;
-    params->_ret = iface->RequestCurrentStats( params->nGameID );
+    params->_ret = iface->RequestCurrentStats( &params->nGameID );
     return 0;
 }
 
@@ -57,7 +57,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStat( void *args
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStat_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStat_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->linux_side;
-    params->_ret = iface->GetStat( params->nGameID, params->pchName, params->pData );
+    params->_ret = iface->GetStat( &params->nGameID, params->pchName, params->pData );
     return 0;
 }
 
@@ -65,7 +65,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStat_2( void *ar
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStat_2_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStat_2_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->linux_side;
-    params->_ret = iface->GetStat( params->nGameID, params->pchName, params->pData );
+    params->_ret = iface->GetStat( &params->nGameID, params->pchName, params->pData );
     return 0;
 }
 
@@ -73,7 +73,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetStat( void *args
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetStat_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetStat_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->linux_side;
-    params->_ret = iface->SetStat( params->nGameID, params->pchName, params->nData );
+    params->_ret = iface->SetStat( &params->nGameID, params->pchName, params->nData );
     return 0;
 }
 
@@ -81,7 +81,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetStat_2( void *ar
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetStat_2_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetStat_2_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->linux_side;
-    params->_ret = iface->SetStat( params->nGameID, params->pchName, params->fData );
+    params->_ret = iface->SetStat( &params->nGameID, params->pchName, params->fData );
     return 0;
 }
 
@@ -89,7 +89,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_UpdateAvgRateStat( 
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_UpdateAvgRateStat_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_UpdateAvgRateStat_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->linux_side;
-    params->_ret = iface->UpdateAvgRateStat( params->nGameID, params->pchName, params->flCountThisSession, params->dSessionLength );
+    params->_ret = iface->UpdateAvgRateStat( &params->nGameID, params->pchName, params->flCountThisSession, params->dSessionLength );
     return 0;
 }
 
@@ -97,7 +97,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievement( voi
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievement_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievement_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->linux_side;
-    params->_ret = iface->GetAchievement( params->nGameID, params->pchName, params->pbAchieved );
+    params->_ret = iface->GetAchievement( &params->nGameID, params->pchName, params->pbAchieved );
     return 0;
 }
 
@@ -105,7 +105,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetAchievement( voi
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetAchievement_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetAchievement_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->linux_side;
-    params->_ret = iface->SetAchievement( params->nGameID, params->pchName );
+    params->_ret = iface->SetAchievement( &params->nGameID, params->pchName );
     return 0;
 }
 
@@ -113,7 +113,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_ClearAchievement( v
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_ClearAchievement_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_ClearAchievement_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->linux_side;
-    params->_ret = iface->ClearAchievement( params->nGameID, params->pchName );
+    params->_ret = iface->ClearAchievement( &params->nGameID, params->pchName );
     return 0;
 }
 
@@ -121,7 +121,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_StoreStats( void *a
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_StoreStats_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_StoreStats_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->linux_side;
-    params->_ret = iface->StoreStats( params->nGameID );
+    params->_ret = iface->StoreStats( &params->nGameID );
     return 0;
 }
 
@@ -129,7 +129,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementIcon(
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementIcon_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementIcon_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->linux_side;
-    params->_ret = iface->GetAchievementIcon( params->nGameID, params->pchName );
+    params->_ret = iface->GetAchievementIcon( &params->nGameID, params->pchName );
     return 0;
 }
 
@@ -137,7 +137,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementDispl
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementDisplayAttribute_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementDisplayAttribute_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->linux_side;
-    params->_ret = iface->GetAchievementDisplayAttribute( params->nGameID, params->pchName, params->pchKey );
+    params->_ret = iface->GetAchievementDisplayAttribute( &params->nGameID, params->pchName, params->pchKey );
     return 0;
 }
 
@@ -145,7 +145,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_IndicateAchievement
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_IndicateAchievementProgress_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_IndicateAchievementProgress_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->linux_side;
-    params->_ret = iface->IndicateAchievementProgress( params->nGameID, params->pchName, params->nCurProgress, params->nMaxProgress );
+    params->_ret = iface->IndicateAchievementProgress( &params->nGameID, params->pchName, params->nCurProgress, params->nMaxProgress );
     return 0;
 }
 

--- a/lsteamclient/cppISteamUser_SteamUser005.cpp
+++ b/lsteamclient/cppISteamUser_SteamUser005.cpp
@@ -145,7 +145,7 @@ NTSTATUS ISteamUser_SteamUser005_InitiateGameConnection( void *args )
 {
     struct ISteamUser_SteamUser005_InitiateGameConnection_params *params = (struct ISteamUser_SteamUser005_InitiateGameConnection_params *)args;
     struct u_ISteamUser_SteamUser005 *iface = (struct u_ISteamUser_SteamUser005 *)params->linux_side;
-    params->_ret = iface->InitiateGameConnection( params->pBlob, params->cbMaxBlob, params->steamID, params->gameID, params->unIPServer, params->usPortServer, params->bSecure );
+    params->_ret = iface->InitiateGameConnection( params->pBlob, params->cbMaxBlob, params->steamID, &params->gameID, params->unIPServer, params->usPortServer, params->bSecure );
     return 0;
 }
 

--- a/lsteamclient/cppISteamUser_SteamUser006.cpp
+++ b/lsteamclient/cppISteamUser_SteamUser006.cpp
@@ -81,7 +81,7 @@ NTSTATUS ISteamUser_SteamUser006_InitiateGameConnection( void *args )
 {
     struct ISteamUser_SteamUser006_InitiateGameConnection_params *params = (struct ISteamUser_SteamUser006_InitiateGameConnection_params *)args;
     struct u_ISteamUser_SteamUser006 *iface = (struct u_ISteamUser_SteamUser006 *)params->linux_side;
-    params->_ret = iface->InitiateGameConnection( params->pBlob, params->cbMaxBlob, params->steamID, params->gameID, params->unIPServer, params->usPortServer, params->bSecure );
+    params->_ret = iface->InitiateGameConnection( params->pBlob, params->cbMaxBlob, params->steamID, &params->gameID, params->unIPServer, params->usPortServer, params->bSecure );
     return 0;
 }
 

--- a/lsteamclient/cppISteamUser_SteamUser007.cpp
+++ b/lsteamclient/cppISteamUser_SteamUser007.cpp
@@ -81,7 +81,7 @@ NTSTATUS ISteamUser_SteamUser007_InitiateGameConnection( void *args )
 {
     struct ISteamUser_SteamUser007_InitiateGameConnection_params *params = (struct ISteamUser_SteamUser007_InitiateGameConnection_params *)args;
     struct u_ISteamUser_SteamUser007 *iface = (struct u_ISteamUser_SteamUser007 *)params->linux_side;
-    params->_ret = iface->InitiateGameConnection( params->pBlob, params->cbMaxBlob, params->steamID, params->gameID, params->unIPServer, params->usPortServer, params->bSecure, params->pvSteam2GetEncryptionKey, params->cbSteam2GetEncryptionKey );
+    params->_ret = iface->InitiateGameConnection( params->pBlob, params->cbMaxBlob, params->steamID, &params->gameID, params->unIPServer, params->usPortServer, params->bSecure, params->pvSteam2GetEncryptionKey, params->cbSteam2GetEncryptionKey );
     return 0;
 }
 

--- a/lsteamclient/cppISteamUser_SteamUser009.cpp
+++ b/lsteamclient/cppISteamUser_SteamUser009.cpp
@@ -33,7 +33,7 @@ NTSTATUS ISteamUser_SteamUser009_InitiateGameConnection( void *args )
 {
     struct ISteamUser_SteamUser009_InitiateGameConnection_params *params = (struct ISteamUser_SteamUser009_InitiateGameConnection_params *)args;
     struct u_ISteamUser_SteamUser009 *iface = (struct u_ISteamUser_SteamUser009 *)params->linux_side;
-    params->_ret = iface->InitiateGameConnection( params->pAuthBlob, params->cbMaxAuthBlob, params->steamIDGameServer, params->gameID, params->unIPServer, params->usPortServer, params->bSecure );
+    params->_ret = iface->InitiateGameConnection( params->pAuthBlob, params->cbMaxAuthBlob, params->steamIDGameServer, &params->gameID, params->unIPServer, params->usPortServer, params->bSecure );
     return 0;
 }
 

--- a/lsteamclient/gen_wrapper.py
+++ b/lsteamclient/gen_wrapper.py
@@ -267,6 +267,17 @@ MANUAL_METHODS = {
     "ISteamUtils_GetAPICallResult": lambda ver, abi: abi == 'u',
 }
 
+INITIATE_GAME_CONNECTION_GAMEID_FIX_INTERFACES = [
+    # 004 has a CGameID parameter, but it is passed by value
+    'ISteamUser_SteamUser005',
+    'ISteamUser_SteamUser006',
+    'ISteamUser_SteamUser007',
+    'ISteamUser_SteamUser008',
+    'ISteamUser_SteamUser009',
+    # Interface versions > 009 dropped the parameter
+    # Interface versions > 020 have this function deprecated
+]
+
 
 DEFINE_INTERFACE_VERSION = re.compile(r'^#define\s*(?P<name>STEAM(?:\w*)_VERSION(?:\w*))\s*"(?P<version>.*)"')
 
@@ -767,7 +778,7 @@ class Class:
             # CGameID -> CGameID &
             # Windows side follows the prototype in the header while Linux
             # steamclient treats gameID parameter as pointer
-            if self.full_name == 'ISteamUser_SteamUser008' \
+            if self.full_name in INITIATE_GAME_CONNECTION_GAMEID_FIX_INTERFACES \
                and method.name == 'InitiateGameConnection':
                 types[3] = 'CGameID *'
 
@@ -1024,9 +1035,9 @@ def handle_method_cpp(method, classname, out):
     # CGameID -> CGameID &
     # Windows side follows the prototype in the header while Linux
     # steamclient treats gameID parameter as pointer
-    if klass.full_name == 'ISteamUser_SteamUser008' \
+    if klass.full_name in INITIATE_GAME_CONNECTION_GAMEID_FIX_INTERFACES \
        and method.name == 'InitiateGameConnection':
-        params[3] = f'&{params[3]}'
+        params[3] = f'&{params[3]}' # CGameID -> CGameID &
 
     out(f'iface->{method.spelling}( {", ".join(params)} );\n')
 

--- a/lsteamclient/gen_wrapper.py
+++ b/lsteamclient/gen_wrapper.py
@@ -781,6 +781,8 @@ class Class:
             if self.full_name in INITIATE_GAME_CONNECTION_GAMEID_FIX_INTERFACES \
                and method.name == 'InitiateGameConnection':
                 types[3] = 'CGameID *'
+            if self.full_name in ['ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001', 'ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002']:
+                types[0] = f'CGameID *'
 
             if type(method) is Destructor:
                 out(f'    virtual ~{prefix}{self.full_name}( {", ".join(types)} ) = 0;\n')
@@ -1038,6 +1040,8 @@ def handle_method_cpp(method, classname, out):
     if klass.full_name in INITIATE_GAME_CONNECTION_GAMEID_FIX_INTERFACES \
        and method.name == 'InitiateGameConnection':
         params[3] = f'&{params[3]}' # CGameID -> CGameID &
+    if klass.full_name in ['ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001', 'ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002']:
+        params[0] = f'&{params[0]}' # CGameID -> CGameID &
 
     out(f'iface->{method.spelling}( {", ".join(params)} );\n')
 

--- a/lsteamclient/unix_private_generated.h
+++ b/lsteamclient/unix_private_generated.h
@@ -286,7 +286,7 @@ struct u_ISteamUser_SteamUser005
     virtual int8_t GetRegistryString( uint32_t, const char *, char *, int32_t ) = 0;
     virtual int8_t SetRegistryInt( uint32_t, const char *, int32_t ) = 0;
     virtual int8_t GetRegistryInt( uint32_t, const char *, int32_t * ) = 0;
-    virtual int32_t InitiateGameConnection( void *, int32_t, CSteamID, CGameID, uint32_t, uint16_t, int8_t ) = 0;
+    virtual int32_t InitiateGameConnection( void *, int32_t, CSteamID, CGameID *, uint32_t, uint16_t, int8_t ) = 0;
     virtual void TerminateGameConnection( uint32_t, uint16_t ) = 0;
     virtual void SetSelfAsPrimaryChatDestination(  ) = 0;
     virtual int8_t IsPrimaryChatDestination(  ) = 0;
@@ -323,7 +323,7 @@ struct u_ISteamUser_SteamUser006
     virtual int8_t GetRegistryString( uint32_t, const char *, char *, int32_t ) = 0;
     virtual int8_t SetRegistryInt( uint32_t, const char *, int32_t ) = 0;
     virtual int8_t GetRegistryInt( uint32_t, const char *, int32_t * ) = 0;
-    virtual int32_t InitiateGameConnection( void *, int32_t, CSteamID, CGameID, uint32_t, uint16_t, int8_t ) = 0;
+    virtual int32_t InitiateGameConnection( void *, int32_t, CSteamID, CGameID *, uint32_t, uint16_t, int8_t ) = 0;
     virtual void TerminateGameConnection( uint32_t, uint16_t ) = 0;
     virtual void TrackAppUsageEvent( CGameID, int32_t, const char * ) = 0;
 #endif /* __cplusplus */
@@ -341,7 +341,7 @@ struct u_ISteamUser_SteamUser007
     virtual int8_t GetRegistryString( uint32_t, const char *, char *, int32_t ) = 0;
     virtual int8_t SetRegistryInt( uint32_t, const char *, int32_t ) = 0;
     virtual int8_t GetRegistryInt( uint32_t, const char *, int32_t * ) = 0;
-    virtual int32_t InitiateGameConnection( void *, int32_t, CSteamID, CGameID, uint32_t, uint16_t, int8_t, void *, int32_t ) = 0;
+    virtual int32_t InitiateGameConnection( void *, int32_t, CSteamID, CGameID *, uint32_t, uint16_t, int8_t, void *, int32_t ) = 0;
     virtual void TerminateGameConnection( uint32_t, uint16_t ) = 0;
     virtual void TrackAppUsageEvent( CGameID, int32_t, const char * ) = 0;
     virtual void RefreshSteam2Login(  ) = 0;
@@ -478,7 +478,7 @@ struct u_ISteamUser_SteamUser009
     virtual int32_t GetHSteamUser(  ) = 0;
     virtual int8_t BLoggedOn(  ) = 0;
     virtual CSteamID GetSteamID(  ) = 0;
-    virtual int32_t InitiateGameConnection( void *, int32_t, CSteamID, CGameID, uint32_t, uint16_t, int8_t ) = 0;
+    virtual int32_t InitiateGameConnection( void *, int32_t, CSteamID, CGameID *, uint32_t, uint16_t, int8_t ) = 0;
     virtual void TerminateGameConnection( uint32_t, uint16_t ) = 0;
     virtual void TrackAppUsageEvent( CGameID, int32_t, const char * ) = 0;
     virtual void RefreshSteam2Login(  ) = 0;

--- a/lsteamclient/unix_private_generated.h
+++ b/lsteamclient/unix_private_generated.h
@@ -169,28 +169,28 @@ struct u_ISteamMatchmakingServers_SteamMatchMakingServers001
 struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION001
 {
 #ifdef __cplusplus
-    virtual uint32_t GetNumStats( CGameID ) = 0;
-    virtual const char * GetStatName( CGameID, uint32_t ) = 0;
-    virtual uint32_t GetStatType( CGameID, const char * ) = 0;
-    virtual uint32_t GetNumAchievements( CGameID ) = 0;
-    virtual const char * GetAchievementName( CGameID, uint32_t ) = 0;
-    virtual uint32_t GetNumGroupAchievements( CGameID ) = 0;
-    virtual const char * GetGroupAchievementName( CGameID, uint32_t ) = 0;
-    virtual int8_t RequestCurrentStats( CGameID ) = 0;
-    virtual int8_t GetStat( CGameID, const char *, int32_t * ) = 0;
-    virtual int8_t GetStat( CGameID, const char *, float * ) = 0;
-    virtual int8_t SetStat( CGameID, const char *, int32_t ) = 0;
-    virtual int8_t SetStat( CGameID, const char *, float ) = 0;
-    virtual int8_t UpdateAvgRateStat( CGameID, const char *, float, double ) = 0;
-    virtual int8_t GetAchievement( CGameID, const char *, int8_t * ) = 0;
-    virtual int8_t GetGroupAchievement( CGameID, const char *, int8_t * ) = 0;
-    virtual int8_t SetAchievement( CGameID, const char * ) = 0;
-    virtual int8_t SetGroupAchievement( CGameID, const char * ) = 0;
-    virtual int8_t StoreStats( CGameID ) = 0;
-    virtual int8_t ClearAchievement( CGameID, const char * ) = 0;
-    virtual int8_t ClearGroupAchievement( CGameID, const char * ) = 0;
-    virtual int32_t GetAchievementIcon( CGameID, const char * ) = 0;
-    virtual const char * GetAchievementDisplayAttribute( CGameID, const char *, const char * ) = 0;
+    virtual uint32_t GetNumStats( CGameID * ) = 0;
+    virtual const char * GetStatName( CGameID *, uint32_t ) = 0;
+    virtual uint32_t GetStatType( CGameID *, const char * ) = 0;
+    virtual uint32_t GetNumAchievements( CGameID * ) = 0;
+    virtual const char * GetAchievementName( CGameID *, uint32_t ) = 0;
+    virtual uint32_t GetNumGroupAchievements( CGameID * ) = 0;
+    virtual const char * GetGroupAchievementName( CGameID *, uint32_t ) = 0;
+    virtual int8_t RequestCurrentStats( CGameID * ) = 0;
+    virtual int8_t GetStat( CGameID *, const char *, int32_t * ) = 0;
+    virtual int8_t GetStat( CGameID *, const char *, float * ) = 0;
+    virtual int8_t SetStat( CGameID *, const char *, int32_t ) = 0;
+    virtual int8_t SetStat( CGameID *, const char *, float ) = 0;
+    virtual int8_t UpdateAvgRateStat( CGameID *, const char *, float, double ) = 0;
+    virtual int8_t GetAchievement( CGameID *, const char *, int8_t * ) = 0;
+    virtual int8_t GetGroupAchievement( CGameID *, const char *, int8_t * ) = 0;
+    virtual int8_t SetAchievement( CGameID *, const char * ) = 0;
+    virtual int8_t SetGroupAchievement( CGameID *, const char * ) = 0;
+    virtual int8_t StoreStats( CGameID * ) = 0;
+    virtual int8_t ClearAchievement( CGameID *, const char * ) = 0;
+    virtual int8_t ClearGroupAchievement( CGameID *, const char * ) = 0;
+    virtual int32_t GetAchievementIcon( CGameID *, const char * ) = 0;
+    virtual const char * GetAchievementDisplayAttribute( CGameID *, const char *, const char * ) = 0;
 #endif /* __cplusplus */
 };
 
@@ -400,24 +400,24 @@ struct u_ISteamFriends_SteamFriends002
 struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002
 {
 #ifdef __cplusplus
-    virtual uint32_t GetNumStats( CGameID ) = 0;
-    virtual const char * GetStatName( CGameID, uint32_t ) = 0;
-    virtual uint32_t GetStatType( CGameID, const char * ) = 0;
-    virtual uint32_t GetNumAchievements( CGameID ) = 0;
-    virtual const char * GetAchievementName( CGameID, uint32_t ) = 0;
-    virtual int8_t RequestCurrentStats( CGameID ) = 0;
-    virtual int8_t GetStat( CGameID, const char *, int32_t * ) = 0;
-    virtual int8_t GetStat( CGameID, const char *, float * ) = 0;
-    virtual int8_t SetStat( CGameID, const char *, int32_t ) = 0;
-    virtual int8_t SetStat( CGameID, const char *, float ) = 0;
-    virtual int8_t UpdateAvgRateStat( CGameID, const char *, float, double ) = 0;
-    virtual int8_t GetAchievement( CGameID, const char *, int8_t * ) = 0;
-    virtual int8_t SetAchievement( CGameID, const char * ) = 0;
-    virtual int8_t ClearAchievement( CGameID, const char * ) = 0;
-    virtual int8_t StoreStats( CGameID ) = 0;
-    virtual int32_t GetAchievementIcon( CGameID, const char * ) = 0;
-    virtual const char * GetAchievementDisplayAttribute( CGameID, const char *, const char * ) = 0;
-    virtual int8_t IndicateAchievementProgress( CGameID, const char *, uint32_t, uint32_t ) = 0;
+    virtual uint32_t GetNumStats( CGameID * ) = 0;
+    virtual const char * GetStatName( CGameID *, uint32_t ) = 0;
+    virtual uint32_t GetStatType( CGameID *, const char * ) = 0;
+    virtual uint32_t GetNumAchievements( CGameID * ) = 0;
+    virtual const char * GetAchievementName( CGameID *, uint32_t ) = 0;
+    virtual int8_t RequestCurrentStats( CGameID * ) = 0;
+    virtual int8_t GetStat( CGameID *, const char *, int32_t * ) = 0;
+    virtual int8_t GetStat( CGameID *, const char *, float * ) = 0;
+    virtual int8_t SetStat( CGameID *, const char *, int32_t ) = 0;
+    virtual int8_t SetStat( CGameID *, const char *, float ) = 0;
+    virtual int8_t UpdateAvgRateStat( CGameID *, const char *, float, double ) = 0;
+    virtual int8_t GetAchievement( CGameID *, const char *, int8_t * ) = 0;
+    virtual int8_t SetAchievement( CGameID *, const char * ) = 0;
+    virtual int8_t ClearAchievement( CGameID *, const char * ) = 0;
+    virtual int8_t StoreStats( CGameID * ) = 0;
+    virtual int32_t GetAchievementIcon( CGameID *, const char * ) = 0;
+    virtual const char * GetAchievementDisplayAttribute( CGameID *, const char *, const char * ) = 0;
+    virtual int8_t IndicateAchievementProgress( CGameID *, const char *, uint32_t, uint32_t ) = 0;
 #endif /* __cplusplus */
 };
 


### PR DESCRIPTION
This addresses most or all of https://github.com/ValveSoftware/Proton/issues/2249, applying the same fix for lsteamclient's InitiateGameConnection in 008 of ISteamUser to the 005, 006, 007, and 009 versions of the interface. Disassembly shows the same compiler optimization is present on these as well, which is consistent with the issues reported. Newer versions of this interface dropped the CGameID parameter and are implicitly unaffected. Version 004 has a CGameID parameter, but it doesn't appear to perform the same dereferencing. Without the fix, calls to `ISteamUser::InitiateGameConnection` on the affected interface versions most frequently lead to a crash, or at best, authentication will just fail, quickly leading to a disconnect. In testing with the fix, a crash no longer occurred on server connection in NEOTOKYO (Steam app 244630), a Source SDK 2006 mod. The crash is reproducible on Proton 9.0-4.

Edit: Per my findings on that same issue, [here](https://github.com/ValveSoftware/Proton/issues/2249#issuecomment-2574145219) - The same fix is also applied to all of the ISteamUsersStats001 and 002 interface functions. I admit that I didn't manually check every function on every version of those two very old (pre-1.00) interface versions, but they all have a first parameter of CGameID, and the 12 or so function versions I didn't at did have the dereferencing issue present. In testing, this fixed the startup crash reported in that issue with the mod version of Black Mesa on Source SDK 2007. I also confirmed that the achievements panel opened and displayed properly.

This is my first contribution to this repo, so please let me know if I missed anything required. I didn't see any contributing guidelines.

For reference, https://github.com/ValveSoftware/Proton/issues/2249#issuecomment-2574115896

> 
> Part of the original issue reported here, creating/joining servers on Source 2007 mods, was fixed a couple of years ago, in cd60b70
> 
> I'm not sure about the achievements issue. There may still be a problem there, judging by ISteamUserStats crash still being reported in #2249 (comment) earlier this year.
> 
> There are other reports in this thread citing the same or similar issues in Source 2006 mods. Part of that is because the server connect fix for the Source 2007 mods was only applied for the specific version of the ISteamUser interface that they target. However, the version targeted by Source 2006 mods, as well as a couple of other versions of the interface are also affected by the same issue.