### PR TITLE
configure.sh: Fix default build-name (regression introduced in 82eb0051)

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -117,7 +117,8 @@ function configure() {
   if [[ -n $build_name ]]; then
     info "Configuring with build name: $build_name"
   else
-    build_name="$DEFAULT_BUILD_NAME" info "No build name specified, using default: $build_name"
+    build_name="$DEFAULT_BUILD_NAME"
+    info "No build name specified, using default: $build_name"
   fi
 
   if [[ ${build_name,,} == *proton* ]]; then


### PR DESCRIPTION
Have to put setting environment variable on its own line as otherwise it just just sets that value for that one line.