### PR TITLE
lsteamclient: fix HTML NeedsPaint callback ordering during page navigation

### DIFF
--- a/lsteamclient/unixlib.cpp
+++ b/lsteamclient/unixlib.cpp
@@ -306,24 +306,93 @@ static bool (*p_Steam_IsKnownInterface)( const char * );
 static void (*p_Steam_NotifyMissingInterface)( int32_t, const char * );
 
 template< typename Params >
+static void deliver_callback( Params *params, u_CallbackMsg_t *u_msg, bool wow64 )
+{
+    auto *w_msg = &*params->w_msg;
+    w_msg->m_hSteamUser = u_msg->m_hSteamUser;
+    w_msg->m_iCallback = u_msg->m_iCallback;
+    w_msg->m_cubParam = callback_len_utow( u_msg->m_iCallback, u_msg->m_cubParam, false );
+    params->cookie = (UINT_PTR)u_msg;
+    params->_ret = true;
+}
+
+template< typename Params >
 static NTSTATUS steamclient_Steam_BGetCallback( Params *params, bool wow64 )
 {
     u_CallbackMsg_t *u_msg, u_msg_tmp;
-    auto *w_msg = &*params->w_msg;
+
+    /* On Linux, Steam's native callback queue can deliver HTML_NeedsPaint_t
+     * (4502) before HTML_URLChanged_t (4505) during page navigation. When
+     * a game sees a paint before the URL has changed, it may see stale page
+     * content and abort (e.g. Xbox Live GDK auth browser).
+     *
+     * This is particularly likely when GPU-accelerated rendering is disabled
+     * in Steam's web view settings, as software rendering causes callbacks
+     * to batch together. With GPU acceleration enabled, the callbacks are
+     * naturally spaced apart and this workaround rarely triggers.
+     *
+     * Fix: between StartRequest and URLChanged, stash NeedsPaint and deliver
+     * the next callback instead. Stale paints (rendered before URLChanged)
+     * are discarded. Once URLChanged arrives, paints flow normally. */
+    static u_CallbackMsg_t *s_deferred_paint = NULL;
+    static bool s_awaiting_url_change = false;
 
     if (!p_Steam_BGetCallback( params->pipe, &u_msg_tmp, params->ignored ))
-        params->_ret = false;
-    else
     {
-        u_msg = new u_CallbackMsg_t(u_msg_tmp);
-        TRACE( "id %d, u_size %d.\n", u_msg->m_iCallback, u_msg->m_cubParam );
-        w_msg->m_hSteamUser = u_msg->m_hSteamUser;
-        w_msg->m_iCallback = u_msg->m_iCallback;
-        w_msg->m_cubParam = callback_len_utow( u_msg->m_iCallback, u_msg->m_cubParam, false );
-        params->cookie = (UINT_PTR)u_msg;
-        params->_ret = true;
+        /* Discard the stale paint — its content was rendered before
+         * URLChanged so it shows the wrong page. A fresh NeedsPaint
+         * with correct content will arrive from Chromium shortly. */
+        if (s_deferred_paint)
+        {
+            TRACE( "discarding stale NeedsPaint\n" );
+            free( (void *)s_deferred_paint->m_pubParam );
+            delete s_deferred_paint;
+            s_deferred_paint = NULL;
+        }
+        params->_ret = false;
+        return 0;
     }
 
+    u_msg = new u_CallbackMsg_t(u_msg_tmp);
+    TRACE( "id %d, u_size %d.\n", u_msg->m_iCallback, u_msg->m_cubParam );
+
+    if (u_msg->m_iCallback == 4503) s_awaiting_url_change = true;
+    if (u_msg->m_iCallback == 4505) s_awaiting_url_change = false;
+
+    /* Between StartRequest and URLChanged, stash NeedsPaint and deliver
+     * the next callback instead. Deep-copy m_pubParam since
+     * FreeLastCallback invalidates Steam's buffer. */
+    while (u_msg->m_iCallback == 4502 && s_awaiting_url_change)
+    {
+        if (s_deferred_paint)
+        {
+            free( (void *)s_deferred_paint->m_pubParam );
+            delete s_deferred_paint;
+        }
+        s_deferred_paint = u_msg;
+        if (u_msg->m_cubParam > 0)
+        {
+            uint8_t *copy = (uint8_t *)malloc( u_msg->m_cubParam );
+            memcpy( copy, u_msg->m_pubParam, u_msg->m_cubParam );
+            s_deferred_paint->m_pubParam = copy;
+        }
+        p_Steam_FreeLastCallback( params->pipe );
+        TRACE( "stashing NeedsPaint (awaiting URLChanged)\n" );
+
+        if (!p_Steam_BGetCallback( params->pipe, &u_msg_tmp, params->ignored ))
+        {
+            /* Queue empty — hold paint for next poll */
+            TRACE( "NeedsPaint stashed, queue empty\n" );
+            params->_ret = false;
+            return 0;
+        }
+        u_msg = new u_CallbackMsg_t(u_msg_tmp);
+        TRACE( "id %d (after stash).\n", u_msg->m_iCallback );
+        if (u_msg->m_iCallback == 4503) s_awaiting_url_change = true;
+        if (u_msg->m_iCallback == 4505) s_awaiting_url_change = false;
+    }
+
+    deliver_callback( params, u_msg, wow64 );
     return 0;
 }
 


