### PR TITLE
proton: Disable DXVK d3d8 when wined3d is active

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ the Wine prefix. Removing the option will revert to the previous behavior.
 |                       | `PROTON_LOG_DIR`                   | Output log files into the directory specified. Defaults to your home directory. |
 |                       | `PROTON_WAIT_ATTACH`               | Wait for a debugger to attach to steam.exe before launching the game process. To attach to the game process at startup, debuggers should be set to follow child processes. |
 |                       | `PROTON_CRASH_REPORT_DIR`          | Write crash logs into this directory. Does not clean up old logs, so may eat all your disk space eventually. |
-| `wined3d`             | `PROTON_USE_WINED3D`               | Use OpenGL-based wined3d instead of Vulkan-based DXVK for d3d11, d3d10, and d3d9. |
+| `wined3d`             | `PROTON_USE_WINED3D`               | Use OpenGL-based wined3d instead of Vulkan-based DXVK for d3d11, d3d10, d3d9, and d3d8. |
 | `nod3d11`             | `PROTON_NO_D3D11`                  | Disable `d3d11.dll`, for d3d11 games which can fall back to and run better with d3d9. |
 | `nod3d10`             | `PROTON_NO_D3D10`                  | Disable `d3d10.dll` and `dxgi.dll`, for d3d10 games which can fall back to and run better with d3d9. |
 | `dxvkd3d8`            | `PROTON_DXVK_D3D8`                 | Use DXVK's `d3d8.dll`. |

--- a/proton
+++ b/proton
@@ -952,7 +952,7 @@ class CompatData:
             use_dxvk_dxgi = not use_wined3d and \
                     not ("WINEDLLOVERRIDES" in g_session.env and "dxgi=b" in g_session.env["WINEDLLOVERRIDES"])
             use_nvapi = 'disablenvapi' not in g_session.compat_config or 'forcenvapi' in g_session.compat_config
-            use_dxvk_d3d8 = "dxvkd3d8" in g_session.compat_config
+            use_dxvk_d3d8 = not use_wined3d and "dxvkd3d8" in g_session.compat_config
 
             builtin_dll_copy = os.environ.get("PROTON_DLL_COPY",
                     #dxsetup redist


### PR DESCRIPTION
## Summary

- When `PROTON_USE_WINED3D` is set, DXVK's d3d8 backend is now also disabled — matching the existing behavior for d3d11, d3d10, d3d9, and dxgi.
- Previously, d3d8 remained under DXVK even with wined3d active, causing crashes since DXVK d3d8 depends on the d3d9 backend which was already switched to wined3d.

## Changes

- `proton`: Add `not use_wined3d` guard to `use_dxvk_d3d8`, matching the existing `use_dxvk_dxgi` pattern.
- `README.md`: Update `PROTON_USE_WINED3D` description to include d3d8.

Fixes [ValveSoftware/Proton#9453](https://github.com/ValveSoftware/Proton/issues/9453)