### PR TITLE
wineopenxr: Implement Win32 performance counter time conversion functions for MSFS2020 VR Controller Tracking

### DIFF
--- a/wineopenxr/loader_thunks.c
+++ b/wineopenxr/loader_thunks.c
@@ -170,6 +170,30 @@ XrResult WINAPI xrComputeNewSceneMSFT(XrSceneObserverMSFT sceneObserver, const X
     return params.result;
 }
 
+XrResult WINAPI xrConvertTimeToWin32PerformanceCounterKHR(XrInstance instance, XrTime time, LARGE_INTEGER *performanceCounter)
+{
+    struct xrConvertTimeToWin32PerformanceCounterKHR_params params;
+    NTSTATUS _status;
+    params.instance = instance;
+    params.time = time;
+    params.performanceCounter = performanceCounter;
+    _status = UNIX_CALL(xrConvertTimeToWin32PerformanceCounterKHR, &params);
+    assert(!_status && "xrConvertTimeToWin32PerformanceCounterKHR");
+    return params.result;
+}
+
+XrResult WINAPI xrConvertWin32PerformanceCounterToTimeKHR(XrInstance instance, const LARGE_INTEGER *performanceCounter, XrTime *time)
+{
+    struct xrConvertWin32PerformanceCounterToTimeKHR_params params;
+    NTSTATUS _status;
+    params.instance = instance;
+    params.performanceCounter = performanceCounter;
+    params.time = time;
+    _status = UNIX_CALL(xrConvertWin32PerformanceCounterToTimeKHR, &params);
+    assert(!_status && "xrConvertWin32PerformanceCounterToTimeKHR");
+    return params.result;
+}
+
 XrResult WINAPI xrCreateAction(XrActionSet actionSet, const XrActionCreateInfo *createInfo, XrAction *action)
 {
     struct xrCreateAction_params params;

--- a/wineopenxr/loader_thunks.h
+++ b/wineopenxr/loader_thunks.h
@@ -40,6 +40,8 @@ enum unix_call
     unix_xrChangeVirtualKeyboardTextContextMETA,
     unix_xrClearSpatialAnchorStoreMSFT,
     unix_xrComputeNewSceneMSFT,
+    unix_xrConvertTimeToWin32PerformanceCounterKHR,
+    unix_xrConvertWin32PerformanceCounterToTimeKHR,
     unix_xrCreateAction,
     unix_xrCreateActionSet,
     unix_xrCreateActionSpace,
@@ -529,6 +531,22 @@ struct xrComputeNewSceneMSFT_params
 {
     XrSceneObserverMSFT sceneObserver;
     const XrNewSceneComputeInfoMSFT *computeInfo;
+    XrResult result;
+};
+
+struct xrConvertTimeToWin32PerformanceCounterKHR_params
+{
+    XrInstance instance;
+    XrTime time;
+    LARGE_INTEGER *performanceCounter;
+    XrResult result;
+};
+
+struct xrConvertWin32PerformanceCounterToTimeKHR_params
+{
+    XrInstance instance;
+    const LARGE_INTEGER *performanceCounter;
+    XrTime *time;
     XrResult result;
 };
 

--- a/wineopenxr/make_openxr
+++ b/wineopenxr/make_openxr
@@ -148,8 +148,6 @@ MANUAL_UNIX_THUNKS = {
 
 # loader functions which are entirely manually implemented
 MANUAL_LOADER_FUNCTIONS = {
-    "xrConvertTimeToWin32PerformanceCounterKHR",
-    "xrConvertWin32PerformanceCounterToTimeKHR",
     "xrGetD3D11GraphicsRequirementsKHR",
     "xrGetD3D12GraphicsRequirementsKHR",
     "xrCreateApiLayerInstance",

--- a/wineopenxr/openxr.c
+++ b/wineopenxr/openxr.c
@@ -4,6 +4,7 @@
 
 #define _GNU_SOURCE
 #include <dlfcn.h>
+#include <time.h>
 
 #include "ntstatus.h"
 #define WIN32_NO_STATUS
@@ -24,6 +25,12 @@ static struct {
     {"XR_KHR_D3D12_enable", "XR_KHR_vulkan_enable"},
     {"XR_KHR_win32_convert_performance_counter_time", "XR_KHR_convert_timespec_time", TRUE, TRUE},
 };
+
+/* Function pointers for timespec conversion, NULL if not available. */
+typedef XrResult (*PFN_xrConvertTimespecTimeToTimeKHR)(XrInstance, const struct timespec *, XrTime *);
+typedef XrResult (*PFN_xrConvertTimeToTimespecTimeKHR)(XrInstance, XrTime, struct timespec *);
+static PFN_xrConvertTimespecTimeToTimeKHR p_xrConvertTimespecTimeToTimeKHR = NULL;
+static PFN_xrConvertTimeToTimespecTimeKHR p_xrConvertTimeToTimespecTimeKHR = NULL;
 
 struct openxr_instance_funcs g_xr_host_instance_dispatch_table;
 
@@ -87,6 +94,12 @@ XrResult WINAPI wine_xrCreateInstance(const XrInstanceCreateInfo *createInfo, Xr
   xrGetInstanceProcAddr(*instance, #x, (PFN_xrVoidFunction *)&g_xr_host_instance_dispatch_table.p_##x);
   ALL_XR_INSTANCE_FUNCS()
 #undef USE_XR_FUNC
+
+  /* These will be NULL if XR_KHR_convert_timespec_time is not available. */
+  xrGetInstanceProcAddr(*instance, "xrConvertTimespecTimeToTimeKHR",
+                        (PFN_xrVoidFunction *)&p_xrConvertTimespecTimeToTimeKHR);
+  xrGetInstanceProcAddr(*instance, "xrConvertTimeToTimespecTimeKHR",
+                        (PFN_xrVoidFunction *)&p_xrConvertTimeToTimespecTimeKHR);
 
 cleanup:
   free((void *)our_createInfo.enabledExtensionNames);
@@ -379,4 +392,77 @@ NTSTATUS init_openxr(void *args) {
   params->create_device_callback = (UINT64)&vk_create_device_callback;
 
   return STATUS_SUCCESS;
+}
+
+/* Constants for time conversion - matches Wine's ntdll/unix/sync.c */
+#define NANOSECONDS_IN_A_SECOND 1000000000LL
+#define TICKSPERSEC             10000000LL
+
+/*
+ * Convert Win32 QPC ticks to XrTime using the native xrConvertTimespecTimeToTimeKHR.
+ * Wine's QPC is based on CLOCK_MONOTONIC with 100ns (10MHz) ticks.
+ */
+XrResult wine_xrConvertWin32PerformanceCounterToTimeKHR(XrInstance instance,
+                                                        const LARGE_INTEGER *performanceCounter,
+                                                        XrTime *time) {
+  wine_XrInstance *wine_instance = wine_instance_from_handle(instance);
+  struct timespec ts;
+  XrResult res;
+
+  TRACE("instance %p, performanceCounter %p (%lld), time %p\n",
+        instance, performanceCounter,
+        performanceCounter ? (long long)performanceCounter->QuadPart : 0, time);
+
+  if (!performanceCounter || !time)
+    return XR_ERROR_VALIDATION_FAILURE;
+
+  if (!p_xrConvertTimespecTimeToTimeKHR) {
+    WARN("XR_KHR_convert_timespec_time not available, cannot convert time.\n");
+    return XR_ERROR_FUNCTION_UNSUPPORTED;
+  }
+
+  /* Convert QPC ticks to timespec (Wine QPC is 10MHz = 100ns ticks). */
+  ts.tv_sec = performanceCounter->QuadPart / TICKSPERSEC;
+  ts.tv_nsec = (performanceCounter->QuadPart % TICKSPERSEC) * (NANOSECONDS_IN_A_SECOND / TICKSPERSEC);
+
+  res = p_xrConvertTimespecTimeToTimeKHR(wine_instance->host_instance, &ts, time);
+  if (res != XR_SUCCESS)
+    WARN("xrConvertTimespecTimeToTimeKHR failed: %d\n", res);
+
+  return res;
+}
+
+/*
+ * Convert XrTime to Win32 QPC ticks using the native xrConvertTimeToTimespecTimeKHR.
+ * Wine's QPC is based on CLOCK_MONOTONIC with 100ns (10MHz) ticks.
+ */
+XrResult wine_xrConvertTimeToWin32PerformanceCounterKHR(XrInstance instance,
+                                                        XrTime time,
+                                                        LARGE_INTEGER *performanceCounter) {
+  wine_XrInstance *wine_instance = wine_instance_from_handle(instance);
+  struct timespec ts;
+  XrResult res;
+
+  TRACE("instance %p, time %lld, performanceCounter %p\n",
+        instance, (long long)time, performanceCounter);
+
+  if (!performanceCounter)
+    return XR_ERROR_VALIDATION_FAILURE;
+
+  if (!p_xrConvertTimeToTimespecTimeKHR) {
+    WARN("XR_KHR_convert_timespec_time not available, cannot convert time.\n");
+    return XR_ERROR_FUNCTION_UNSUPPORTED;
+  }
+
+  res = p_xrConvertTimeToTimespecTimeKHR(wine_instance->host_instance, time, &ts);
+  if (res != XR_SUCCESS) {
+    WARN("xrConvertTimeToTimespecTimeKHR failed: %d\n", res);
+    return res;
+  }
+
+  /* Convert timespec to QPC ticks (Wine QPC is 10MHz = 100ns ticks). */
+  performanceCounter->QuadPart = ts.tv_sec * TICKSPERSEC +
+                                 ts.tv_nsec / (NANOSECONDS_IN_A_SECOND / TICKSPERSEC);
+
+  return XR_SUCCESS;
 }

--- a/wineopenxr/openxr_loader.c
+++ b/wineopenxr/openxr_loader.c
@@ -1667,22 +1667,6 @@ XrResult WINAPI xrEndFrame(XrSession session, const XrFrameEndInfo *frameEndInfo
   return params.result;
 }
 
-XrResult WINAPI xrConvertTimeToWin32PerformanceCounterKHR(XrInstance instance,
-                                                          XrTime time,
-                                                          LARGE_INTEGER *performanceCounter) {
-  FIXME("unimplemented\n");
-  /* FIXME */
-  return XR_ERROR_INITIALIZATION_FAILED;
-}
-
-XrResult WINAPI xrConvertWin32PerformanceCounterToTimeKHR(XrInstance instance,
-                                                          const LARGE_INTEGER *performanceCounter,
-                                                          XrTime *time) {
-  FIXME("unimplemented\n");
-  /* FIXME */
-  return XR_ERROR_INITIALIZATION_FAILED;
-}
-
 XrResult WINAPI xrGetD3D11GraphicsRequirementsKHR(XrInstance instance,
                                                   XrSystemId systemId,
                                                   XrGraphicsRequirementsD3D11KHR *graphicsRequirements) {

--- a/wineopenxr/openxr_thunks.c
+++ b/wineopenxr/openxr_thunks.c
@@ -252,6 +252,30 @@ static NTSTATUS thunk64_xrComputeNewSceneMSFT(void *args)
 #endif /* _WIN64 */
 
 #ifdef _WIN64
+static NTSTATUS thunk64_xrConvertTimeToWin32PerformanceCounterKHR(void *args)
+{
+    struct xrConvertTimeToWin32PerformanceCounterKHR_params *params = args;
+
+    TRACE("%p, 0x%s, %p\n", params->instance, wine_dbgstr_longlong(params->time), params->performanceCounter);
+
+    params->result = wine_xrConvertTimeToWin32PerformanceCounterKHR(params->instance, params->time, params->performanceCounter);
+    return STATUS_SUCCESS;
+}
+#endif /* _WIN64 */
+
+#ifdef _WIN64
+static NTSTATUS thunk64_xrConvertWin32PerformanceCounterToTimeKHR(void *args)
+{
+    struct xrConvertWin32PerformanceCounterToTimeKHR_params *params = args;
+
+    TRACE("%p, %p, %p\n", params->instance, params->performanceCounter, params->time);
+
+    params->result = wine_xrConvertWin32PerformanceCounterToTimeKHR(params->instance, params->performanceCounter, params->time);
+    return STATUS_SUCCESS;
+}
+#endif /* _WIN64 */
+
+#ifdef _WIN64
 static NTSTATUS thunk64_xrCreateAction(void *args)
 {
     struct xrCreateAction_params *params = args;
@@ -5032,6 +5056,8 @@ const unixlib_entry_t __wine_unix_call_funcs[] =
     thunk64_xrChangeVirtualKeyboardTextContextMETA,
     thunk64_xrClearSpatialAnchorStoreMSFT,
     thunk64_xrComputeNewSceneMSFT,
+    thunk64_xrConvertTimeToWin32PerformanceCounterKHR,
+    thunk64_xrConvertWin32PerformanceCounterToTimeKHR,
     thunk64_xrCreateAction,
     thunk64_xrCreateActionSet,
     thunk64_xrCreateActionSpace,

--- a/wineopenxr/openxr_thunks.h
+++ b/wineopenxr/openxr_thunks.h
@@ -25,6 +25,8 @@
 #define WINE_XR_VERSION XR_API_VERSION_1_1
 
 /* Functions for which we have custom implementations outside of the thunks. */
+XrResult wine_xrConvertTimeToWin32PerformanceCounterKHR(XrInstance instance, XrTime time, LARGE_INTEGER *performanceCounter);
+XrResult wine_xrConvertWin32PerformanceCounterToTimeKHR(XrInstance instance, const LARGE_INTEGER *performanceCounter, XrTime *time);
 XrResult wine_xrCreateInstance(const XrInstanceCreateInfo *createInfo, XrInstance *instance);
 XrResult wine_xrCreateSession(XrInstance instance, const XrSessionCreateInfo *createInfo, XrSession *session);
 XrResult wine_xrCreateSwapchain(XrSession session, const XrSwapchainCreateInfo *createInfo, XrSwapchain *swapchain);


### PR DESCRIPTION
Implements both xrConvertWin32PerformanceCounterToTimeKHR and xrConvertTimeToWin32PerformanceCounterKHR for converting between QueryPerformanceCounter ticks and XrTime nanoseconds.

Fixes VR controller tracking in Microsoft Flight Simulator 2020, where controllers would spawn at the HMD position due to failed time conversion. Debug logs showed these functions being called every frame for pose timing.