### PR TITLE
steampipe_fixups: Fix usage text to reference the "process" verb.

### DIFF
--- a/steampipe_fixups.py
+++ b/steampipe_fixups.py
@@ -15,7 +15,7 @@ DEFAULT_MANIFEST_NAME = "steampipe_fixups.json"
 
 def usage():
     print("Usage:")
-    print("\t" + sys.argv[0] + "\tprepare\t<path to directory to process>\t[manifest output file]")
+    print("\t" + sys.argv[0] + "\tprocess\t<path to directory to process>\t[manifest output file]")
     print("\t\tProcess the given path and output the manifest file to the given path, or <path/" + DEFAULT_MANIFEST_NAME + "> if unspecified.")
     print("")
     print("\t" + sys.argv[0] + "\trestore\t<path to directory to process>\t[manifest file]")


### PR DESCRIPTION
The `usage()` output documents the first verb as `prepare`, but the argument
dispatch in `__main__` only accepts `process` (matching the `do_process`
function). Running the documented command therefore falls through to the usage
branch and exits non-zero instead of processing the directory:

    $ steampipe_fixups.py prepare somedir
    Usage:
    ...
    $ echo $?
    1

The working verb is `process`; this aligns the help text with it. No behavior
change, only the printed usage string is corrected.