### PR TITLE
wineopenxr: Fix session list leak and add helper function

### DIFF
--- a/wineopenxr/openxr.c
+++ b/wineopenxr/openxr.c
@@ -84,11 +84,11 @@ substitute_extensions[] =
     {"XR_KHR_win32_convert_performance_counter_time", "XR_KHR_convert_timespec_time", TRUE, TRUE},
 };
 
-static char *wineopenxr_strdup(const char *src)
+static char *strdupA(const char *s)
 {
-    const size_t l = strlen(src) + 1;
+    size_t l = strlen(s) + 1;
     char *r = heap_alloc(l);
-    strcpy(r, src);
+    memcpy(r, s, l);
     return r;
 }
 
@@ -848,7 +848,7 @@ XrResult WINAPI wine_xrCreateInstance(const XrInstanceCreateInfo *createInfo, Xr
             }
         }
         if (ext_name)
-            new_list[count++] = wineopenxr_strdup(ext_name);
+            new_list[count++] = strdupA(ext_name);
     }
 
     our_createInfo = *createInfo;
@@ -1166,6 +1166,12 @@ XrResult WINAPI wine_xrDestroySession(XrSession session)
         WINE_WARN("xrDestroySession failed: %d\n", res);
         return res;
     }
+
+    EnterCriticalSection(&session_list_lock);
+
+    list_remove(&wine_session->entry);
+
+    LeaveCriticalSection(&session_list_lock);
 
     heap_free(wine_session->projection_views);
     heap_free(wine_session->view_infos);

--- a/wineopenxr/openxr_private.h
+++ b/wineopenxr/openxr_private.h
@@ -115,3 +115,8 @@ extern XrResult load_host_openxr_loader(void);
 extern void register_dispatchable_handle(uint64_t handle, struct openxr_instance_funcs *funcs);
 extern void unregister_dispatchable_handle(uint64_t handle);
 extern struct openxr_instance_funcs *get_dispatch_table(uint64_t handle);
+
+static inline BOOL is_d3d_session(const wine_XrSession *session)
+{
+    return session->session_type == SESSION_TYPE_D3D11 || session->session_type == SESSION_TYPE_D3D12;
+}


### PR DESCRIPTION
- Remove duplicate wineopenxr_strdup, use existing strdupA instead
- Fix memory leak in wine_xrDestroySession: session was never removed from session_list before being freed
- Add is_d3d_session() inline helper for session type checks