### PR TITLE
proton: detect incomplete default_pfx

### DIFF
--- a/proton
+++ b/proton
@@ -578,8 +578,13 @@ class Proton:
                             f.write(new_fixup_mtime + "\n")
 
     def missing_default_prefix(self):
-        '''Check if the default prefix dir is missing. Returns true if missing, false if present'''
-        return not os.path.isdir(self.default_pfx_dir)
+        '''Check if the default prefix dir is missing or incomplete. Returns true if missing, false if present'''
+        required_paths = (
+            self.default_pfx_dir + "system.reg",
+            self.default_pfx_dir + "drive_c/windows/system32/d3d8.dll",
+            self.default_pfx_dir + "drive_c/windows/syswow64/d3d8.dll",
+        )
+        return any(not os.path.isfile(path) for path in required_paths)
 
     def make_default_prefix(self):
         with self.dist_lock:


### PR DESCRIPTION
### Summary

`missing_default_prefix()` only checked whether the `default_pfx` directory exists. If the directory exists but is empty or incomplete, Proton treats it as valid and skips rebuilding it with `wineboot`.

This updates the check to require a few expected default prefix files that later setup code depends on:

* `system.reg`
* `drive_c/windows/system32/d3d8.dll`
* `drive_c/windows/syswow64/d3d8.dll`

For #9660.

### Testing

* Reproduced the validation failure with an empty/incomplete `default_pfx` directory.
* Verified an absent `default_pfx` is still treated as missing.
* Verified an empty `default_pfx` is now treated as missing.
* Verified a partially-created `default_pfx` without the expected sentinel files is treated as missing.
* Verified a sentinel-valid `default_pfx` is treated as present.
* Ran `python -m py_compile proton steampipe_fixups.py`.
* Ran `git diff --check`.
