### PR TITLE
steampipe_fixups: skip missing no_write_paths entries

### DIFF
--- a/steampipe_fixups.py
+++ b/steampipe_fixups.py
@@ -87,7 +87,10 @@ def do_restore(path, manifest):
 
     for file_ in no_write_paths:
         this_file = os.path.join(path, file_)
-        stat_result = os.lstat(this_file)
+        try:
+            stat_result = os.lstat(this_file)
+        except FileNotFoundError:
+            continue
         os.chmod(this_file,
                 stat_result.st_mode & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH))
 


### PR DESCRIPTION
### Summary

`steampipe_fixups.do_restore()` currently assumes every `no_write_paths` entry from `steampipe_fixups.json` still exists. If one of those files is missing, restore fails with `FileNotFoundError` before Proton can launch.

This skips missing `no_write_paths` entries during restore, while still applying the chmod behavior to files that do exist.

For #9746.

### Testing

* Reproduced the `FileNotFoundError` with a minimal manifest containing a missing `no_write_paths` entry.
* Verified existing `no_write_paths` entries still have write bits removed.
* Verified missing `empty_dirs` behavior is unchanged.
* Ran `python -m py_compile steampipe_fixups.py`.
