### PR TITLE
proton: limit DIRT 5 to P-cores

### DIFF
--- a/proton
+++ b/proton
@@ -1438,6 +1438,39 @@ default_cpu_limit = {
     "65540"     :  16,  # Gothic 1 Classic
 }
 
+pcore_cpu_limit = {
+    "1038250" : True, # DIRT 5
+}
+
+# This function reads the cpu_core/cpus file - responsible for listing the
+# P-cores - and returns a string that matches the format WINE_CPU_TOPOLOGY
+# wants. If the file contains something such as "0-3,6,8-9", we'll return
+# "7:0,1,2,3,6,8,9".
+def cpu_range_to_wine_topology_str():
+    try:
+        with open("/sys/devices/cpu_core/cpus", "r") as f:
+            range_string = f.read().strip()
+
+        cpus = []
+
+        subranges = range_string.split(",")
+        for sr in subranges:
+            start_end = list(map(int, sr.split("-")))
+            if (len(start_end) == 1):
+                sr_cpus = start_end
+            elif (len(start_end) == 2):
+                sr_cpus = list(range(start_end[0], start_end[1] + 1))
+            else:
+                raise Exception("unexpected file contents")
+
+            cpus += sr_cpus
+
+        n_cpus = len(sr_cpus)
+        cpus_str = ",".join(map(str, cpus))
+        return f"{n_cpus}:{cpus_str}"
+    except Exception:
+        return ""
+
 class Session:
     def __init__(self):
         self.log_file = None
@@ -1484,6 +1517,10 @@ class Session:
             self.env["WINE_CPU_TOPOLOGY"] = self.env["PROTON_CPU_TOPOLOGY"]
         elif appid in default_cpu_limit:
             self.env["WINE_CPU_TOPOLOGY"] = str(default_cpu_limit[appid])
+        elif appid in pcore_cpu_limit:
+            topology_str = cpu_range_to_wine_topology_str()
+            if topology_str != "":
+                self.env["WINE_CPU_TOPOLOGY"] = topology_str
 
         if "WINE_HIDE_AMD_GPU" not in self.env and appid in [
                     "1282690",


### PR DESCRIPTION
### COMMIT

Older games or their libraries may have included code that somehow made use of the CPU identifiers or hashed CPU information and that code broke in heterogeneous CPU architectures, such as newer Intel processors that have P-cores and E-cores. They would detect the different CPUs and crash or close the game.

While some of the games were already updated and don't encounter this problem anymore, some games in the wild still have this issue. In this patch we add infrastructure to restrict these games to P-cores by reading sysfs files and then setting WINE_CPU_TOPOLOGY.

For now, the only game on the list is DIRT 5.

From what I understand, what we're doing here is what Windows allegedly does through their Compatibility Fixes system, and the compatibility is called ProcessorCountLieForHybridCPU. The list of games can be queried using the "Compatibility Administrator (64-bit)" tool, which is part of the Windows Assessment And Deployment Kit (ADK). We don't seem to require this workaround for all games that Windows applies this fix for, but I haven't tested all of them.

Link: https://gitlab.freedesktop.org/mesa/mesa/-/work_items/15193
Link: https://github.com/ValveSoftware/Proton/issues/4498#issuecomment-4665007733

### EXTRA

Here is the list of games I tested:

- DIRT 5
- Assassin's Creed: Ordissey
- Total War: THREE KINGDOMS (Proton version)
- Tomb Raider (Proton version)
- Total War: WARHAMMER 2 (Proton version)
- Wolfenstein: Youngblood

I think it would be cool if someone with access to the other games on the ADK list could try them and see if they still require the workaround.

### DISCLAIMERS

I should point that I didn't extensively test this on multiple machines, so although I tried to make the WA give up in case anything went in unexpected ways, I'm not 100% sure if we won't be able to find `cpu_core/cpus` files in processors where we wouldn't want the workaround.

Also, the way I tested this was by directly patching the `proton` script in my `~/.steam/debian-installation/steamapps/common/Proton*` directories, not by installing Proton from the git repository.