### PR TITLE
Add support for Banter which uses an in app browser from vuplex. 

### DIFF
--- a/proton
+++ b/proton
@@ -1278,6 +1278,7 @@ def default_compat_config():
                 "3314070", #The Sims 2 Legacy Collection
                 "2709570", #Supermarket Together
                 "2623190", #The Elder Scrolls IV: Oblivion Remastered
+                "2564460", #Banter
                 ]:
             ret.add("gamedrive")
 


### PR DESCRIPTION
This is instead of the PR into Proton 9: https://github.com/ValveSoftware/Proton/pull/8337