### PR TITLE
Add Warudo to proton disablenvapi

### DIFF
--- a/proton
+++ b/proton
@@ -1361,6 +1361,7 @@ def default_compat_config():
                 "435150", #Divinity: Original Sin 2 - Definitive Edition
                 "2176900", #Fablecraft
                 "2853730", #Skull and Bones
+                "2079120", #Warudo
                 ]:
             ret.add("disablenvapi")
 

--- a/proton
+++ b/proton
@@ -1390,6 +1390,7 @@ def default_compat_config():
 
         if appid in [
                 "2698940", #The Crew Motorfest
+                "2079120", #Warudo
                 ]:
             ret.add("hidenvgpu")
 


### PR DESCRIPTION
On Proton 9 and up Warudo will crash on launch with NVIDIA cards unless NVAPI is disabled.

This adds Warudo to the list of exceptions for disablenvapi