### PR TITLE
Fix libraryfolders.vdf index incrementing in setup_steam_files

### DIFF
--- a/steam_helper/steam.c
+++ b/steam_helper/steam.c
@@ -648,6 +648,7 @@ static void setup_steam_files(void)
         else
         {
             pos += strappend( &buf, &buf_size, pos, "\t\"%u\"\n\t{\n\t\t\"path\"\t\t\"%s\"\n\t}\n", index, str );
+            ++index;
             free( str );
         }
     }
@@ -671,6 +672,7 @@ static void setup_steam_files(void)
         else
         {
             pos += strappend( &buf, &buf_size, pos, "\t\"%u\"\n\t{\n\t\t\"path\"\t\t\"%s\"\n\t}\n", index, str );
+            ++index;
             free( str );
         }
         free( path );


### PR DESCRIPTION
- Add missing ++index statements after each library folder entry
- Fixes issue where all library folders were assigned index 0
- Resolves compatibility issues with ModEngine2 and other parsers
- Restores behavior consistent with Proton 9.0

Fixes #8899