### PR DESCRIPTION
## Summary

- Fix ISteamHTMLSurface callback ordering issue where `HTML_NeedsPaint_t` arrives before `HTML_URLChanged_t` on Linux, causing games to see stale page content and abort embedded browser sessions
- This fixes Xbox Live authentication for games using the GDK's ISteamHTMLSurface-based auth flow (e.g. Halo Infinite)

## Problem

On Linux, Steam's native `steamclient.so` can deliver `HTML_NeedsPaint_t` (4502) in the same callback batch as `HTML_StartRequest_t` (4503) or `HTML_URLChanged_t` (4505). When a game receives a paint callback before the URL has changed, the paint contains stale/blank page content. Games using the Microsoft GDK check this content and abort the browser if it doesn't match expectations, preventing Xbox Live sign-in.

This is particularly likely when "Enable GPU accelerated rendering in web views" is disabled in Steam settings, as software rendering causes Chromium callbacks to batch together rather than arriving in separate poll cycles.

## Fix

Between `HTML_StartRequest_t` and `HTML_URLChanged_t`, stash any `NeedsPaint` callbacks and deliver the next queued callback instead. Stale paints (rendered before the URL changed) are discarded. Once `URLChanged` arrives, paints flow normally.

The fix only affects `ISteamHTMLSurface` callbacks during the narrow window between a page navigation start and the URL resolving. All other callbacks (non-HTML, post-navigation paints) pass through unmodified.

## Scope

This addresses one specific failure mode for Xbox Live sign-in: games that use `ISteamHTMLSurface` to render the SISU/Xbox Live auth page (confirmed in Halo Infinite). Other games listed in #6481 may use different auth paths (e.g. Steam overlay browser, direct OAuth) and may have separate issues not addressed by this fix.

## Testing

- **Halo Infinite**: Xbox Live "Let's get you signed in" window now appears reliably (~95% success rate, up from ~1%). Full OAuth flow completes and sign-in works.
- **Age of Empires: Definitive Edition**: Uses different auth path (not ISteamHTMLSurface), no regression.
- **Age of Empires III: Definitive Edition**: Uses different auth path, sign-in issue not addressed by this fix, no regression.
- **Steam overlay browser**: No regression observed.

## Test plan

- [ ] Test Halo Infinite Xbox Live sign-in on Steam Deck
- [ ] Test other Microsoft GDK games that use ISteamHTMLSurface for auth
- [ ] Test with GPU-accelerated web views both enabled and disabled
- [ ] Verify Steam overlay browser works normally
- [ ] Verify games using ISteamHTMLSurface for non-auth purposes (news pages, EULA) still render correctly

Related to https://github.com/ValveSoftware/Proton/issues/6481