### PR TITLE
Add block for Call of Duty: Black Ops Cold War (1985810)

### DIFF
--- a/proton
+++ b/proton
@@ -1878,6 +1878,10 @@ class Session:
         else:
             argv = [g_proton.wine64_bin, "c:\\windows\\system32\\steam.exe"]
 
+        # CoD: Black Ops Cold War block to prevent game bans
+        if os.environ.get("SteamGameId", 0) == "1985810":
+            sys.exit(0)
+
         rc = self.run_proc(adverb + argv + sys.argv[2:] + self.cmdlineappend)
 
         if remote_debug_proc:


### PR DESCRIPTION
Many people on [ProtonDB](https://www.protondb.com/app/1985810) have reported that just launching the game alone can get you banned and Activision does not reverse these bans. This issue has been around ever since Proton has been able to launch the game, so I made this quick fix so we can prevent more players from being banned.

This is my first open-source contribution, so if I did anything wrong, please let me know. I want to be able to make good contributions in the future.