### PR TITLE
VRClientCoreFactory (and presumably HmdSystemFactory) need to be cdecl to match OpenVR SDK (Closes 8749)

### DIFF
--- a/vrclient_x64/vrclient.spec
+++ b/vrclient_x64/vrclient.spec
@@ -1,6 +1,6 @@
 # Generated from vrclient.dll by winedump
 
-1 stdcall HmdSystemFactory(ptr ptr)
-2 stdcall VRClientCoreFactory(ptr ptr)
+1 cdecl HmdSystemFactory(ptr ptr)
+2 cdecl VRClientCoreFactory(ptr ptr)
 
 @ cdecl -private vrclient_init_registry()

--- a/vrclient_x64/vrclient_main.c
+++ b/vrclient_x64/vrclient_main.c
@@ -180,7 +180,7 @@ static int load_vrclient(void)
     return vrclient_loaded;
 }
 
-void * __stdcall HmdSystemFactory(const char *name, int *return_code)
+void *CDECL HmdSystemFactory(const char *name, int *return_code)
 {
     struct vrclient_HmdSystemFactory_params params = {.name = name, .return_code = return_code};
     TRACE("name: %s, return_code: %p\n", name, return_code);
@@ -189,7 +189,7 @@ void * __stdcall HmdSystemFactory(const char *name, int *return_code)
     return create_win_interface( name, params._ret );
 }
 
-void * __stdcall VRClientCoreFactory(const char *name, int *return_code)
+void *CDECL VRClientCoreFactory(const char *name, int *return_code)
 {
     struct vrclient_VRClientCoreFactory_params params = {.name = name, .return_code = return_code};
     TRACE("name: %s, return_code: %p\n", name, return_code);


### PR DESCRIPTION
The `VRClientCoreFactory` function is declared in the [OpenVR SDK](https://github.com/ValveSoftware/openvr/blob/master/src/openvr_api_public.cpp#L43C1-L44C1) without a calling convention. According to Microsoft [cdecl is the default calling convention for C and C++ functions](https://learn.microsoft.com/en-us/cpp/cpp/cdecl?view=msvc-170), so this means that the user side needs VRClientCoreFactory to be cdecl and not stdcall. This only affects x86 as the compiler ignores `stdcall` and `cdecl` when compiling for x64 mode. Without this the calling `VR_Init` from x86 code crashes.

Also switched the spec file to be `cdecl` to get rid of some longstanding linker warnings. Presumably it didn't matter that these were wrong as `VRClientCoreFactory` is only called by the OpenVR SDK `VR_Init`, which manually loads the library, performing an explicit symbol lookup, and calls through a `cdecl` function pointer.