### PR TITLE
proton: Catch JSON decode errors when trying to parse OpenVR paths

### DIFF
--- a/proton
+++ b/proton
@@ -331,8 +331,11 @@ def setup_openvr_paths():
     if not openvr_paths or not file_exists(openvr_paths, follow_symlinks=True):
         return
 
-    with open(openvr_paths, 'r') as file:
-        contents = json.load(file)
+    try:
+        with open(openvr_paths, 'r') as file:
+            contents = json.load(file)
+    except json.decoder.JSONDecodeError:
+        return
 
     if 'runtime' not in contents or type(contents['runtime']) != list:
         contents['runtime'] = []


### PR DESCRIPTION
This situation can happen when `openvrpaths.vrpath` exists, but does not contain valid JSON. Instead of crashing, just act like the file does not exist.