### PR TITLE
lsteamclient: Fix crash on ISteamUserStats version 2

### DIFF
--- a/lsteamclient/cppISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002.cpp
+++ b/lsteamclient/cppISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002.cpp
@@ -9,7 +9,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetNumStats( void *
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetNumStats_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetNumStats_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->GetNumStats( params->nGameID );
+    params->_ret = iface->GetNumStats( &params->nGameID );
     return 0;
 }
 
@@ -18,7 +18,7 @@ NTSTATUS wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetNumStats( 
 {
     struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetNumStats_params *params = (struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetNumStats_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->GetNumStats( params->nGameID );
+    params->_ret = iface->GetNumStats( &params->nGameID );
     return 0;
 }
 #endif
@@ -27,7 +27,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStatName( void *
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStatName_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStatName_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->GetStatName( params->nGameID, params->iStat );
+    params->_ret = iface->GetStatName( &params->nGameID, params->iStat );
     return 0;
 }
 
@@ -36,7 +36,7 @@ NTSTATUS wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStatName( 
 {
     struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStatName_params *params = (struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStatName_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->GetStatName( params->nGameID, params->iStat );
+    params->_ret = iface->GetStatName( &params->nGameID, params->iStat );
     return 0;
 }
 #endif
@@ -45,7 +45,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStatType( void *
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStatType_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStatType_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->GetStatType( params->nGameID, params->pchName );
+    params->_ret = iface->GetStatType( &params->nGameID, params->pchName );
     return 0;
 }
 
@@ -54,7 +54,7 @@ NTSTATUS wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStatType( 
 {
     struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStatType_params *params = (struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStatType_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->GetStatType( params->nGameID, params->pchName );
+    params->_ret = iface->GetStatType( &params->nGameID, params->pchName );
     return 0;
 }
 #endif
@@ -63,7 +63,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetNumAchievements(
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetNumAchievements_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetNumAchievements_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->GetNumAchievements( params->nGameID );
+    params->_ret = iface->GetNumAchievements( &params->nGameID );
     return 0;
 }
 
@@ -72,7 +72,7 @@ NTSTATUS wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetNumAchieve
 {
     struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetNumAchievements_params *params = (struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetNumAchievements_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->GetNumAchievements( params->nGameID );
+    params->_ret = iface->GetNumAchievements( &params->nGameID );
     return 0;
 }
 #endif
@@ -81,7 +81,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementName(
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementName_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementName_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->GetAchievementName( params->nGameID, params->iAchievement );
+    params->_ret = iface->GetAchievementName( &params->nGameID, params->iAchievement );
     return 0;
 }
 
@@ -90,7 +90,7 @@ NTSTATUS wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievemen
 {
     struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementName_params *params = (struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementName_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->GetAchievementName( params->nGameID, params->iAchievement );
+    params->_ret = iface->GetAchievementName( &params->nGameID, params->iAchievement );
     return 0;
 }
 #endif
@@ -99,7 +99,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_RequestCurrentStats
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_RequestCurrentStats_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_RequestCurrentStats_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->RequestCurrentStats( params->nGameID );
+    params->_ret = iface->RequestCurrentStats( &params->nGameID );
     return 0;
 }
 
@@ -108,7 +108,7 @@ NTSTATUS wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_RequestCurren
 {
     struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_RequestCurrentStats_params *params = (struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_RequestCurrentStats_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->RequestCurrentStats( params->nGameID );
+    params->_ret = iface->RequestCurrentStats( &params->nGameID );
     return 0;
 }
 #endif
@@ -117,7 +117,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStat( void *args
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStat_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStat_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->GetStat( params->nGameID, params->pchName, params->pData );
+    params->_ret = iface->GetStat( &params->nGameID, params->pchName, params->pData );
     return 0;
 }
 
@@ -126,7 +126,7 @@ NTSTATUS wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStat( void
 {
     struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStat_params *params = (struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStat_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->GetStat( params->nGameID, params->pchName, params->pData );
+    params->_ret = iface->GetStat( &params->nGameID, params->pchName, params->pData );
     return 0;
 }
 #endif
@@ -135,7 +135,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStat_2( void *ar
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStat_2_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStat_2_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->GetStat( params->nGameID, params->pchName, params->pData );
+    params->_ret = iface->GetStat( &params->nGameID, params->pchName, params->pData );
     return 0;
 }
 
@@ -144,7 +144,7 @@ NTSTATUS wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStat_2( vo
 {
     struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStat_2_params *params = (struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetStat_2_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->GetStat( params->nGameID, params->pchName, params->pData );
+    params->_ret = iface->GetStat( &params->nGameID, params->pchName, params->pData );
     return 0;
 }
 #endif
@@ -153,7 +153,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetStat( void *args
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetStat_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetStat_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->SetStat( params->nGameID, params->pchName, params->nData );
+    params->_ret = iface->SetStat( &params->nGameID, params->pchName, params->nData );
     return 0;
 }
 
@@ -162,7 +162,7 @@ NTSTATUS wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetStat( void
 {
     struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetStat_params *params = (struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetStat_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->SetStat( params->nGameID, params->pchName, params->nData );
+    params->_ret = iface->SetStat( &params->nGameID, params->pchName, params->nData );
     return 0;
 }
 #endif
@@ -171,7 +171,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetStat_2( void *ar
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetStat_2_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetStat_2_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->SetStat( params->nGameID, params->pchName, params->fData );
+    params->_ret = iface->SetStat( &params->nGameID, params->pchName, params->fData );
     return 0;
 }
 
@@ -180,7 +180,7 @@ NTSTATUS wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetStat_2( vo
 {
     struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetStat_2_params *params = (struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetStat_2_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->SetStat( params->nGameID, params->pchName, params->fData );
+    params->_ret = iface->SetStat( &params->nGameID, params->pchName, params->fData );
     return 0;
 }
 #endif
@@ -189,7 +189,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_UpdateAvgRateStat( 
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_UpdateAvgRateStat_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_UpdateAvgRateStat_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->UpdateAvgRateStat( params->nGameID, params->pchName, params->flCountThisSession, params->dSessionLength );
+    params->_ret = iface->UpdateAvgRateStat( &params->nGameID, params->pchName, params->flCountThisSession, params->dSessionLength );
     return 0;
 }
 
@@ -198,7 +198,7 @@ NTSTATUS wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_UpdateAvgRate
 {
     struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_UpdateAvgRateStat_params *params = (struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_UpdateAvgRateStat_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->UpdateAvgRateStat( params->nGameID, params->pchName, params->flCountThisSession, params->dSessionLength );
+    params->_ret = iface->UpdateAvgRateStat( &params->nGameID, params->pchName, params->flCountThisSession, params->dSessionLength );
     return 0;
 }
 #endif
@@ -207,7 +207,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievement( voi
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievement_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievement_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->GetAchievement( params->nGameID, params->pchName, params->pbAchieved );
+    params->_ret = iface->GetAchievement( &params->nGameID, params->pchName, params->pbAchieved );
     return 0;
 }
 
@@ -216,7 +216,7 @@ NTSTATUS wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievemen
 {
     struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievement_params *params = (struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievement_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->GetAchievement( params->nGameID, params->pchName, params->pbAchieved );
+    params->_ret = iface->GetAchievement( &params->nGameID, params->pchName, params->pbAchieved );
     return 0;
 }
 #endif
@@ -225,7 +225,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetAchievement( voi
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetAchievement_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetAchievement_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->SetAchievement( params->nGameID, params->pchName );
+    params->_ret = iface->SetAchievement( &params->nGameID, params->pchName );
     return 0;
 }
 
@@ -234,7 +234,7 @@ NTSTATUS wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetAchievemen
 {
     struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetAchievement_params *params = (struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_SetAchievement_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->SetAchievement( params->nGameID, params->pchName );
+    params->_ret = iface->SetAchievement( &params->nGameID, params->pchName );
     return 0;
 }
 #endif
@@ -243,7 +243,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_ClearAchievement( v
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_ClearAchievement_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_ClearAchievement_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->ClearAchievement( params->nGameID, params->pchName );
+    params->_ret = iface->ClearAchievement( &params->nGameID, params->pchName );
     return 0;
 }
 
@@ -252,7 +252,7 @@ NTSTATUS wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_ClearAchievem
 {
     struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_ClearAchievement_params *params = (struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_ClearAchievement_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->ClearAchievement( params->nGameID, params->pchName );
+    params->_ret = iface->ClearAchievement( &params->nGameID, params->pchName );
     return 0;
 }
 #endif
@@ -261,7 +261,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_StoreStats( void *a
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_StoreStats_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_StoreStats_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->StoreStats( params->nGameID );
+    params->_ret = iface->StoreStats( &params->nGameID );
     return 0;
 }
 
@@ -270,7 +270,7 @@ NTSTATUS wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_StoreStats( v
 {
     struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_StoreStats_params *params = (struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_StoreStats_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->StoreStats( params->nGameID );
+    params->_ret = iface->StoreStats( &params->nGameID );
     return 0;
 }
 #endif
@@ -279,7 +279,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementIcon(
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementIcon_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementIcon_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->GetAchievementIcon( params->nGameID, params->pchName );
+    params->_ret = iface->GetAchievementIcon( &params->nGameID, params->pchName );
     return 0;
 }
 
@@ -288,7 +288,7 @@ NTSTATUS wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievemen
 {
     struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementIcon_params *params = (struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementIcon_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->GetAchievementIcon( params->nGameID, params->pchName );
+    params->_ret = iface->GetAchievementIcon( &params->nGameID, params->pchName );
     return 0;
 }
 #endif
@@ -297,7 +297,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementDispl
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementDisplayAttribute_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementDisplayAttribute_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->GetAchievementDisplayAttribute( params->nGameID, params->pchName, params->pchKey );
+    params->_ret = iface->GetAchievementDisplayAttribute( &params->nGameID, params->pchName, params->pchKey );
     return 0;
 }
 
@@ -306,7 +306,7 @@ NTSTATUS wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievemen
 {
     struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementDisplayAttribute_params *params = (struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_GetAchievementDisplayAttribute_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->GetAchievementDisplayAttribute( params->nGameID, params->pchName, params->pchKey );
+    params->_ret = iface->GetAchievementDisplayAttribute( &params->nGameID, params->pchName, params->pchKey );
     return 0;
 }
 #endif
@@ -315,7 +315,7 @@ NTSTATUS ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_IndicateAchievement
 {
     struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_IndicateAchievementProgress_params *params = (struct ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_IndicateAchievementProgress_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->IndicateAchievementProgress( params->nGameID, params->pchName, params->nCurProgress, params->nMaxProgress );
+    params->_ret = iface->IndicateAchievementProgress( &params->nGameID, params->pchName, params->nCurProgress, params->nMaxProgress );
     return 0;
 }
 
@@ -324,7 +324,7 @@ NTSTATUS wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_IndicateAchie
 {
     struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_IndicateAchievementProgress_params *params = (struct wow64_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002_IndicateAchievementProgress_params *)args;
     struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *iface = (struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002 *)params->u_iface;
-    params->_ret = iface->IndicateAchievementProgress( params->nGameID, params->pchName, params->nCurProgress, params->nMaxProgress );
+    params->_ret = iface->IndicateAchievementProgress( &params->nGameID, params->pchName, params->nCurProgress, params->nMaxProgress );
     return 0;
 }
 #endif

--- a/lsteamclient/gen_wrapper.py
+++ b/lsteamclient/gen_wrapper.py
@@ -835,6 +835,9 @@ class Class:
                and method.name == 'InitiateGameConnection':
                 types[3] = 'CGameID *'
 
+            if self.full_name == 'ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002':
+                types[0] = 'CGameID *'
+
             if type(method) is Destructor:
                 out(f'    virtual ~{prefix}{self.full_name}( {", ".join(types)} ) = 0;\n')
             else:
@@ -1121,6 +1124,9 @@ def handle_method_cpp(method, classname, out, wow64):
     if klass.full_name == 'ISteamUser_SteamUser008' \
        and method.name == 'InitiateGameConnection':
         params[3] = f'&{params[3]}'
+
+    if klass.full_name == 'ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002':
+        params[0] = f'&{params[0]}'
 
     out(f'iface->{method.spelling}( {", ".join(params)} );\n')
 

--- a/lsteamclient/unix_private_generated.h
+++ b/lsteamclient/unix_private_generated.h
@@ -400,24 +400,24 @@ struct u_ISteamFriends_SteamFriends002
 struct u_ISteamUserStats_STEAMUSERSTATS_INTERFACE_VERSION002
 {
 #ifdef __cplusplus
-    virtual uint32_t GetNumStats( CGameID ) = 0;
-    virtual const char * GetStatName( CGameID, uint32_t ) = 0;
-    virtual uint32_t GetStatType( CGameID, const char * ) = 0;
-    virtual uint32_t GetNumAchievements( CGameID ) = 0;
-    virtual const char * GetAchievementName( CGameID, uint32_t ) = 0;
-    virtual int8_t RequestCurrentStats( CGameID ) = 0;
-    virtual int8_t GetStat( CGameID, const char *, int32_t * ) = 0;
-    virtual int8_t GetStat( CGameID, const char *, float * ) = 0;
-    virtual int8_t SetStat( CGameID, const char *, int32_t ) = 0;
-    virtual int8_t SetStat( CGameID, const char *, float ) = 0;
-    virtual int8_t UpdateAvgRateStat( CGameID, const char *, float, double ) = 0;
-    virtual int8_t GetAchievement( CGameID, const char *, int8_t * ) = 0;
-    virtual int8_t SetAchievement( CGameID, const char * ) = 0;
-    virtual int8_t ClearAchievement( CGameID, const char * ) = 0;
-    virtual int8_t StoreStats( CGameID ) = 0;
-    virtual int32_t GetAchievementIcon( CGameID, const char * ) = 0;
-    virtual const char * GetAchievementDisplayAttribute( CGameID, const char *, const char * ) = 0;
-    virtual int8_t IndicateAchievementProgress( CGameID, const char *, uint32_t, uint32_t ) = 0;
+    virtual uint32_t GetNumStats( CGameID * ) = 0;
+    virtual const char * GetStatName( CGameID *, uint32_t ) = 0;
+    virtual uint32_t GetStatType( CGameID *, const char * ) = 0;
+    virtual uint32_t GetNumAchievements( CGameID * ) = 0;
+    virtual const char * GetAchievementName( CGameID *, uint32_t ) = 0;
+    virtual int8_t RequestCurrentStats( CGameID * ) = 0;
+    virtual int8_t GetStat( CGameID *, const char *, int32_t * ) = 0;
+    virtual int8_t GetStat( CGameID *, const char *, float * ) = 0;
+    virtual int8_t SetStat( CGameID *, const char *, int32_t ) = 0;
+    virtual int8_t SetStat( CGameID *, const char *, float ) = 0;
+    virtual int8_t UpdateAvgRateStat( CGameID *, const char *, float, double ) = 0;
+    virtual int8_t GetAchievement( CGameID *, const char *, int8_t * ) = 0;
+    virtual int8_t SetAchievement( CGameID *, const char * ) = 0;
+    virtual int8_t ClearAchievement( CGameID *, const char * ) = 0;
+    virtual int8_t StoreStats( CGameID * ) = 0;
+    virtual int32_t GetAchievementIcon( CGameID *, const char * ) = 0;
+    virtual const char * GetAchievementDisplayAttribute( CGameID *, const char *, const char * ) = 0;
+    virtual int8_t IndicateAchievementProgress( CGameID *, const char *, uint32_t, uint32_t ) = 0;
 #endif /* __cplusplus */
 };
 


### PR DESCRIPTION
Applies the same changes as done in 09846111b.

Might need to be extended for other versions as well.
Fixes #8979 (Ninja Reflex: Steamworks Edition)