### PR TITLE
Switch blank video from smpte to a missing-codecs message

### DIFF
--- a/media/Makefile
+++ b/media/Makefile
@@ -2,7 +2,7 @@ all: blank.mkv blank.ptna
 
 blank.mkv:
 	#120 frames @ 30 FPS == 4 seconds
-	gst-launch-1.0 videotestsrc num-buffers=120 pattern=smpte ! 'video/x-raw,format=(string)I420,width=320,height=240,framerate=(fraction)30/1' ! av1enc ! queue ! mux. audiotestsrc num-buffers=400 freq=0 samplesperbuffer=441 ! 'audio/x-raw,rate=48000,channels=2' ! opusenc ! queue ! mux. matroskamux name=mux ! filesink location=blank.mkv
+	gst-launch-1.0 videotestsrc num-buffers=160 horizontal-speed=2 ! 'video/x-raw,format=(string)I420,width=320,height=240,framerate=(fraction)30/1' ! textoverlay text="Missing audio or video codecs" valignment=center font-desc="Sans 32" ! av1enc ! queue ! mux. audiotestsrc num-buffers=400 wave=silence samplesperbuffer=441 ! 'audio/x-raw,rate=48000,channels=2' ! opusenc ! queue ! mux. matroskamux name=mux ! filesink location=blank.mkv
 
 make_blank_ptna: make_blank_ptna.c
 	gcc -Wall -O2 $(shell pkg-config --cflags opus) -o $@ $< -lm $(shell pkg-config --libs opus)


### PR DESCRIPTION
/r/linux_gaming and other forums regularly get posts asking about "weird colors" in games with cutscenes:

https://www.reddit.com/r/linux_gaming/comments/1kf59i6/fragpunk_showing_weird_colors/

https://www.reddit.com/r/linux_gaming/comments/1k47643/blue_prince_game_launches_but_when_i_click_new/ 

https://www.reddit.com/r/linux_gaming/comments/1ftevcl/star_wars_jedi_survivor_is_giving_me_a_weird/

Putting a message in there is probably more useful.

Also switch audio to use wave=silence, which is more correct.

This is what the video will look like after this change: 
![image](https://github.com/user-attachments/assets/ffedf722-e5a0-4c2b-899e-e5b55970230e). As a bonus, the video will also be smaller.

