### PR TITLE
Replace shebangs with `/usr/bin/env bash`

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/lsteamclient/gen.sh
+++ b/lsteamclient/gen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rm win*.h
 rm win*.c

--- a/vrclient_x64/gen.sh
+++ b/vrclient_x64/gen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rm win*.h
 rm win*.c

--- a/vrclient_x64/make_sdks.sh
+++ b/vrclient_x64/make_sdks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #run from within openvr.git
 


### PR DESCRIPTION
This PR replaces `#!/bin/bash` shebangs with `#!/usr/bin/env` bash.
Though these scripts are POSIX compliant, so should not even use bash.
