### PR TITLE
proton: Add work-around for Diablo II: Resurrected – Infernal Edition.

### DIFF
--- a/proton
+++ b/proton
@@ -1106,6 +1106,12 @@ class CompatData:
                         os.makedirs(os.path.dirname(dstvdf), exist_ok=True)
                         shutil.copyfile(srcvdf, dstvdf)
 
+                # Diablo II: Resurrected – Infernal Edition initially needs a ClientSdk directory to not hang on error:
+                # You have not been online in the last 30 days. Please start the game while online to check for any login agreements.
+                if os.environ.get("SteamGameId", 0) == "2536520":
+                    diablo2_clientsdk_dir = "/drive_c/users/steamuser/AppData/Local/Blizzard Entertainment/ClientSdk"
+                    makedirs(self.prefix_dir + diablo2_clientsdk_dir)
+
                 #copy openvr files into place
                 makedirs(self.prefix_dir + "/drive_c/vrclient/bin")
                 try_copy(g_proton.arch_pe_dir("wine", True) + "vrclient.dll", "drive_c/vrclient/bin",


### PR DESCRIPTION
Recently bought two copies of the game for two different steam accounts and this **initial** issue appeared on two different machines one running latest Fedora Linux and one Exherbo Linux. Both steam accounts used on these machines have not used battle.net for quite some time and probably haven't been linked before so it might be related to that, especially now that the problem is no longer reproducible for me.

<img width="934" height="705" alt="image" src="https://github.com/user-attachments/assets/640a5a5f-bae1-4820-b880-3d359e51ea6f" />

Without the hint on https://www.protondb.com/app/2536520 where apparently others are running into this initial issue as well I'd have had no idea how to get the game working. There's also for example https://steamcommunity.com/app/2536520/discussions/0/807975542034834556/ on the steam discussions where the workaround is also [mentioned](https://steamcommunity.com/app/2536520/discussions/0/807975542034834556/?ctp=4#c837249693974055295).

I've also tried to verify my suggested fix by creating a new proton prefix but I couldn't reproduce the initial error anymore as the directory got created without any manual interaction and a file `cookie.bin` placed there now:

<img width="861" height="120" alt="image" src="https://github.com/user-attachments/assets/0d649b5c-6119-4122-bd72-61954eee54fb" />

Proton version used: `1779117445 experimental-11.0-20260518b`