### PR TITLE
wineopenxr: Fix session list management causing crash in xrPollEvent | Fixes BMS crashing on 2nd flight

### DIFF
--- a/wineopenxr/openxr_loader.c
+++ b/wineopenxr/openxr_loader.c
@@ -718,6 +718,10 @@ XrResult WINAPI xrDestroySession(XrSession session) {
     return params.result;
   }
 
+  EnterCriticalSection(&session_list_lock);
+  list_remove(&wine_session->entry);
+  LeaveCriticalSection(&session_list_lock);
+
   free(wine_session);
   return XR_SUCCESS;
 }
@@ -734,35 +738,60 @@ XrResult WINAPI xrPollEvent(XrInstance instance, XrEventDataBuffer *eventData) {
   WINE_TRACE("eventData->type %#x\n", eventData->type);
 
   if (params.result == XR_SUCCESS) {
+    wine_XrSession *wrapped;
     switch (eventData->type) {
       case XR_TYPE_EVENT_DATA_INTERACTION_PROFILE_CHANGED: {
         XrEventDataInteractionProfileChanged *evt = (XrEventDataInteractionProfileChanged *)eventData;
-        evt->session = (XrSession)get_wrapped_XrSession(evt->session);
+        wrapped = get_wrapped_XrSession(evt->session);
+        if (wrapped)
+          evt->session = (XrSession)wrapped;
+        else
+          WARN("Session %p not found in session list for interaction profile changed event\n", evt->session);
         break;
       }
       case XR_TYPE_EVENT_DATA_SESSION_STATE_CHANGED: {
         XrEventDataSessionStateChanged *evt = (XrEventDataSessionStateChanged *)eventData;
-        evt->session = (XrSession)get_wrapped_XrSession(evt->session);
+        wrapped = get_wrapped_XrSession(evt->session);
+        if (wrapped)
+          evt->session = (XrSession)wrapped;
+        else
+          WARN("Session %p not found in session list for session state changed event\n", evt->session);
         break;
       }
       case XR_TYPE_EVENT_DATA_VISIBILITY_MASK_CHANGED_KHR: {
         XrEventDataVisibilityMaskChangedKHR *evt = (XrEventDataVisibilityMaskChangedKHR *)eventData;
-        evt->session = (XrSession)get_wrapped_XrSession(evt->session);
+        wrapped = get_wrapped_XrSession(evt->session);
+        if (wrapped)
+          evt->session = (XrSession)wrapped;
+        else
+          WARN("Session %p not found in session list for visibility mask changed event\n", evt->session);
         break;
       }
       case XR_TYPE_EVENT_DATA_REFERENCE_SPACE_CHANGE_PENDING: {
         XrEventDataReferenceSpaceChangePending *evt = (XrEventDataReferenceSpaceChangePending *)eventData;
-        evt->session = (XrSession)get_wrapped_XrSession(evt->session);
+        wrapped = get_wrapped_XrSession(evt->session);
+        if (wrapped)
+          evt->session = (XrSession)wrapped;
+        else
+          WARN("Session %p not found in session list for reference space change pending event\n", evt->session);
         break;
       }
       case XR_TYPE_EVENT_DATA_USER_PRESENCE_CHANGED_EXT: {
         XrEventDataUserPresenceChangedEXT *evt = (XrEventDataUserPresenceChangedEXT *)eventData;
-        evt->session = (XrSession)get_wrapped_XrSession(evt->session);
+        wrapped = get_wrapped_XrSession(evt->session);
+        if (wrapped)
+          evt->session = (XrSession)wrapped;
+        else
+          WARN("Session %p not found in session list for user presence changed event\n", evt->session);
         break;
       }
       case XR_TYPE_EVENT_DATA_LOCALIZATION_CHANGED_ML: {
         XrEventDataLocalizationChangedML *evt = (XrEventDataLocalizationChangedML *)eventData;
-        evt->session = (XrSession)get_wrapped_XrSession(evt->session);
+        wrapped = get_wrapped_XrSession(evt->session);
+        if (wrapped)
+          evt->session = (XrSession)wrapped;
+        else
+          WARN("Session %p not found in session list for localization changed event\n", evt->session);
         break;
       }
       default:


### PR DESCRIPTION
  - Fix use-after-free in xrPollEvent session handle lookup caused by xrDestroySession never removing entries from session_list
  - After multiple session create/destroy cycles, stale dangling pointers in the list cause get_wrapped_XrSession() to return incorrect session handles from freed memory
  - The application receives unrecognized session handles in SESSION_STATE_CHANGED events, never calls xrBeginSession, and gets stuck in an XR_ERROR_SESSION_NOT_RUNNING loop
  - Add NULL checks for get_wrapped_XrSession() returns in all xrPollEvent event handlers to prevent NULL dereference if a session is destroyed while events are still queued