### PR TITLE
steampipe_fixups.py: Fix usage text to match the actual verb.

### DIFF
--- a/steampipe_fixups.py
+++ b/steampipe_fixups.py
@@ -15,7 +15,7 @@ DEFAULT_MANIFEST_NAME = "steampipe_fixups.json"
 
 def usage():
     print("Usage:")
-    print("\t" + sys.argv[0] + "\tprepare\t<path to directory to process>\t[manifest output file]")
+    print("\t" + sys.argv[0] + "\tprocess\t<path to directory to process>\t[manifest output file]")
     print("\t\tProcess the given path and output the manifest file to the given path, or <path/" + DEFAULT_MANIFEST_NAME + "> if unspecified.")
     print("")
     print("\t" + sys.argv[0] + "\trestore\t<path to directory to process>\t[manifest file]")


### PR DESCRIPTION
The usage message instructed running the script with "prepare", but the script only accepts "process" (and that is the verb the build invokes in Makefile.in). Following the printed usage produced an error and a usage re-print. Correct the text to "process".