### PR TITLE
proton: Add OPENSSL_ia32cap env variable for Kabounce

### DIFF
--- a/proton
+++ b/proton
@@ -1670,6 +1670,7 @@ class Session:
                 "433530", #Heliborne - Enhanced Edition
                 "521890", #Hello Neighbor
                 "783170", #INSOMNIA: The Ark
+                "431930", #Kabounce
                 "1195460", #Last Year
                 "1029890", #Layers of Fear 2 (2019)
                 "535850", #Micro Machines World Series


### PR DESCRIPTION
Kabounce is affected by the [OpenSSL* SHA Crash Bug](https://www.intel.com/content/www/us/en/developer/articles/troubleshooting/openssl-sha-crash-bug-requires-application-update.html). Adding the `OPENSSL_ia32cap=~0x20000000` env [fixes the issue](https://steamcommunity.com/app/431930/discussions/2/5400412499751434799/).