### PR TITLE
lsteamclient: Fix count in wow64 networking messages conversion.

### DIFF
--- a/lsteamclient/unix_steam_networking_manual.cpp
+++ b/lsteamclient/unix_steam_networking_manual.cpp
@@ -121,7 +121,9 @@ template< typename Umsg, typename Wmsg >
 static void receive_messages_utow( uint32_t count, Umsg **u_msgs, ptr32< Wmsg** > w_msgs )
 {
     Wmsg **msgs = new Wmsg *[count];
-    while (count--) msgs[count] = w_msgs[count];
+    uint32_t i;
+
+    for (i = 0; i < count; ++i) msgs[i] = w_msgs[i];
     receive_messages_utow( count, u_msgs, msgs );
     delete[] msgs;
 }
@@ -153,7 +155,9 @@ template< typename Wmsg, typename Umsg >
 static void send_messages_wtou( uint32_t count, ptr32< Wmsg *const* > w_msgs, Umsg **u_msgs )
 {
     Wmsg **msgs = new Wmsg *[count];
-    while (count--) msgs[count] = w_msgs[count];
+    uint32_t i;
+
+    for (i = 0; i < count; ++i) msgs[i] = w_msgs[i];
     send_messages_wtou( count, msgs, u_msgs );
     delete[] msgs;
 }
@@ -162,7 +166,9 @@ template< typename Wmsg, typename Umsg >
 static void send_messages_wtou( uint32_t count, ptr32< Wmsg** > w_msgs, Umsg **u_msgs )
 {
     Wmsg **msgs = new Wmsg *[count];
-    while (count--) msgs[count] = w_msgs[count];
+    uint32_t i;
+
+    for (i = 0; i < count; ++i) msgs[i] = w_msgs[i];
     send_messages_wtou( count, msgs, u_msgs );
     delete[] msgs;
 }


### PR DESCRIPTION
## Fix count in WOW64 networking messages conversion

### Problem

Multiplayer is broken for 32-bit games running on 64-bit systems (the WOW64 path). Stardew Valley is the most commonly reported case, players can't join or host multiplayer sessions on Proton 10.0, but it works fine on 9.0-4.

The WOW64 overloads of `receive_messages_utow` and `send_messages_wtou` in `lsteamclient/unix_steam_networking_manual.cpp` use `while(count--)` to copy `ptr32<>` pointer arrays into native 64-bit arrays. Since `count` is `uint32_t`, the post-decrement wraps it to `UINT32_MAX` after the loop. The subsequent call to the actual message processing function receives this corrupted count, so networking messages are never delivered.

### Affected games

Any 32-bit game that uses Steam networking APIs for multiplayer, including:
- **Stardew Valley** (AppID 322170)
- Other 32-bit titles using `ISteamNetworkingSockets` or `ISteamNetworkingMessages`

64-bit games are unaffected as they don't use the `ptr32<>` code path.

### Fix

Replace `while(count--)` with `for(i = 0; i < count; ++i)` in all three WOW64 thunk functions so `count` is preserved for the subsequent call.