### PR TITLE
gitattributes: exclude Korean font sources from Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.sc linguist-detectable=false
 *.SC linguist-detectable=false
+*.K linguist-detectable=false


### PR DESCRIPTION
Exclude the Korean Source Han Sans `.K` font source files from GitHub Linguist detection.

These files are PostScript/OpenType font sources used to build Korean fallback fonts, but GitHub currently classifies them as KCL and counts them in the repository language stats. The matching `.SC` Source Han Sans files are already exclude from Linguist via `.gitattributes`, so this applies the same treatment to the Korean font sources.